### PR TITLE
Restore target for higher order method calls

### DIFF
--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -29,8 +29,14 @@ final class HigherOrderMessageCollection
      */
     public function chain(object $target): void
     {
+        $originalTarget = $target;
+
         foreach ($this->messages as $message) {
             $target = $message->call($target);
+
+            if ($target === null) {
+                $target = $originalTarget;
+            }
         }
     }
 

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -29,13 +29,11 @@ final class HigherOrderMessageCollection
      */
     public function chain(object $target): void
     {
-        $originalTarget = $target;
-
         foreach ($this->messages as $message) {
-            $target = $message->call($target);
+            $returnedObject = $message->call($target);
 
-            if ($target === null) {
-                $target = $originalTarget;
+            if ($returnedObject !== null) {
+                $target = $returnedObject;
             }
         }
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -55,6 +55,7 @@
 
    PASS  Tests\Features\HigherOrderMessages
   ✓ it proxies calls to object
+  ✓ it proxies multiple calls to object
 
    PASS  Tests\Features\It
   ✓ it is a test
@@ -135,5 +136,5 @@
    WARN  Tests\Visual\Success
   s visual snapshot of test suite on success
 
-  Tests:  6 skipped, 70 passed
-  Time:   2.68s
+  Tests:  6 skipped, 71 passed
+  Time:   2.92s

--- a/tests/Features/HigherOrderMessages.php
+++ b/tests/Features/HigherOrderMessages.php
@@ -4,4 +4,10 @@ beforeEach()->assertTrue(true);
 
 it('proxies calls to object')->assertTrue(true);
 
-afterEach()->assertTrue(true);
+it('proxies multiple calls to object')
+    ->assertTrue(true)
+    ->assertTrue(true);
+
+afterEach()
+    ->assertTrue(true)
+    ->assertArrayHasKey('key', ['key' => 'value']);


### PR DESCRIPTION
if higher order method call does return null or nothing use the
original target for future calls

Resolves #28 