### PR TITLE
Fix Windows builds running Pest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
     - name: Unit Tests
-      run: bin/pest --colors=always --exclude-group=integration
+      run: php bin/pest --colors=always --exclude-group=integration
 
     - name: Integration Tests
-      run: bin/pest --colors=always --group=integration
+      run: php bin/pest --colors=always --group=integration


### PR DESCRIPTION
This fixes #36, and gets the test suite running, however there might be an underlying issue with paths in Windows. 🤔

https://github.com/owenvoke/pest/runs/715929243