### PR TITLE
Feature/support colors never

### DIFF
--- a/src/Actions/AddsDefaults.php
+++ b/src/Actions/AddsDefaults.php
@@ -21,7 +21,7 @@ final class AddsDefaults
     public static function to(array $arguments): array
     {
         if (!array_key_exists('printer', $arguments)) {
-            $arguments['printer'] = new Printer();
+            $arguments['printer'] = new Printer(null, $arguments['verbose'] ?? false, $arguments['colors'] ?? 'always');
         }
 
         return $arguments;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -124,9 +124,11 @@
    PASS  Tests\Visual\SingleTestOrDirectory
   ✓ allows to run a single test
   ✓ allows to run a directory
+  ✓ it has ascii chars (decorated printer)
+  ✓ it disable decorating printer when colors is set to never
 
    WARN  Tests\Visual\Success
   s visual snapshot of test suite on success
 
-  Tests:  6 skipped, 67 passed
-  Time:   2.67s
+  Tests:  6 skipped, 69 passed
+  Time:   2.34s

--- a/tests/Visual/SingleTestOrDirectory.php
+++ b/tests/Visual/SingleTestOrDirectory.php
@@ -30,3 +30,37 @@ test('allows to run a directory', function () use ($run) {
   Tests:  2 passed
 EOF, $run('tests/Fixtures'));
 });
+
+it('has ascii chars (decorated printer)', function () {
+    $process = new Process([
+        './bin/pest',
+        'tests/Fixtures/DirectoryWithTests/ExampleTest.php',
+    ], dirname(__DIR__, 2));
+
+    $process->run();
+    $output = $process->getOutput();
+    assertStringContainsString(<<<EOF
+  \e[30;42;1m PASS \e[39;49;22m\e[39m Tests\Fixtures\DirectoryWithTests\ExampleTest\e[39m
+  \e[32;1m✓\e[39;22m\e[39m \e[2mit example\e[22m\e[39m
+
+  \e[37;1mTests:  \e[39;22m\e[32;1m1 passed\e[39;22m
+EOF, $output);
+});
+
+it('disable decorating printer when colors is set to never', function () {
+    $process = new Process([
+        './bin/pest',
+        '--colors=never',
+        'tests/Fixtures/DirectoryWithTests/ExampleTest.php',
+    ], dirname(__DIR__, 2));
+    $process->run();
+    $output = $process->getOutput();
+
+    assertStringContainsString(<<<EOF
+   PASS  Tests\Fixtures\DirectoryWithTests\ExampleTest
+  ✓ \e[2mit example\e[22m
+
+  Tests:  1 passed
+EOF, $output);
+
+});


### PR DESCRIPTION
Related issue #49 

There is a still present escaped sequence ascii when running with `--colors=never`. I think it's because hardcoded here : https://github.com/nunomaduro/collision/blob/stable/src/Adapters/Phpunit/Style.php#L89

 