### PR TITLE
Optimise debug_backtrace calls

### DIFF
--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -25,7 +25,7 @@ final class Backtrace
     {
         $current = null;
 
-        foreach (debug_backtrace() as $trace) {
+        foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
             if (Str::endsWith($trace[self::FILE], (string) realpath('vendor/phpunit/phpunit/src/Util/FileLoader.php'))) {
                 break;
             }

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -15,7 +15,7 @@ final class Backtrace
      * @var string
      */
     private const FILE = 'file';
-    
+
     private const BACKTRACE_OPTIONS = DEBUG_BACKTRACE_IGNORE_ARGS;
 
     /**

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -15,6 +15,8 @@ final class Backtrace
      * @var string
      */
     private const FILE = 'file';
+    
+    private const BACKTRACE_OPTIONS = DEBUG_BACKTRACE_IGNORE_ARGS;
 
     /**
      * Returns the current test file.
@@ -43,7 +45,7 @@ final class Backtrace
      */
     public static function file(): string
     {
-        return debug_backtrace()[1][self::FILE];
+        return debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE];
     }
 
     /**
@@ -51,7 +53,7 @@ final class Backtrace
      */
     public static function dirname(): string
     {
-        return dirname(debug_backtrace()[1][self::FILE]);
+        return dirname(debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE]);
     }
 
     /**
@@ -59,6 +61,6 @@ final class Backtrace
      */
     public static function line(): int
     {
-        return debug_backtrace()[1]['line'];
+        return debug_backtrace(self::BACKTRACE_OPTIONS)[1]['line'];
     }
 }


### PR DESCRIPTION
With this PR, we prevent PHP from populating the backtrace with all the functions/methods arguments.

This PR can have little to BIG effects, depending on when `Backtrace::file()`  and `Backtrace::file()` are called, so chance are that at some point this can save a lot of memory, considering the fact that they are called *really* often, afaik.

I did some benchmarking and it saves between nothing and 6MB (with tests and logic) (using Blackfire). Ofc, it doesn't mean a lot because benchmarking will depends on a bunch of things.

Quoting [php.net](https://www.php.net/manual/en/function.debug-backtrace.php):
> DEBUG_BACKTRACE_IGNORE_ARGS : Whether or not to omit the "args" index, and thus all the function/method arguments, **to save memory**.


