### PR TITLE
Add problem matcher output to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,9 @@ jobs:
 
     - name: Integration Tests
       run: php bin/pest --colors=always --group=integration
+
+    - name: Setup problem matchers for PHP
+      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+    - name: Setup problem matchers for Pest
+      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
As per comments in Discord, this adds ["Problem matchers"](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md#problem-matchers) for PHP and PHPUnit.

As far as I can tell, the PHPUnit matcher should work fine with Pest. But if there are any issues in future, we can always generate our own [matcher config](https://raw.githubusercontent.com/shivammathur/setup-php/master/src/configs/phpunit.json).

See: https://github.com/marketplace/actions/setup-php-action#problem-matchers