### PR TITLE
Fix in Test Repository use method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.xml
 .temp/coverage.php
 *.swp
 *.swo
+.vscode/

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Repositories;
 
+use Pest\TestSuite;
+use Pest\Support\Str;
+use Pest\Factories\TestCaseFactory;
 use Pest\Exceptions\ShouldNotHappen;
 use Pest\Exceptions\TestAlreadyExist;
 use Pest\Exceptions\TestCaseAlreadyInUse;
 use Pest\Exceptions\TestCaseClassOrTraitNotFound;
-use Pest\Factories\TestCaseFactory;
-use Pest\Support\Str;
-use Pest\TestSuite;
 
 /**
  * @internal
@@ -104,7 +104,14 @@ final class TestRepository
         }
 
         foreach ($paths as $path) {
-            $this->uses[$path] = [$classOrTraits, $groups];
+            if (array_key_exists($path, $this->uses)) {
+                $this->uses[$path] = [
+                    array_merge($this->uses[$path][0], $classOrTraits),
+                    array_merge($this->uses[$path][1], $groups)
+                ];
+            } else {
+                $this->uses[$path] = [$classOrTraits, $groups];
+            }
         }
     }
 

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Repositories;
 
-use Pest\TestSuite;
-use Pest\Support\Str;
-use Pest\Factories\TestCaseFactory;
 use Pest\Exceptions\ShouldNotHappen;
 use Pest\Exceptions\TestAlreadyExist;
 use Pest\Exceptions\TestCaseAlreadyInUse;
 use Pest\Exceptions\TestCaseClassOrTraitNotFound;
+use Pest\Factories\TestCaseFactory;
+use Pest\Support\Str;
+use Pest\TestSuite;
 
 /**
  * @internal
@@ -107,7 +107,7 @@ final class TestRepository
             if (array_key_exists($path, $this->uses)) {
                 $this->uses[$path] = [
                     array_merge($this->uses[$path][0], $classOrTraits),
-                    array_merge($this->uses[$path][1], $groups)
+                    array_merge($this->uses[$path][1], $groups),
                 ];
             } else {
                 $this->uses[$path] = [$classOrTraits, $groups];

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -101,6 +101,7 @@
 
    PASS  Tests\Plugins\Traits
   ✓ it allows global uses
+  ✓ it allows multiple global uses registered in the same path
 
    PASS  Tests\Unit\Actions\AddsDefaults
   ✓ it sets defaults
@@ -143,5 +144,5 @@
    WARN  Tests\Visual\Success
   s visual snapshot of test suite on success
 
-  Tests:  6 skipped, 78 passed
-  Time:   3.09s
+  Tests:  6 skipped, 79 passed
+  Time:   3.44s

--- a/tests/Autoload.php
+++ b/tests/Autoload.php
@@ -12,4 +12,13 @@ trait PluginTrait
     }
 }
 
+trait SecondPluginTrait
+{
+    public function assertSecondPluginTraitGotRegistered(): void
+    {
+        assertTrue(true);
+    }
+}
+
 Pest\Plugin::uses(PluginTrait::class);
+Pest\Plugin::uses(SecondPluginTrait::class);

--- a/tests/Plugins/Traits.php
+++ b/tests/Plugins/Traits.php
@@ -1,3 +1,5 @@
 <?php
 
 it('allows global uses')->assertPluginTraitGotRegistered();
+
+it('allows multiple global uses registered in the same path')->assertSecondPluginTraitGotRegistered();


### PR DESCRIPTION
While loading the class or traits & groups for the given path it overrides the previous configuration. The pest plugins where not loading the traits with the Plugin::use() method.