### PR TITLE
Add next section link to the CHANGELOG

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,6 +38,8 @@ jobs:
           section: content
           ---
           ${{ steps.package.outputs.content }}
+
+          Next section: [Upgrade Guide →](/docs/upgrade-guide)
         write-mode: overwrite
     - name: Copy CHANGELOG to website repository
       run: cp CHANGELOG.md pestphp-website/source/docs/changelog.md


### PR DESCRIPTION
See: https://github.com/pestphp/website/pull/66#discussion_r447211656

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

This makes sure that the "Next section" link is included in the website changelog.