### PR TITLE
Add --thanks option plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         },
         "pest": {
             "plugins": [
+                "Pest\\Plugins\\Thanks",
                 "Pest\\Plugins\\Version"
             ]
         },

--- a/src/Plugins/Thanks.php
+++ b/src/Plugins/Thanks.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Plugins;
+
+use Pest\Contracts\Plugins\HandlesArguments;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Thanks implements HandlesArguments
+{
+    private const THANKS_OPTION = '--thanks';
+
+    /** @var array<int, string> */
+    private const FUNDING_MESSAGES = [
+        "\n  Want to support Pest? Here are some ways you can help:",
+        "\n    - Star or contribute to Pest on GitHub:\n      <options=bold>https://github.com/pestphp/pest</>",
+        "\n    - Tweet about Pest on Twitter:\n      <options=bold>https://twitter.com/pestphp</>",
+        "\n    - Sponsor Nuno Maduro on GitHub:\n      <options=bold>https://github.com/sponsors/nunomaduro</>",
+        "\n    - Sponsor Nuno Maduro on Patreon:\n      <options=bold>https://patreon.com/nunomaduro</>",
+    ];
+
+    /** @var OutputInterface */
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function handleArguments(array $arguments): array
+    {
+        if (!in_array(self::THANKS_OPTION, $arguments, true)) {
+            return $arguments;
+        }
+
+        foreach (self::FUNDING_MESSAGES as $message) {
+            $this->output->writeln($message);
+        }
+
+        exit(0);
+    }
+}

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -135,6 +135,10 @@
   ✓ it throws exception when `process isolation` is true
   ✓ it do not throws exception when `process isolation` is false
 
+   WARN  Tests\Unit\Plugins\Thanks
+  - it outputs funding options when --thanks is used → The plugin uses `exit()` so not sure how to implement this
+  ✓ it does not output funding options when --thanks is not used
+
    PASS  Tests\Unit\Plugins\Version
   ✓ it outputs the version when --version is used
   ✓ it do not outputs version when --version is not used
@@ -167,5 +171,5 @@
    WARN  Tests\Visual\Success
   - visual snapshot of test suite on success
 
-  Tests:  6 skipped, 96 passed
-  Time:   3.56s
+  Tests:  7 skipped, 97 passed
+  Time:   3.57s

--- a/tests/Unit/Plugins/Thanks.php
+++ b/tests/Unit/Plugins/Thanks.php
@@ -1,0 +1,14 @@
+<?php
+
+use Pest\Plugins\Thanks;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+it('outputs funding options when --thanks is used')->skip('The plugin uses `exit()` so not sure how to implement this');
+
+it('does not output funding options when --thanks is not used', function () {
+    $output = new BufferedOutput();
+    $plugin = new Thanks($output);
+
+    $plugin->handleArguments(['foo', 'bar']);
+    assertEquals('', $output->fetch());
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #116

This adds the `--thanks` option as shown below:

![Preview screenshot of the Pest thanks plugin](https://user-images.githubusercontent.com/1899334/86227958-afa39800-bb85-11ea-94a1-55935ae35c4c.png)

---

As the plugin uses `exit(0)`, I wasn't sure how best to write the test for it as it just kills the test-suite.

Closes #116