### PR TITLE
Add 'hr' tag to separate link

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,6 +39,8 @@ jobs:
           ---
           ${{ steps.package.outputs.content }}
 
+          ----
+
           Next section: [Upgrade Guide →](/docs/upgrade-guide)
         write-mode: overwrite
     - name: Copy CHANGELOG to website repository


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This updates the changelog action to add an `<hr/>` tag to the end of the changelog so that the "next section" link isn't so close.

**Without `<hr/>` tag**

![Preview without hr tag](https://user-images.githubusercontent.com/1899334/86340704-3d968600-bc4d-11ea-9410-84035e5e8172.png)

**With `<hr/>` tag**

![Preview with hr tag](https://user-images.githubusercontent.com/1899334/86340614-163fb900-bc4d-11ea-9ad1-05490dbec561.png)
