### PR TITLE
Feat/expect

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -373,6 +373,46 @@ final class Expectation
     }
 
     /**
+     * Assert that the value array has the key.
+     */
+    public function toHaveKey(string $key): Expectation
+    {
+        Assert::assertArrayHasKey($key, $this->value);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the value is a directory.
+     */
+    public function toBeDirectory(): Expectation
+    {
+        Assert::assertDirectoryExists($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the value is a directory and is readable.
+     */
+    public function toBeReadableDirectory(): Expectation
+    {
+        Assert::assertDirectoryIsReadable($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the value is a directory and is writable.
+     */
+    public function toBeWritableDirectory(): Expectation
+    {
+        Assert::assertDirectoryIsWritable($this->value);
+
+        return $this;
+    }
+
+    /**
      * Dynamically calls methods on the class without any arguments.
      *
      * @return Expectation

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -142,17 +142,17 @@
   ✓ failures
   ✓ not failures
 
-   PASS  Tests\Expect\toCount
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
    PASS  Tests\Expect\toEqual
   ✓ pass
   ✓ failures
   ✓ not failures
 
    PASS  Tests\Expect\toEqualWithDelta
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
+   PASS  Tests\Expect\toHaveCount
   ✓ pass
   ✓ failures
   ✓ not failures

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -26,6 +26,11 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Expect\toBeDirectory
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Expect\toBeEmpty
   ✓ pass
   ✓ failures
@@ -101,6 +106,11 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Expect\toBeReadableDirectory
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Expect\toBeResource
   ✓ pass
   ✓ failures
@@ -121,9 +131,19 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Expect\toBeWritableDirectory
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Expect\toContain
   ✓ passes strings
   ✓ passes arrays
+  ✓ failures
+  ✓ not failures
+
+   PASS  Tests\Expect\toCount
+  ✓ pass
   ✓ failures
   ✓ not failures
 
@@ -137,7 +157,7 @@
   ✓ failures
   ✓ not failures
 
-   PASS  Tests\Expect\toHaveCount
+   PASS  Tests\Expect\toHaveKey
   ✓ pass
   ✓ failures
   ✓ not failures
@@ -312,5 +332,5 @@
    WARN  Tests\Visual\Success
   - visual snapshot of test suite on success
 
-  Tests:  6 skipped, 183 passed
-  Time:   5.77s
+  Tests:  6 skipped, 195 passed
+  Time:   5.27s

--- a/tests/Expect/toBeDirectory.php
+++ b/tests/Expect/toBeDirectory.php
@@ -1,0 +1,17 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    $temp = sys_get_temp_dir();
+
+    expect($temp)->toBeDirectory();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever')->toBeDirectory();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect('.')->not->toBeDirectory();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toBeReadableDirectory.php
+++ b/tests/Expect/toBeReadableDirectory.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect(sys_get_temp_dir())->toBeWritableDirectory();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever')->toBeWritableDirectory();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(sys_get_temp_dir())->not->toBeWritableDirectory();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toBeWritableDirectory.php
+++ b/tests/Expect/toBeWritableDirectory.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect(sys_get_temp_dir())->toBeWritableDirectory();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever')->toBeWritableDirectory();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(sys_get_temp_dir())->not->toBeWritableDirectory();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toEqualCanonicalizing.php
+++ b/tests/Expect/toEqualCanonicalizing.php
@@ -1,0 +1,16 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect([1, 2, 3])->toEqualCanonicalizing([3, 1, 2]);
+    expect(['g', 'a', 'z'])->not->toEqualCanonicalizing(['a', 'z']);
+});
+
+test('failures', function () {
+    expect([3, 2, 1])->toEqualCanonicalizing([1, 2]);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(['a', 'b', 'c'])->not->toEqualCanonicalizing(['b', 'a', 'c']);
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveKey.php
+++ b/tests/Expect/toHaveKey.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKey('c');
+});
+
+test('failures', function () {
+    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKey('hello');
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(['a' => 1, 'hello' => 'world', 'c'])->not->toHaveKey('hello');
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | 

Adds new methods for "expect" helper.

Looking at the Jest documentation, missing methods:

- toHaveLength
- toBeCloseTo (we have toEqualsWithDelta but the 3rd argument works differently)
- toContainEqual

While PHPUnit has asserts that do not exist in Jest:

- assertClassHasStaticAttribute
- assertContainsOnly
- assertContainsOnlyInstanceOf
- assertEqualsCanonicalizing
- assertEqualsIgnoringCase
- assertFileEquals
- assertFileExists
- assertFileIsReadable
- assertFileIsWritable
- assertJsonFileEqualsJsonFile
- assertJsonStringEqualsJsonFile
- assertJsonStringEqualsJsonString
- assertObjectHasAttribute
- assertMatchesRegularExpression
- assertStringMatchesFormat
- assertStringMatchesFormatFile
- assertStringEndsWith
- assertStringEqualsFile
- assertStringStartsWith
- assertXmlFileEqualsXmlFile
- assertXmlStringEqualsXmlFile
- assertXmlStringEqualsXmlString

Let me know which other matcher needs to be implemented.