### PR TITLE
Add name to description for named datasets

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -77,10 +77,10 @@ final class Datasets
         $dataSetDescriptions = [];
         $dataSetValues       = [];
 
-        foreach ($data as $values) {
+        foreach ($data as $key => $values) {
             $values = is_array($values) ? $values : [$values];
 
-            $dataSetDescriptions[] = $description . self::getDataSetDescription($values);
+            $dataSetDescriptions[] = $description . self::getDataSetDescription($key, $values);
             $dataSetValues[]       = $values;
         }
 
@@ -104,12 +104,15 @@ final class Datasets
     }
 
     /**
+     * @param int|string        $key
      * @param array<int, mixed> $data
      */
-    private static function getDataSetDescription(array $data): string
+    private static function getDataSetDescription($key, array $data): string
     {
         $exporter = new Exporter();
 
-        return \sprintf(' with (%s)', $exporter->shortenedRecursiveExport($data));
+        $nameInsert = is_string($key) ? \sprintf('data set "%s" ', $key) : '';
+
+        return \sprintf(' with %s(%s)', $nameInsert, $exporter->shortenedRecursiveExport($data));
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -6,7 +6,7 @@
   ✓ not property calls
 
    PASS  Tests\Expect\toBe
-  ✓ expect true → toBeTrue  → and false → toBeFalse 
+  ✓ expect true → toBeTrue  → and false → toBeFalse
   ✓ strict comparisons
   ✓ failures
   ✓ not failures
@@ -255,6 +255,9 @@
   ✓ eager wrapped registered datasets with (1)
   ✓ eager wrapped registered datasets with (2)
   ✓ eager registered wrapped datasets did the job right
+  ✓ named datasets with data set "one" (1)
+  ✓ named datasets with data set "two" (2)
+  ✓ named datasets did the job right
   ✓ lazy named datasets with (Bar Object (...))
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #2
@@ -292,8 +295,8 @@
   ✓ it has bar
 
    PASS  Tests\Features\PendingHigherOrderTests
-  ✓ get 'foo' → get 'bar' → expect true → toBeTrue 
-  ✓ get 'foo' → expect true → toBeTrue 
+  ✓ get 'foo' → get 'bar' → expect true → toBeTrue
+  ✓ get 'foo' → expect true → toBeTrue
 
    WARN  Tests\Features\Skip
   ✓ it do not skips
@@ -388,5 +391,4 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 228 passed
-  
+  Tests:  7 skipped, 231 passed

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -345,6 +345,9 @@
   ✓ it throws exception when `process isolation` is true
   ✓ it do not throws exception when `process isolation` is false
 
+   PASS  Tests\Unit\Datasets
+  ✓ it show the names of named datasets in their description
+
    PASS  Tests\Unit\Plugins\Version
   ✓ it outputs the version when --version is used
   ✓ it do not outputs version when --version is not used
@@ -385,5 +388,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 227 passed
+  Tests:  7 skipped, 228 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -6,7 +6,7 @@
   ✓ not property calls
 
    PASS  Tests\Expect\toBe
-  ✓ expect true → toBeTrue  → and false → toBeFalse
+  ✓ expect true → toBeTrue  → and false → toBeFalse 
   ✓ strict comparisons
   ✓ failures
   ✓ not failures
@@ -295,8 +295,8 @@
   ✓ it has bar
 
    PASS  Tests\Features\PendingHigherOrderTests
-  ✓ get 'foo' → get 'bar' → expect true → toBeTrue
-  ✓ get 'foo' → expect true → toBeTrue
+  ✓ get 'foo' → get 'bar' → expect true → toBeTrue 
+  ✓ get 'foo' → expect true → toBeTrue 
 
    WARN  Tests\Features\Skip
   ✓ it do not skips
@@ -392,3 +392,4 @@
   ✓ depends run test only once
 
   Tests:  7 skipped, 231 passed
+  

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -95,6 +95,18 @@ test('eager registered wrapped datasets did the job right', function () use ($st
     expect($state->text)->toBe('1212121212');
 });
 
+test('named datasets', function ($text) use ($state, $datasets) {
+    $state->text .= $text;
+    expect($datasets)->toContain([$text]);
+})->with([
+    'one' => [1],
+    'two' => [2],
+]);
+
+test('named datasets did the job right', function () use ($state) {
+    expect($state->text)->toBe('121212121212');
+});
+
 class Bar
 {
     public $name = 1;

--- a/tests/Unit/Datasets.php
+++ b/tests/Unit/Datasets.php
@@ -8,6 +8,6 @@ it('show the names of named datasets in their description', function () {
         'two' => [[2]],
     ]));
 
-    $this->assertSame('test description with data set "one" (1)', $descriptions[0]);
-    $this->assertSame('test description with data set "two" (array(2))', $descriptions[1]);
+    expect($descriptions[0])->toBe('test description with data set "one" (1)');
+    expect($descriptions[1])->toBe('test description with data set "two" (array(2))');
 });

--- a/tests/Unit/Datasets.php
+++ b/tests/Unit/Datasets.php
@@ -1,0 +1,13 @@
+<?php
+
+use Pest\Datasets;
+
+it('show the names of named datasets in their description', function () {
+    $descriptions = array_keys(Datasets::resolve('test description', [
+        'one' => [1],
+        'two' => [[2]],
+    ]));
+
+    $this->assertSame('test description with data set "one" (1)', $descriptions[0]);
+    $this->assertSame('test description with data set "two" (array(2))', $descriptions[1]);
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | 

With named datasets, Pest does not currently include the dataset name in test output. This PR inserts the dataset name in the dataset description, so that the output of both the test result and failure messages mimic the PHPUnit format.

For example, given the test:

```
test('same pest style', function ($val) {
    $this->assertSame(1, $val);
})->with([
    'one' => [1],
    'two' => [2],
]);
```

the current output includes:
```
  ✓ same with (1)
  ⨯ same with (2)

  ---

  • Tests\Unit\Datasets > same with (2)
```

With this PR, the new output is:

```
  ✓ same with data set "one" (1)
  ⨯ same with data set "two" (2)

  ---

  • Tests\Unit\Datasets > same with data set "two" (2)
```

The PHPUnit failure output, for a test equivalent to the above, is:

```
1) DatasetsTest::testSame with data set "two" (2)
```