### PR TITLE
New expectations: toHaveKeys() & toContainAll()

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -159,7 +159,7 @@ final class Expectation
     /**
      * Asserts that all of the provided $needles are elements of the value.
      *
-     * @param array{mixed} $needles
+     * @param array<mixed> $needles
      */
     public function toContainAll(array $needles): Expectation
     {
@@ -405,7 +405,7 @@ final class Expectation
     /**
      * Asserts that the value array has all of the provided $keys.
      *
-     * @param array{mixed} $keys
+     * @param array<mixed> $keys
      */
     public function toHaveKeys(array $keys): Expectation
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -383,6 +383,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value array has all of the provided $keys.
+     */
+    public function toHaveKeys(array $keys): Expectation
+    {
+        foreach ($keys as $key) {
+            Assert::assertArrayHasKey($key, $this->value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is a directory.
      */
     public function toBeDirectory(): Expectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -157,6 +157,26 @@ final class Expectation
     }
 
     /**
+     * Asserts that all of the provided $needles are elements of the value.
+     *
+     * @param array $needles
+     */
+    public function toContainAll(array $needles): Expectation
+    {
+        if (is_string($this->value)) {
+            foreach ($needles as $needle) {
+                Assert::assertStringContainsString($needle, $this->value);
+            }
+        } else {
+            foreach ($needles as $needle) {
+                Assert::assertContains($needle, $this->value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that $count matches the number of elements of the value.
      */
     public function toHaveCount(int $count): Expectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -159,7 +159,7 @@ final class Expectation
     /**
      * Asserts that all of the provided $needles are elements of the value.
      *
-     * @param array $needles
+     * @param array{mixed} $needles
      */
     public function toContainAll(array $needles): Expectation
     {
@@ -404,6 +404,8 @@ final class Expectation
 
     /**
      * Asserts that the value array has all of the provided $keys.
+     *
+     * @param array{mixed} $keys
      */
     public function toHaveKeys(array $keys): Expectation
     {

--- a/tests/Expect/toContainAll.php
+++ b/tests/Expect/toContainAll.php
@@ -1,0 +1,59 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass when all values exist')
+    ->expect([1, 2, 42])
+    ->toContainAll([42, 2])
+    ->group('toContainAll');
+
+test('pass when all strings exist')
+    ->expect('Pest is awesome')
+    ->toContainAll(['Pest', 'awesome'])
+    ->group('toContainAll');
+
+test('fail when at least one value is missing')
+    ->expect([1, 2, 42])
+    ->toContainAll([42, 14])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');
+
+test('fail when at least one string is missing')
+    ->expect('Pest is awesome')
+    ->toContainAll(['Laravel', 'awesome'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');
+
+test('not - pass when all values are missing')
+    ->expect([1, 2, 42])
+    ->not()->toContainAll([3, 14])
+    ->group('toContainAll');
+
+test('not - pass when all strings are missing')
+    ->expect('Pest is awesome')
+    ->not()->toContainAll(['Laravel', 'clever'])
+    ->group('toContainAll');
+
+test('not - fail when all values exist')
+    ->expect([1, 2, 42])
+    ->not()->toContainAll([2, 42])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');
+
+test('not - fail when all strings exist')
+    ->expect('Pest is awesome')
+    ->not()->toContainAll(['Pest', 'awesome'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');
+
+test('not - fail when at least one value exists')
+    ->expect([1, 2, 42])
+    ->not()->toContainAll([3, 42])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');
+
+test('not - fail when at least one string exists')
+    ->expect('Pest is awesome')
+    ->not()->toContainAll(['Pest', 'clever'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toContainAll');

--- a/tests/Expect/toHaveKeys.php
+++ b/tests/Expect/toHaveKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass when all keys exist')
+    ->expect(['a' => 1, 'b', 'c' => 'world'])
+    ->toHaveKeys(['a', 'c'])
+    ->group('toHaveKeys');
+
+test('fail when at least one key is missing')
+    ->expect(['a' => 1, 'b', 'c' => 'world'])
+    ->toHaveKeys(['a', 'hello'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toHaveKeys');
+
+test('not - pass when all keys are missing')
+    ->expect(['a' => 1, 'b', 'c' => 'world'])
+    ->not()->toHaveKeys(['hello', 'world'])
+    ->group('toHaveKeys');
+
+test('not - fail when all keys exist')
+    ->expect(['a' => 1, 'hello' => 'world', 'c'])
+    ->not()->toHaveKeys(['a', 'hello'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toHaveKeys');
+
+test('not - fail when at least one key exists')
+    ->expect(['a' => 1, 'b', 'c' => 'world'])
+    ->not()->toHaveKeys(['a', 'hello'])
+    ->throws(ExpectationFailedException::class)
+    ->group('toHaveKeys');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

Adds new expectations:
- `toHaveKeys(array $keys)`
- `toContainAll(array $needles)`

Inspired by Freek in a recent livestream: https://youtu.be/KXUVnu-fTIM?t=3625