### PR TITLE
add method / property override

### DIFF
--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -92,7 +92,7 @@ final class TestCaseFactory
     /**
      * Registered properties to override from base test class.
      *
-     * @var array <string, string|int|double|array>
+     * @var array <string, scalar|array|null>
      */
     public $properties = [];
 

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\PendingObjects;
 
+use Closure;
 use Pest\Exceptions\InvalidUsesPath;
 use Pest\TestSuite;
 
@@ -32,6 +33,20 @@ final class UsesCall
      * @var array<int, string>
      */
     private $targets;
+
+    /**
+     * Holds the overridden methods.
+     *
+     * @var array<string, Closure>
+     */
+    private $methods = [];
+
+    /**
+     * Holds the overridden methods.
+     *
+     * @var array<string, int|double|string|array>
+     */
+    private $properties = [];
 
     /**
      * Holds the groups of the uses.
@@ -98,10 +113,28 @@ final class UsesCall
     }
 
     /**
+     * Override parent methods.
+     *
+     * @param array<string, Closure|string|float|int|array> $overrides
+     */
+    public function with(array $overrides): UsesCall
+    {
+        foreach ($overrides as $key => $override) {
+            if ($override instanceof Closure) {
+                $this->methods[$key] = $override;
+            } else {
+                $this->properties[$key] = $override;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Dispatch the creation of uses.
      */
     public function __destruct()
     {
-        TestSuite::getInstance()->tests->use($this->classAndTraits, $this->groups, $this->targets);
+        TestSuite::getInstance()->tests->use($this->classAndTraits, $this->groups, $this->targets, $this->methods, $this->properties);
     }
 }

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -44,7 +44,7 @@ final class UsesCall
     /**
      * Holds the overridden methods.
      *
-     * @var array<string, int|double|string|array>
+     * @var array<string, scalar|array|null>
      */
     private $properties = [];
 
@@ -115,32 +115,33 @@ final class UsesCall
     /**
      * Override parent properties.
      *
-     * @param array<string, scalar> | string $property
-     * @param scalar | NULL                  $value
+     * @param array<string, scalar | array | null > | string $property
+     * @param scalar | array<scalar> | null                  $default
      */
-    public function with($property, $value = null): UsesCall
+    public function with($property, $default = null): UsesCall
     {
-        $properties = is_array($property) ? $property : [$property => $value];
-
-        foreach ($properties as $property => $value) {
-            $this->properties[$property] = $value;
-        }
+        $this->properties = array_merge(
+            $this->properties,
+            is_array($property) ? $property : [$property => $default]
+        );
 
         return $this;
     }
 
     /**
-     * Override parent properties.
+     * Override parent methods.
      *
      * @param array<string, Closure> | string $method
-     * @param Closure | NULL                  $value
+     * @param Closure | NULL                  $override
      */
-    public function extends($method, ? Closure $value = null): UsesCall
+    public function extends($method, $override = null): UsesCall
     {
-        $methods = is_array($method) ? $method : [$method => $value];
+        if (!is_array($method) && $override !== null) {
+            $this->methods[$method] = $override;
+        }
 
-        foreach ($methods as $name => $method) {
-            $this->methods[$name] = $method;
+        if (is_array($method)) {
+            $this->methods = array_merge($this->methods, $method);
         }
 
         return $this;

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -113,18 +113,34 @@ final class UsesCall
     }
 
     /**
-     * Override parent methods.
+     * Override parent properties.
      *
-     * @param array<string, Closure|string|float|int|array> $overrides
+     * @param array<string, scalar> | string $property
+     * @param scalar | NULL                  $value
      */
-    public function with(array $overrides): UsesCall
+    public function with($property, $value = null): UsesCall
     {
-        foreach ($overrides as $key => $override) {
-            if ($override instanceof Closure) {
-                $this->methods[$key] = $override;
-            } else {
-                $this->properties[$key] = $override;
-            }
+        $properties = is_array($property) ? $property : [$property => $value];
+
+        foreach ($properties as $property => $value) {
+            $this->properties[$property] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Override parent properties.
+     *
+     * @param array<string, Closure> | string $method
+     * @param Closure | NULL                  $value
+     */
+    public function extends($method, ? Closure $value = null): UsesCall
+    {
+        $methods = is_array($method) ? $method : [$method => $value];
+
+        foreach ($methods as $name => $method) {
+            $this->methods[$name] = $method;
         }
 
         return $this;
@@ -135,6 +151,12 @@ final class UsesCall
      */
     public function __destruct()
     {
-        TestSuite::getInstance()->tests->use($this->classAndTraits, $this->groups, $this->targets, $this->methods, $this->properties);
+        TestSuite::getInstance()->tests->use(
+            $this->classAndTraits,
+            $this->groups,
+            $this->targets,
+            $this->methods,
+            $this->properties
+        );
     }
 }

--- a/src/Repositories/MethodProxyRepository.php
+++ b/src/Repositories/MethodProxyRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Repositories;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class MethodProxyRepository
+{
+    /**
+     * @var array<string, array<string, Closure>>
+     */
+    private static $methodProxies = [];
+
+    /**
+     * @param class-string $fqn
+     */
+    public static function register(string $fqn, string $methodName, Closure $method): void
+    {
+        if (!array_key_exists($fqn, self::$methodProxies)) {
+            self::$methodProxies[$fqn] = [];
+        }
+
+        self::$methodProxies[$fqn][$methodName] = $method;
+    }
+
+    /**
+     * @param array<mixed> $params
+     *
+     * @return mixed
+     */
+    public static function evaluate(TestCase $newThis, string $methodName, array $params)
+    {
+        return self::$methodProxies[get_class($newThis)][$methodName]->bindTo($newThis)(...$params);
+    }
+
+    /**
+     * @param class-string<TestCase> $class
+     * @param array<mixed>           $params
+     *
+     * @return mixed
+     */
+    public static function staticEvaluate(string $class, string $methodName, array $params)
+    {
+        return self::$methodProxies[$class][$methodName]->bindTo(null, $class)(...$params);
+    }
+}

--- a/src/Repositories/MethodProxyRepository.php
+++ b/src/Repositories/MethodProxyRepository.php
@@ -36,7 +36,7 @@ final class MethodProxyRepository
      */
     public static function evaluate(TestCase $newThis, string $methodName, array $params)
     {
-        return self::$methodProxies[get_class($newThis)][$methodName]->bindTo($newThis)(...$params);
+        return self::$methodProxies[get_class($newThis)][$methodName]->call($newThis, ...$params);
     }
 
     /**

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -25,7 +25,7 @@ final class TestRepository
     private $state = [];
 
     /**
-     * @var array<string, array{0: array<int, string>, 1: array<int,string>, 2: array<string, Closure>, 3: array<string, int|double|string|array>}>
+     * @var array<string, array{array<int, string>, array<int,string>, array<string, Closure>, array<scalar|array|null>}>>
      */
     private $uses = [];
 
@@ -97,11 +97,11 @@ final class TestRepository
     /**
      * Uses the given `$testCaseClass` on the given `$paths`.
      *
-     * @param array<int, string>                     $classOrTraits
-     * @param array<int, string>                     $groups
-     * @param array<int, string>                     $paths
-     * @param array<string, Closure>                 $methods
-     * @param array<string, string|double|array|int> $properties
+     * @param array<int, string>               $classOrTraits
+     * @param array<int, string>               $groups
+     * @param array<int, string>               $paths
+     * @param array<string, Closure>           $methods
+     * @param array<string, scalar|array|null> $properties
      */
     public function use(array $classOrTraits, array $groups, array $paths, array $methods = [], array $properties = []): void
     {

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -166,7 +166,13 @@ final class Reflection
          */
         $returnType = self::getReflectionMethod($class, $method)->getReturnType();
 
-        return $returnType !== null ? (': ' . self::getTypeHint($returnType)) : '';
+        if ($returnType === null) {
+            return '';
+        }
+
+        $typehint = self::getTypeHint($returnType);
+
+        return ': ' . (class_exists($typehint) ? ' \\' . $typehint : $typehint);
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -335,6 +335,9 @@
   ✓ protected methods can be overridden
   ✓ static methods can be overridden
   ✓ properties can be overridden
+  ✓ overriding a method that has the same name as a property works
+  ✓ that a closure can return a closure without issues
+  ✓ that a method can return a custom class without issues
 
    PASS  Tests\Playground
   ✓ basic
@@ -399,5 +402,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 237 passed
+  Tests:  7 skipped, 240 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -328,6 +328,14 @@
   ✓ custom traits can be used
   ✓ trait applied in this file
 
+   PASS  Tests\PHPUnit\OverriddenTestCase\MethodOverridenTest
+  ✓ methods can be overridden
+  ✓ typed methods can be overridden
+  ✓ untyped methods can be overridden
+  ✓ protected methods can be overridden
+  ✓ static methods can be overridden
+  ✓ properties can be overridden
+
    PASS  Tests\Playground
   ✓ basic
 
@@ -391,5 +399,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 231 passed
+  Tests:  7 skipped, 237 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -338,6 +338,7 @@
   ✓ overriding a method that has the same name as a property works
   ✓ that a closure can return a closure without issues
   ✓ that a method can return a custom class without issues
+  ✓ that a method can call parent methods
 
    PASS  Tests\Playground
   ✓ basic
@@ -402,5 +403,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 240 passed
+  Tests:  7 skipped, 241 passed
   

--- a/tests/PHPUnit/CustomTestCase/ExecutedTest.php
+++ b/tests/PHPUnit/CustomTestCase/ExecutedTest.php
@@ -19,5 +19,3 @@ class ExecutedTest extends TestCase
         assertTrue(true);
     }
 }
-
-// register_shutdown_function(fn () => assertTrue(ExecutedTest::$executed));

--- a/tests/PHPUnit/OverriddenTestCase/DummyFoo.php
+++ b/tests/PHPUnit/OverriddenTestCase/DummyFoo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\PHPUnit\OverriddenTestCase;
+
+class DummyFoo
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
+++ b/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
@@ -50,6 +50,11 @@ class MethodOverriddenTest extends PHPUnit\Framework\TestCase
     {
         return 'method'; 
     }
+
+    public function methodThatReturnsAClosure()
+    {
+        return function () : string { return 'foo'; }; 
+    }
 }
 
 uses(MethodOverriddenTest::class)
@@ -84,7 +89,13 @@ uses(MethodOverriddenTest::class)
         return 'method-override';
     })
     
-    ->with('propertyThatIsAlsoAMethod', 'property-override');
+    ->with('propertyThatIsAlsoAMethod', 'property-override')
+
+    ->extends('methodThatReturnsAClosure', function () {
+        return function () {
+            return 'bar';
+        };
+    });
 
 test('methods can be overridden', function () {
     $this->assertOverride();
@@ -115,4 +126,8 @@ test('properties can be overridden', function () {
 test('overriding a method that has the same name as a property works', function () {
     $this->assertEquals('property-override', $this->propertyThatIsAlsoAMethod);
     $this->assertEquals('method-override', $this->propertyThatIsAlsoAMethod());
+});
+
+test('that a closure can return a closure without issues', function () {
+    $this->assertEquals('bar', $this->methodThatReturnsAClosure()());
 });

--- a/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
+++ b/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
@@ -1,0 +1,96 @@
+<?php
+
+class MethodOverriddenTest extends PHPUnit\Framework\TestCase
+{
+    public $foo;
+
+    public $bar = 'foo';
+
+    public $baz = [
+        'baz' => 'baz',
+    ];
+
+    public function assertOverride()
+    {
+        $this->assertTrue(false);
+    }
+
+    public function assertTypedOverride(string $foo, ? int $bar = null): string
+    {
+        $this->assertTrue(false);
+        $this->assertEquals($foo, 'bar');
+        $this->assertEquals($bar, 456);
+
+        return $foo;
+    }
+
+    public function assertUntypedOverride($foo, $bar = 123, $baz = 'bap')
+    {
+        $this->assertTrue(false);
+        $this->assertEquals($foo, 'bar');
+        $this->assertEquals($baz, 'baz');
+        $this->assertEquals($bar, 456);
+
+        return $foo;
+    }
+
+    protected function overrideableConfig($config = ['foo' => 'bar', 'baz', 123, 'a' => ['b' => ['c']]]): array
+    {
+        return $config;
+    }
+
+    public static function getStaticValue(): int
+    {
+        return 0;
+    }
+}
+
+$typedOverride = function (string $foo, ? int $bar): string {
+    $this->assertEquals($foo, 'foo');
+    $this->assertEquals($bar, 123);
+
+    return $foo;
+};
+
+$untypedOverride = function ($foo) {
+    $this->assertEquals($foo, 'foo');
+
+    return $foo;
+};
+
+uses(MethodOverriddenTest::class)->with([
+    'assertOverride'        => function () { $this->assertTrue(true); },
+    'assertTypedOverride'   => $typedOverride,
+    'assertUntypedOverride' => $untypedOverride,
+    'overrideableConfig'    => function (): array { return ['foo' => 'baz']; },
+    'getStaticValue'        => function (): int { return 42; },
+    'foo'                   => 'foo-override',
+    'bar'                   => 'bar-override',
+    'baz'                   => ['baz' => 'baz-override'],
+]);
+
+test('methods can be overridden', function () {
+    $this->assertOverride();
+});
+
+test('typed methods can be overridden', function () {
+    $this->assertTypedOverride('foo', 123);
+});
+
+test('untyped methods can be overridden', function () {
+    $this->assertUntypedOverride('foo');
+});
+
+test('protected methods can be overridden', function () {
+    $this->assertEquals('baz', $this->overrideableConfig()['foo']);
+});
+
+test('static methods can be overridden', function () {
+    $this->assertEquals(42, self::getStaticValue());
+});
+
+test('properties can be overridden', function () {
+    $this->assertEquals('foo-override', $this->foo);
+    $this->assertEquals('bar-override', $this->bar);
+    $this->assertEquals(['baz' => 'baz-override'], $this->baz);
+});

--- a/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
+++ b/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
@@ -62,6 +62,11 @@ class MethodOverriddenTest extends PHPUnit\Framework\TestCase
     {
         return new DummyFoo('foo');
     }
+
+    public function methodThatWillBeCalledAsParent(): string
+    {
+        return 'parent';
+    }
 }
 
 uses(MethodOverriddenTest::class)
@@ -106,6 +111,10 @@ uses(MethodOverriddenTest::class)
 
     ->extends('methodThatReturnsAClass', function () {
         return new DummyFoo('bar');
+    })
+
+    ->extends('methodThatWillBeCalledAsParent', function () {
+        return parent::methodThatWillBeCalledAsParent() . '-child';
     });
 
 test('methods can be overridden')->assertOverride();
@@ -139,4 +148,8 @@ test('that a closure can return a closure without issues', function () {
 
 test('that a method can return a custom class without issues', function () {
     $this->assertEquals('bar', $this->methodThatReturnsAClass()->value);
+});
+
+test('that a method can call parent methods', function () {
+    $this->assertEquals('parent-child', $this->methodThatWillBeCalledAsParent());
 });

--- a/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
+++ b/tests/PHPUnit/OverriddenTestCase/MethodOverridenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\PHPUnit\OverriddenTestCase\DummyFoo;
+
 class MethodOverriddenTest extends PHPUnit\Framework\TestCase
 {
     public $foo;
@@ -48,12 +50,17 @@ class MethodOverriddenTest extends PHPUnit\Framework\TestCase
 
     public function propertyThatIsAlsoAMethod(): string
     {
-        return 'method'; 
+        return 'method';
     }
 
-    public function methodThatReturnsAClosure()
+    public function methodThatReturnsAClosure(): Closure
     {
-        return function () : string { return 'foo'; }; 
+        return function (): string { return 'foo'; };
+    }
+
+    public function methodThatReturnsAClass(): DummyFoo
+    {
+        return new DummyFoo('foo');
     }
 }
 
@@ -84,30 +91,28 @@ uses(MethodOverriddenTest::class)
         'bar'   => 'bar-override',
         'baz'   => ['baz' => 'baz-override'],
     ])
-    
-    ->extends('propertyThatIsAlsoAMethod', function() : string {
+
+    ->extends('propertyThatIsAlsoAMethod', function (): string {
         return 'method-override';
     })
-    
+
     ->with('propertyThatIsAlsoAMethod', 'property-override')
 
     ->extends('methodThatReturnsAClosure', function () {
         return function () {
             return 'bar';
         };
+    })
+
+    ->extends('methodThatReturnsAClass', function () {
+        return new DummyFoo('bar');
     });
 
-test('methods can be overridden', function () {
-    $this->assertOverride();
-});
+test('methods can be overridden')->assertOverride();
 
-test('typed methods can be overridden', function () {
-    $this->assertTypedOverride('foo', 123);
-});
+test('typed methods can be overridden')->assertTypedOverride('foo', 123);
 
-test('untyped methods can be overridden', function () {
-    $this->assertUntypedOverride('foo');
-});
+test('untyped methods can be overridden')->assertUntypedOverride('foo');
 
 test('protected methods can be overridden', function () {
     $this->assertEquals('baz', $this->overrideableConfig()['foo']);
@@ -130,4 +135,8 @@ test('overriding a method that has the same name as a property works', function 
 
 test('that a closure can return a closure without issues', function () {
     $this->assertEquals('bar', $this->methodThatReturnsAClosure()());
+});
+
+test('that a method can return a custom class without issues', function () {
+    $this->assertEquals('bar', $this->methodThatReturnsAClass()->value);
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | [#143](https://github.com/pestphp/pest/issues/143)

# Summary of the API:

A quick summary of this RFC's API.

extends can be used to extend a method or methods.
For extending a method supply the method name and the new value. You can also supply an array of method/value sets for overriding multiple methods or chain extends call.

```php
uses(MyTestCase::class)
    ->extends(
        'createBill',
        fn(string $name) => $this->billService->create($name)
    )
    ->extends([
        'containerProvides' => ['BillService', 'UserService', 'LoginService'],
        'initializeContainer' => function() {
            $container = parent::initializeContainer();
            $container->add(GoogleStorage::class, Mockery::spy(GoogleStorage::class));
        },
    ]);
```

For calling the parent instance method, simply use self::parent(). Calling static parent methods is currently not supported due to limitations within PHP itself.

with can be used to override a property.
For overriding a property, we can use the with method. It works the same way as extends except that it does not support closures, as statements in properties are forbidden.

```php
uses(MyTestCase::class)
    ->with('appName', 'MyAwesomePestApp')
    ->with([
        'useDatabase' => true,
        'databaseMode' => DatabaseMode::TRANSACTION,
    ]);
```

Fixes #143