### PR TITLE
Avoid command interactions when the `--no-interaction` flag is given

### DIFF
--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -60,7 +60,7 @@ final class PestInstallCommand extends Command
         $this->output->success('`tests/Pest.php` created successfully.');
         $this->output->success('`tests/Helpers.php` created successfully.');
 
-        if (! (bool) $this->option('no-interaction')) {
+        if (!(bool) $this->option('no-interaction')) {
             (new \Pest\Console\Thanks($this->output))();
         }
     }

--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -60,7 +60,9 @@ final class PestInstallCommand extends Command
         $this->output->success('`tests/Pest.php` created successfully.');
         $this->output->success('`tests/Helpers.php` created successfully.');
 
-        (new \Pest\Console\Thanks($this->output))();
+        if (! (bool) $this->option('no-interaction')) {
+            (new \Pest\Console\Thanks($this->output))();
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

This PR makes the `pest:install` command correctly handle the `--no-interaction` flag by avoiding the call of the invokable class `\Pest\Console\Thanks` if said flag is defined. 

For context, I was making a preset, and because of that command, the preset was hanging. 

Note that I decided to completely avoid the `Thanks` process if the `--no-interaction` flag was set because I figured that if it was defined, the user wouldn't read that command's output, but if you want, I can change the code so that `Thanks` runs but doesn't ask the question. 

Additionnal note, the linting fails on my Windows machine because of line endings. Not sure how to fix that (I know it's on my end). Everything else passes, though.

