### PR TITLE
Require PHPUnit 9.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "pestphp/pest-plugin": "^0.3",
         "pestphp/pest-plugin-coverage": "^0.3",
         "pestphp/pest-plugin-init": "^0.3",
-        "phpunit/phpunit": "9.3.3"
+        "phpunit/phpunit": "9.3.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Once we are sure, there will be no more breaking changes to internal classes on 9.3.x, we could relax this version constraint, but for now, we will pin the exact version we want, and upgrade it as needed.