### PR TITLE
feat(expectations): add file assertions

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -415,6 +415,36 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is a file.
+     */
+    public function toBeFile(): Expectation
+    {
+        Assert::assertFileExists($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is a file and is readable.
+     */
+    public function toBeReadableFile(): Expectation
+    {
+        Assert::assertFileIsReadable($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is a file and is writable.
+     */
+    public function toBeWritableFile(): Expectation
+    {
+        Assert::assertFileIsWritable($this->value);
+
+        return $this;
+    }
+
+    /**
      * Dynamically calls methods on the class without any arguments.
      *
      * @return Expectation

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -353,5 +353,3 @@
   ✓ depends run test only once
 
   Tests:  6 skipped, 207 passed
-  Time:   5.89s
-

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -41,6 +41,11 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Expect\toBeFile
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Expect\toBeFloat
   ✓ pass
   ✓ failures
@@ -111,6 +116,11 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Expect\toBeReadableFile
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Expect\toBeResource
   ✓ pass
   ✓ failures
@@ -132,6 +142,11 @@
   ✓ not failures
 
    PASS  Tests\Expect\toBeWritableDirectory
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
+   PASS  Tests\Expect\toBeWritableFile
   ✓ pass
   ✓ failures
   ✓ not failures
@@ -337,4 +352,6 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  6 skipped, 198 passed
+  Tests:  6 skipped, 207 passed
+  Time:   5.89s
+

--- a/tests/Expect/toBeFile.php
+++ b/tests/Expect/toBeFile.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+beforeEach(function () {
+    touch($this->tempFile = sys_get_temp_dir() . '/fake.file');
+});
+
+afterEach(function () {
+    unlink($this->tempFile);
+});
+
+test('pass', function () {
+    expect($this->tempFile)->toBeFile();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever.file')->toBeFile();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect($this->tempFile)->not->toBeFile();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toBeReadableDirectory.php
+++ b/tests/Expect/toBeReadableDirectory.php
@@ -3,13 +3,13 @@
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
-    expect(sys_get_temp_dir())->toBeWritableDirectory();
+    expect(sys_get_temp_dir())->toBeReadableDirectory();
 });
 
 test('failures', function () {
-    expect('/random/path/whatever')->toBeWritableDirectory();
+    expect('/random/path/whatever')->toBeReadableDirectory();
 })->throws(ExpectationFailedException::class);
 
 test('not failures', function () {
-    expect(sys_get_temp_dir())->not->toBeWritableDirectory();
+    expect(sys_get_temp_dir())->not->toBeReadableDirectory();
 })->throws(ExpectationFailedException::class);

--- a/tests/Expect/toBeReadableFile.php
+++ b/tests/Expect/toBeReadableFile.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+beforeEach(function () {
+    touch($this->tempFile = sys_get_temp_dir() . '/fake.file');
+});
+
+afterEach(function () {
+    unlink($this->tempFile);
+});
+
+test('pass', function () {
+    expect($this->tempFile)->toBeReadableFile();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever.file')->toBeReadableFile();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect($this->tempFile)->not->toBeReadableFile();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toBeWritableFile.php
+++ b/tests/Expect/toBeWritableFile.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+beforeEach(function () {
+    touch($this->tempFile = sys_get_temp_dir() . '/fake.file');
+});
+
+afterEach(function () {
+    unlink($this->tempFile);
+});
+
+test('pass', function () {
+    expect($this->tempFile)->toBeWritableFile();
+});
+
+test('failures', function () {
+    expect('/random/path/whatever.file')->toBeWritableFile();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect($this->tempFile)->not->toBeWritableFile();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This adds 3 new methods to the assertions API that matches the `toBeDirectory*` methods.

- `toBeFile()`
- `toBeReadableFile()`
- `toBeWritableFile()`

I've also fixed the test case for `toBeReadableDirectory()` as it was running the wrong methods.
https://github.com/pestphp/pest/commit/d5a7becb54df1594381101a41cd6a5d6564727c7

---

For some reason, the snapshot validation isn't working despite me regenerating it. Not really sure how to resolve this...