### PR TITLE
fix: don't decorate output if --colors=never is set

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -6,6 +6,7 @@ use Pest\Actions\ValidatesEnvironment;
 use Pest\Console\Command;
 use Pest\Support\Container;
 use Pest\TestSuite;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -27,7 +28,9 @@ use Symfony\Component\Console\Output\OutputInterface;
     $rootPath = getcwd();
 
     $testSuite = TestSuite::getInstance($rootPath);
-    $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, true);
+
+    $isDecorated = (new ArgvInput())->getParameterOption('--colors', 'always') !== 'never';
+    $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);
 
     $container = Container::getInstance();
     $container->add(TestSuite::class, $testSuite);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This makes sure that the `Output` class in the container is following the provided `--colors` flag.

Currently without this change, using `--colors=never` still uses colours in the output:
![image](https://user-images.githubusercontent.com/1899334/90635729-78ff0b00-e221-11ea-8280-42c11be16de2.png)

With this change, plugins will follow the `--colors=never` configuration:
![image](https://user-images.githubusercontent.com/1899334/90635779-8ddb9e80-e221-11ea-9076-1cf2f6811da7.png)

---

As displayed in the screenshots, this only applies to plugins that are using the container instance. I know there are other references that will not obey this ([in Collision](https://github.com/nunomaduro/collision/blob/424a2ff61dccf0f98fbefaec252d444411b4bf83/src/Adapters/Phpunit/Style.php#L55) as mentioned in https://github.com/pestphp/pest/pull/51), but this should make it better for plugins.