### PR TITLE
chore: indicate 0.3 dev in version

### DIFF
--- a/src/Pest.php
+++ b/src/Pest.php
@@ -6,5 +6,5 @@ namespace Pest;
 
 function version(): string
 {
-    return '0.2.2';
+    return '0.3.x-dev';
 }

--- a/tests/Unit/Plugins/Version.php
+++ b/tests/Unit/Plugins/Version.php
@@ -1,6 +1,7 @@
 <?php
 
 use Pest\Plugins\Version;
+use function Pest\version;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 it('outputs the version when --version is used', function () {
@@ -8,7 +9,7 @@ it('outputs the version when --version is used', function () {
     $plugin = new Version($output);
 
     $plugin->handleArguments(['foo', '--version']);
-    expect($output->fetch())->toContain('Pest    0.2.2');
+    expect($output->fetch())->toContain('Pest    ' . version());
 });
 
 it('do not outputs version when --version is not used', function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I think this makes more sense when using the development (`dev-master`) version of Pest. It seems a bit odd running Pest `^0.3` and seeing `0.2.2` in the output. Especially as this wasn't updated in the [`v0.2` branch](https://github.com/pestphp/pest/blob/v0.2.x/src/Pest.php), so it shows `0.2.2` even when using Pest `0.2.3` or `0.2.4`.

I've also used the `Pest\version()` function in the test which means that the hardcoded string doesn't have to be updated after each release.