### PR TITLE
Forward TestCase bad method calls to global functions

### DIFF
--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -6,6 +6,7 @@ namespace Pest\Support;
 
 use Closure;
 use Pest\Exceptions\ShouldNotHappen;
+use Pest\TestSuite;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
@@ -38,6 +39,12 @@ final class Reflection
         } catch (ReflectionException $exception) {
             if (method_exists($object, '__call')) {
                 return $object->__call($method, $args);
+            }
+
+            if (is_callable($method)) {
+                return Closure::fromCallable($method)->bindTo(
+                    TestSuite::getInstance()->test
+                )(...$args);
             }
 
             throw $exception;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -244,6 +244,7 @@
   ✓ it throws error if property do not exist
   ✓ it allows to call underlying protected/private methods
   ✓ it throws error if method do not exist
+  ✓ it can forward unexpected calls to any global function
 
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
@@ -352,5 +353,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  6 skipped, 207 passed
+  Tests:  6 skipped, 208 passed
   

--- a/tests/Autoload.php
+++ b/tests/Autoload.php
@@ -22,3 +22,8 @@ trait SecondPluginTrait
 
 Pest\Plugin::uses(PluginTrait::class);
 Pest\Plugin::uses(SecondPluginTrait::class);
+
+function _assertThat()
+{
+    expect(true)->toBeTrue();
+}

--- a/tests/Features/Helpers.php
+++ b/tests/Features/Helpers.php
@@ -40,3 +40,5 @@ it('allows to call underlying protected/private methods', function () {
 it('throws error if method do not exist', function () {
     test()->name();
 })->throws(\ReflectionException::class, 'Call to undefined method PHPUnit\Framework\TestCase::name()');
+
+it('can forward unexpected calls to any global function')->_assertThat();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

```php
// tests/Helpers.php

function assertSomething() {}
```

```php
// tests/SomeTest.php

it('works')->assertSomething();
```

Right now, any functions can be called like `substr` or `dd`, maybe we want to restrict that behavior to function asserting something. (if there is no new assertions, we still throw a BadMethodCallException) ?

This is still WIP but it works, without breaking any existing test.
