### PR TITLE
fix: update snapshot generation to strip time

### DIFF
--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -353,3 +353,4 @@
   ✓ depends run test only once
 
   Tests:  6 skipped, 207 passed
+  

--- a/tests/Visual/Success.php
+++ b/tests/Visual/Success.php
@@ -17,7 +17,10 @@ test('visual snapshot of test suite on success', function () {
     };
 
     if (getenv('REBUILD_SNAPSHOTS')) {
-        file_put_contents($snapshot, $output());
+        // Strip time from end of snapshot
+        $outputContent = preg_replace('/Time\: \s+\d+\.\d+s\s+/m', '', $output());
+
+        file_put_contents($snapshot, $outputContent);
     } elseif (!getenv('EXCLUDE')) {
         $output = explode("\n", $output());
         array_pop($output);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This updates the snapshot generation for visual tests to remove the time value in the snapshot output as this causes issues when re-generating for anyone doing a PR.