### PR TITLE
proof of concept custom expectations

### DIFF
--- a/src/Actions/LoadStructure.php
+++ b/src/Actions/LoadStructure.php
@@ -23,6 +23,7 @@ final class LoadStructure
     private const STRUCTURE = [
         'Datasets.php',
         'Helpers.php',
+        'Expectations.php',
         'Pest.php',
         'Datasets',
     ];

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -494,4 +494,22 @@ final class Expectation
         /* @phpstan-ignore-next-line */
         return $this->{$name}();
     }
+
+    /**
+     * Dynamically calls custom expectation if it can be found
+     *
+     * @param string $method
+     * @param array $args
+     */
+    public function __call(string $method, array $args)
+    {
+        if (function_exists($method)) {
+            $result = $method($this->value, ...$args);
+            Assert::assertTrue($result);
+
+            return $this;
+        }
+
+        throw new \InvalidArgumentException("Could not find expectation for $method");
+    }
 }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pest;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
+
 
 /**
  * @internal
@@ -499,9 +501,10 @@ final class Expectation
      * Dynamically calls custom expectation if it can be found
      *
      * @param string $method
-     * @param array $args
+     * @param array<mixed> $args
+     * @return Expectation
      */
-    public function __call(string $method, array $args)
+    public function __call(string $method, array $args): Expectation
     {
         if (function_exists($method)) {
             $result = $method($this->value, ...$args);
@@ -510,6 +513,6 @@ final class Expectation
             return $this;
         }
 
-        throw new \InvalidArgumentException("Could not find expectation for $method");
+        throw new InvalidArgumentException("Could not find expectation for $method");
     }
 }

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -1,0 +1,11 @@
+<?php
+
+function toBeFoo($value)
+{
+    return "foo" === $value;
+}
+
+function toBeSomething($value, $something)
+{
+    return $something === $value;
+}

--- a/tests/Features/CustomExpectations.php
+++ b/tests/Features/CustomExpectations.php
@@ -1,0 +1,21 @@
+<?php
+
+it ('calls a custom expectation', function () {
+    $foo = "foo";
+    expect($foo)->toBeFoo();
+});
+
+it ('calls a custom expectation with not', function () {
+    $bar = "bar";
+    expect($bar)->not->toBeFoo();
+});
+
+it ('calls a custom expectation with a parameter', function () {
+    $foo = "foo";
+    expect($foo)->toBeSomething("foo");
+});
+
+it ('fails with an invalid custom expectation', function () {
+    $foo = "foo";
+    expect($foo)->toNonexistentExpectation();
+})->throws(\InvalidArgumentException::class, "Could not find expectation for toNonexistentExpectation");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This is a proof of concept for custom expectations. The basic idea is that you'd optionally have an "Expectations.php" file in your root tests directory, which can define any number of expectation functions. Such functions must return true/false to indicate whether the expectation is met or not. Expectation functions would be passed the current value as the first parameter and any additional parameters afterward.