### PR TITLE
Revert to original target if new target is null

### DIFF
--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -30,7 +30,7 @@ final class HigherOrderMessageCollection
     public function chain(object $target): void
     {
         foreach ($this->messages as $message) {
-            $target = $message->call($target);
+            $target = $message->call($target) ?? $target;
         }
     }
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -278,6 +278,7 @@
 
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
+  ✓ it is capable doing multiple assertions
 
    PASS  Tests\Features\It
   ✓ it is a test
@@ -302,6 +303,7 @@
   - it skips with truthy closure condition
   ✓ it do not skips with falsy closure condition
   - it skips with condition and message → skipped because foo
+  - it skips when skip after assertion
 
    PASS  Tests\Features\Test
   ✓ a test
@@ -383,5 +385,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  6 skipped, 226 passed
+  Tests:  7 skipped, 227 passed
   

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -4,4 +4,8 @@ beforeEach()->assertTrue(true);
 
 it('proxies calls to object')->assertTrue(true);
 
+it('is capable doing multiple assertions')
+    ->assertTrue(true)
+    ->assertFalse(false);
+
 afterEach()->assertTrue(true);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -27,3 +27,7 @@ it('do not skips with falsy closure condition')
 it('skips with condition and message')
     ->skip(true, 'skipped because foo')
     ->assertTrue(false);
+
+it('skips when skip after assertion')
+    ->assertTrue(true)
+    ->skip();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #184 

This fixes higher order tests where an assert is followed by any other higher order message. This is due to the fact that the PHPUnit assert methods (located in `vendor/phpunit/phpunit/src/Framework/Assert.php`) return void. 

