### PR TITLE
Skip tests based on PHP version

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\PendingObjects;
 
 use Closure;
+use Pest\Expectation;
 use Pest\Factories\TestCaseFactory;
 use Pest\Support\Backtrace;
 use Pest\Support\NullClosure;
@@ -13,7 +14,7 @@ use PHPUnit\Framework\ExecutionOrderDependency;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
- * @method \Pest\Expectation expect(mixed $value)
+ * @method Expectation expect(mixed $value)
  *
  * @internal
  */
@@ -78,7 +79,7 @@ final class TestCall
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *
-     * @param \Closure|iterable<int, mixed>|string $data
+     * @param Closure|iterable<int, mixed>|string $data
      */
     public function with($data): TestCall
     {
@@ -128,6 +129,17 @@ final class TestCall
     }
 
     /**
+     * Skips the test for a given version of PHP.
+     */
+    public function skipForVersion(string $version, string $operator = null, string $message = ''): TestCall
+    {
+        return $this->skip(
+            version_compare(PHP_VERSION, $version, $operator ?? '=='),
+            $message
+        );
+    }
+
+    /**
      * Skips the current test.
      *
      * @param Closure|bool|string $conditionOrMessage
@@ -155,6 +167,17 @@ final class TestCall
         }
 
         return $this;
+    }
+
+    /**
+     * Runs the test only for a given version of PHP.
+     */
+    public function onlyForVersion(string $version, string $message = ''): TestCall
+    {
+        return $this->skip(
+            version_compare(PHP_VERSION, $version, '=='),
+            $message
+        );
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -395,5 +395,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  10 skipped, 228 passed
+  Tests:  10 skipped, 232 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -304,6 +304,10 @@
   ✓ it do not skips with falsy closure condition
   - it skips with condition and message → skipped because foo
   - it skips when skip after assertion
+  - it skips if the PHP version is the current one (with message) → because of the current version
+  - it skips if the PHP version is greater that 7 (should skip)
+  ✓ it skips if the PHP version is less than 7 (should never skip)
+  - it runs only if the PHP version is the current one (should never skip)
 
    PASS  Tests\Features\Test
   ✓ a test
@@ -385,5 +389,5 @@
   ✓ depends with defined arguments
   ✓ depends run test only once
 
-  Tests:  7 skipped, 227 passed
+  Tests:  10 skipped, 228 passed
   

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -17,11 +17,15 @@ it('skips with message')
     ->assertTrue(false);
 
 it('skips with truthy closure condition')
-    ->skip(function () { return '1'; })
+    ->skip(function () {
+        return '1';
+    })
     ->assertTrue(false);
 
 it('do not skips with falsy closure condition')
-    ->skip(function () { return false; })
+    ->skip(function () {
+        return false;
+    })
     ->assertTrue(true);
 
 it('skips with condition and message')
@@ -31,3 +35,19 @@ it('skips with condition and message')
 it('skips when skip after assertion')
     ->assertTrue(true)
     ->skip();
+
+it('skips if the PHP version is the current one (with message)')
+    ->skipForVersion(PHP_VERSION, null, 'because of the current version')
+    ->assertTrue(true);
+
+it('skips if the PHP version is greater that 7 (should skip)')
+    ->skipForVersion('7', '>')
+    ->assertTrue(true);
+
+it('skips if the PHP version is less than 7 (should never skip)')
+    ->skipForVersion('7', '<')
+    ->assertTrue(true);
+
+it('runs only if the PHP version is the current one (should never skip)')
+    ->onlyForVersion(PHP_VERSION)
+    ->assertTrue(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

It provides the ability to skip a test for a given PHP version.

Maybe we should also add a `onlyForVersion()` too.
