### PR TITLE
Add Pest version to help command

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -11,6 +11,8 @@ use Pest\Actions\ValidatesConfiguration;
 use Pest\Contracts\Plugins\AddsOutput;
 use Pest\Contracts\Plugins\HandlesArguments;
 use Pest\Plugin\Loader;
+use Pest\Plugins\Version;
+use Pest\Support\Container;
 use Pest\TestSuite;
 use PHPUnit\Framework\TestSuite as BaseTestSuite;
 use PHPUnit\TextUI\Command as BaseCommand;
@@ -138,5 +140,13 @@ final class Command extends BaseCommand
         }
 
         exit($result);
+    }
+
+    protected function showHelp(): void
+    {
+        /** @var Version $version */
+        $version = Container::getInstance()->get(Version::class);
+        $version->handleArguments(['--version']);
+        parent::showHelp();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds the pest version when running help.
![image](https://user-images.githubusercontent.com/5870441/95443617-155da800-095d-11eb-8ac6-cd6251ff1fb2.png)

