### PR TITLE
Update phpunit dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "pestphp/pest-plugin": "^0.3",
         "pestphp/pest-plugin-coverage": "^0.3",
         "pestphp/pest-plugin-init": "^0.3",
-        "phpunit/phpunit": ">= 9.3.7 <= 9.4.0"
+        "phpunit/phpunit": ">= 9.3.7 <= 9.4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  no
| Fixed tickets | #205 

allow all phpunit versions greater or equal to 9.3.7
