### PR TITLE
Get root path based on composer autoloader

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -19,16 +19,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
     if (file_exists($vendorPath)) {
         include_once $vendorPath;
-        $rootPath = dirname($vendorPath, 2);
+        $autoloadPath = $vendorPath;
     } else {
         include_once $localPath;
-        $rootPath = dirname($localPath, 5);
+        $autoloadPath = $localPath;
     }
 
     (new Provider())->register();
 
-    // fallback in case we couldn't find out the path before.
-    $rootPath = (isset($rootPath) && !empty($rootPath)) ? $rootPath : getcwd();
+    // get $rootPath based on $autoloadPath
+    $rootPath =  dirname($autoloadPath, 2);
 
     $testSuite = TestSuite::getInstance($rootPath);
 

--- a/bin/pest
+++ b/bin/pest
@@ -19,13 +19,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
     if (file_exists($vendorPath)) {
         include_once $vendorPath;
+        $rootPath = dirname($vendorPath, 2);
     } else {
         include_once $localPath;
+        $rootPath = dirname($localPath, 5);
     }
 
     (new Provider())->register();
 
-    $rootPath = getcwd();
+    // fallback in case we couldn't find out the path before.
+    $rootPath = (isset($rootPath) && !empty($rootPath)) ? $rootPath : getcwd();
 
     $testSuite = TestSuite::getInstance($rootPath);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | https://github.com/pestphp/pest-intellij/issues/73

So this is not necessarily something we want to support, so wanna get the rest of your guys feedback on it.

So basically the issue is that @NickSdot has a pretty strange folder structure, where the root of the project is actually not the root of php application.
The phpstorm plugin set's the CWD to be the project root, however Pest expects CWD to be the php application's root. This can prob. be solved in the plugin by changing the CWD to the php application root.

 The solution in this pr is created by @NickSdot.

It basically suggests a structure where we guess the php application root from the composer autoloader path instead. This solution should be viable as composer enforces a structure where the php application root will always be just outside the `vendor` folder.

The downside with this solution is you can't have a global composer pest installed and use that for running tests.