### PR TITLE
Improve exception output in teamcity printer

### DIFF
--- a/src/TeamCity.php
+++ b/src/TeamCity.php
@@ -24,7 +24,6 @@ final class TeamCity extends DefaultResultPrinter
     private const DURATION            = 'duration';
     private const TEST_SUITE_STARTED  = 'testSuiteStarted';
     private const TEST_SUITE_FINISHED = 'testSuiteFinished';
-    private const TEST_FAILED         = 'testFailed';
 
     /** @var int */
     private $flowId;
@@ -149,19 +148,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function addError(Test $test, Throwable $t, float $time): void
     {
-        if (!TeamCity::isPestTest($test)) {
-            $this->phpunitTeamCity->addError($test, $t, $time);
-
-            return;
-        }
-
-        $this->printEvent(
-            self::TEST_FAILED, [
-            self::NAME     => $test->getName(),
-            'message'      => $t->getMessage(),
-            'details'      => $t->getTraceAsString(),
-            self::DURATION => self::toMilliseconds($time),
-        ]);
+        $this->phpunitTeamCity->addError($test, $t, $time);
     }
 
     /**
@@ -171,19 +158,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        if (!TeamCity::isPestTest($test)) {
-            $this->phpunitTeamCity->addWarning($test, $e, $time);
-
-            return;
-        }
-
-        $this->printEvent(
-            self::TEST_FAILED, [
-            self::NAME     => $test->getName(),
-            'message'      => $e->getMessage(),
-            'details'      => $e->getTraceAsString(),
-            self::DURATION => self::toMilliseconds($time),
-        ]);
+        $this->phpunitTeamCity->addWarning($test, $e, $time);
     }
 
     public function addFailure(Test $test, AssertionFailedError $e, float $time): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Our teamcity printer didn't do the cleanup on the exception which phpunit does, so I added that in.

```php
it("fails", function () {
    throw new Exception("fails");
});
```

It still does not use collision, as I cannot figure out how to make that work. However this will at least help a lot of users with debugging their exceptions.

New result:
![image](https://user-images.githubusercontent.com/5870441/98089385-ef0b2980-1e82-11eb-9f72-2c9673028111.png)
Old result:
![image](https://user-images.githubusercontent.com/5870441/98089524-1feb5e80-1e83-11eb-8465-a7774112fa8b.png)

