### PR TITLE
fix(depends): resolve issue with dependency names

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -95,7 +95,11 @@ final class TestCall
         $className = $this->testCaseFactory->getClassName();
 
         $tests = array_map(function (string $test) use ($className): ExecutionOrderDependency {
-            return ExecutionOrderDependency::createFromDependsAnnotation($className, $test);
+            if (strpos($test, '::') === false) {
+                $test = "{$className}::{$test}";
+            }
+
+            return new ExecutionOrderDependency($test, null, '');
         }, $tests);
 
         $this->testCaseFactory

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -392,10 +392,12 @@
    PASS  Tests\Features\Depends
   ✓ first
   ✓ second
+  ✓ it asserts true is true
   ✓ depends
   ✓ depends with ...params
   ✓ depends with defined arguments
   ✓ depends run test only once
+  ✓ depends works with the correct test name
 
-  Tests:  7 skipped, 233 passed
+  Tests:  7 skipped, 235 passed
   

--- a/tests/Features/Depends.php
+++ b/tests/Features/Depends.php
@@ -32,3 +32,7 @@ test('depends with defined arguments', function (string $first, string $second) 
 test('depends run test only once', function () use (&$runCounter) {
     expect($runCounter)->toBe(2);
 })->depends('first', 'second');
+
+// Regression tests. See https://github.com/pestphp/pest/pull/216
+it('asserts true is true')->assertTrue(true);
+test('depends works with the correct test name')->assertTrue(true)->depends('it asserts true is true');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | fixes #213

This resolves #213, although it needs some thorough testing.

The issue is that [`ExecutionOrderDependency::createFromDependsAnnotation()`](https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/ExecutionOrderDependency.php#L46) splits the provided test name by spaces in order to determine the ["clone option"](https://phpunit.readthedocs.io/en/9.3/writing-tests-for-phpunit.html#writing-tests-for-phpunit-test-dependencies). We currently use this in the [`TestCall::depends()`](https://github.com/pestphp/pest/blob/d85432933cfd916f691a564ccd10dab82d008dd6/src/PendingObjects/TestCall.php#L98) method, so when depending on a test with spaces in the name, you need to prefix it with another word.

For example:

```php
// Resulting testname is `it asserts true is true`
it('asserts true is true')->assertTrue(true);

// This does not work, despite the test name being correct
it('does not work')->assertTrue(true)->depends('it asserts true is true');

// This works, however it uses `it it` in the test name (clone option would be "it")
it('works... but needs a double "it"')->assertTrue(true)->depends('it it asserts true is true');

// This also works, and the "clone option" is set to `bah`
it('works... but is the wrong name')->assertTrue(true)->depends('bah it asserts true is true');
```

See https://github.com/pestphp/pest/issues/213#issuecomment-723937696 for more background details.

This does mean that we drop support for clone options, although... I'm not really sure what they are and whether Pest users are using them anyway...