### PR TITLE
Add a dusk command for Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "require-dev": {
         "illuminate/console": "^7.16.1",
         "illuminate/support": "^7.16.1",
+        "laravel/dusk": "^6.9.0",
         "mockery/mockery": "^1.4.1",
         "pestphp/pest-dev-tools": "dev-master"
     },

--- a/src/Laravel/Commands/PestDuskCommand.php
+++ b/src/Laravel/Commands/PestDuskCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Commands;
+
+use Laravel\Dusk\Console\DuskCommand;
+
+/**
+ * @internal
+ */
+final class PestDuskCommand extends DuskCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'pest:dusk {--without-tty : Disable output to TTY}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the Dusk tests for the application with Pest';
+
+    /**
+     * Get the PHP binary to execute.
+     *
+     * @return array<string>
+     */
+    protected function binary()
+    {
+        if ('phpdbg' === PHP_SAPI) {
+            return [PHP_BINARY, '-qrr', 'vendor/bin/pest'];
+        }
+
+        return [PHP_BINARY, 'vendor/bin/pest'];
+    }
+}

--- a/src/Laravel/PestServiceProvider.php
+++ b/src/Laravel/PestServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Pest\Laravel;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Dusk\Console\DuskCommand;
 use Pest\Laravel\Commands\PestDatasetCommand;
+use Pest\Laravel\Commands\PestDuskCommand;
 use Pest\Laravel\Commands\PestInstallCommand;
 use Pest\Laravel\Commands\PestTestCommand;
 
@@ -22,6 +24,12 @@ final class PestServiceProvider extends ServiceProvider
                 PestTestCommand::class,
                 PestDatasetCommand::class,
             ]);
+
+            if (class_exists(DuskCommand::class)) {
+                $this->commands([
+                    PestDuskCommand::class,
+                ]);
+            }
         }
     }
 }


### PR DESCRIPTION
This new command will replicate Dusk behavior with .env.dusk files

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #212

Laravel Dusk has a feature to replace current `.env` file with a specific one depending on your environment, this PR replicate this feature in Pest.

Link to the Dusk feature: https://laravel.com/docs/8.x/dusk#environment-handling

I'm not sure of my implementation as I had to install `laravel/dusk` as a dev dependency, but if I'm not installing it I'm getting error from rector as it doesn't find the class.
Should I disable lint for this file or is there a better way to do it?