### PR TITLE
feat: add support for macroing Expectation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
+        "illuminate/macroable": "^8.16",
         "nunomaduro/collision": "^5.0",
         "pestphp/pest-plugin": "^0.3",
         "pestphp/pest-plugin-coverage": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         ]
     },
     "require-dev": {
-        "illuminate/console": "^7.16.1",
-        "illuminate/support": "^7.16.1",
+        "illuminate/console": "^8.0",
+        "illuminate/support": "^8.0",
         "mockery/mockery": "^1.4.1",
         "pestphp/pest-dev-tools": "dev-master"
     },

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest;
 
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 
@@ -14,6 +15,8 @@ use PHPUnit\Framework\Constraint\Constraint;
  */
 final class Expectation
 {
+    use Macroable;
+
     /**
      * The expectation value.
      *

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -2,6 +2,12 @@
    PASS  Tests\CustomTestCase\ExecutedTest
   ✓ that gets executed
 
+   PASS  Tests\Expect\Macro
+  ✓ it macros true is true
+  ✓ it macros false is not true
+  ✓ it macros true is true with argument
+  ✓ it macros false is not true with argument
+
    PASS  Tests\Expect\not
   ✓ not property calls
 
@@ -404,5 +410,5 @@
   ✓ depends run test only once
   ✓ depends works with the correct test name
 
-  Tests:  7 skipped, 238 passed
+  Tests:  7 skipped, 242 passed
   

--- a/tests/Expect/Macro.php
+++ b/tests/Expect/Macro.php
@@ -1,0 +1,32 @@
+<?php
+
+use Pest\Expectation;
+use PHPUnit\Framework\Assert;
+
+Expectation::macro('toBeAMacroExpectation', function () {
+    Assert::assertTrue($this->value);
+
+    return $this;
+});
+
+Expectation::macro('toBeAMacroExpectationWithArguments', function (bool $value) {
+    Assert::assertSame($value, $this->value);
+
+    return $this;
+});
+
+it('macros true is true', function () {
+    expect(true)->toBeAMacroExpectation();
+});
+
+it('macros false is not true', function () {
+    expect(false)->not->toBeAMacroExpectation();
+});
+
+it('macros true is true with argument', function () {
+    expect(true)->toBeAMacroExpectationWithArguments(true);
+});
+
+it('macros false is not true with argument', function () {
+    expect(false)->not->toBeAMacroExpectationWithArguments(true);
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This is an alternative to #186, it adds support for using the `::macro()` method on the `Expectation` class.

This allows the ability for users or plugins to add new custom expectations.

For example:

```php
use Pest\Expectation;

Expectation::macro('toBeResource', function () {
    Assert::assertIsResource($this->value);

    return $this;
});

// Write test
it('asserts resource is resource', function () {
    expect($resource)->toBeResource();
});
```

Note that any assertions can be used, although you must return `$this` when assertions are finished.