### PR TITLE
fix: authorize string as key for datasets

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -51,7 +51,7 @@ final class Datasets
     /**
      * Resolves the current dataset to an array value.
      *
-     * @param Traversable<int, mixed>|Closure|iterable<int, mixed>|string|null $data
+     * @param Traversable<int|string, mixed>|Closure|iterable<int|string, mixed>|string|null $data
      *
      * @return array<string, mixed>
      */

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -59,7 +59,7 @@ final class TestCaseFactory
     /**
      * Holds the dataset, if any.
      *
-     * @var Closure|iterable<int, mixed>|string|null
+     * @var Closure|iterable<int|string, mixed>|string|null
      */
     public $dataset;
 

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -78,7 +78,7 @@ final class TestCall
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *
-     * @param \Closure|iterable<int, mixed>|string $data
+     * @param \Closure|iterable<int|string, mixed>|string $data
      */
     public function with($data): TestCall
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

When using dataset with string as array key in projects, PHPStan refuses because of:
```
$ vendor/bin/pest

   PASS  Tests\Unit\DatasetTest
  ✓ it tests with string key for dataset with data set "with value `true`" (true)

  Tests:  1 passed
  Time:   0.04s

$ vendor/bin/phpstan analyze
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/Unit\DatasetTest.php                                                                                                                
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------- 
  12    Parameter #1 $data of method Pest\PendingObjects\TestCall::with() expects Closure|iterable<int, mixed>|string, array('with value `true`' => true) given.  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 1 error
```
for the test below:
```
it('tests with string key for dataset', function (bool $expected) {
    assertTrue($expected);
})->with([
    'with value `true`' => true
]);
```

This PR fixes this.
