### PR TITLE
Add test for inheritance with depends

### DIFF
--- a/src/Concerns/TestCase.php
+++ b/src/Concerns/TestCase.php
@@ -7,6 +7,7 @@ namespace Pest\Concerns;
 use Closure;
 use Pest\Support\ExceptionTrace;
 use Pest\TestSuite;
+use PHPUnit\Framework\ExecutionOrderDependency;
 use PHPUnit\Util\Test;
 use Throwable;
 
@@ -52,6 +53,24 @@ trait TestCase
         $groups = array_unique(array_merge($this->getGroups(), $groups));
 
         $this->setGroups($groups);
+    }
+
+    /**
+     * Add dependencies to the test case and map them to instances of ExecutionOrderDependency.
+     */
+    public function addDependencies(array $tests): void
+    {
+        $className = get_class($this);
+
+        $tests = array_map(function (string $test) use ($className): ExecutionOrderDependency {
+            if (strpos($test, '::') === false) {
+                $test = "{$className}::{$test}";
+            }
+
+            return new ExecutionOrderDependency($test, null, '');
+        }, $tests);
+
+        $this->setDependencies($tests);
     }
 
     /**

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -157,14 +157,6 @@ final class TestCaseFactory
     }
 
     /**
-     * Makes a fully qualified class name from the current filename.
-     */
-    public function getClassName(): string
-    {
-        return $this->makeClassFromFilename($this->filename);
-    }
-
-    /**
      * Makes a fully qualified class name from the given filename.
      */
     public function makeClassFromFilename(string $filename): string

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -9,7 +9,6 @@ use Pest\Factories\TestCaseFactory;
 use Pest\Support\Backtrace;
 use Pest\Support\NullClosure;
 use Pest\TestSuite;
-use PHPUnit\Framework\ExecutionOrderDependency;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
@@ -92,19 +91,9 @@ final class TestCall
      */
     public function depends(string ...$tests): TestCall
     {
-        $className = $this->testCaseFactory->getClassName();
-
-        $tests = array_map(function (string $test) use ($className): ExecutionOrderDependency {
-            if (strpos($test, '::') === false) {
-                $test = "{$className}::{$test}";
-            }
-
-            return new ExecutionOrderDependency($test, null, '');
-        }, $tests);
-
         $this->testCaseFactory
             ->factoryProxies
-            ->add(Backtrace::file(), Backtrace::line(), 'setDependencies', [$tests]);
+            ->add(Backtrace::file(), Backtrace::line(), 'addDependencies', [$tests]);
 
         return $this;
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -184,5 +184,9 @@
   ✓ depends run test only once
   ✓ depends works with the correct test name
 
-  Tests:  7 skipped, 106 passed
+   PASS  Tests\Features\DependsInheritance
+  ✓ it is a test
+  ✓ it uses correct parent class
+
+  Tests:  7 skipped, 108 passed
   

--- a/tests/Features/DependsInheritance.php
+++ b/tests/Features/DependsInheritance.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class InheritanceTest extends TestCase
+{
+    public function foo()
+    {
+        return 'bar';
+    }
+}
+
+uses(InheritanceTest::class);
+
+it('is a test', function () {
+    expect(true)->toBeTrue();
+});
+
+it('uses correct parent class', function () {
+    expect(get_parent_class($this))->toEqual(InheritanceTest::class);
+    expect($this->foo())->toEqual('bar');
+})->depends('it is a test');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #230

As requested in #230. This pull request contains a failing test demonstrating that test class inheritance via `uses` does not work when `depends` is called.

I added the tests in a separate file in order not to break the tests in `Depends.php`.

