### PR TITLE
change binary path pest:dusk

### DIFF
--- a/src/Laravel/Commands/PestDuskCommand.php
+++ b/src/Laravel/Commands/PestDuskCommand.php
@@ -33,9 +33,9 @@ final class PestDuskCommand extends DuskCommand
     protected function binary()
     {
         if ('phpdbg' === PHP_SAPI) {
-            return [PHP_BINARY, '-qrr', 'vendor/bin/pest'];
+            return [PHP_BINARY, '-qrr', 'vendor/pestphp/pest/bin/pest'];
         }
 
-        return [PHP_BINARY, 'vendor/bin/pest'];
+        return [PHP_BINARY, 'vendor/pestphp/pest/bin/pest'];
     }
 }


### PR DESCRIPTION
In windows not work
full path is used in [https://github.com/laravel/dusk/blob/7e05b3ca4f17afcba528c4c5a2390a2dd9949b38/src/Console/DuskCommand.php#L91](https://github.com/laravel/dusk/blob/7e05b3ca4f17afcba528c4c5a2390a2dd9949b38/src/Console/DuskCommand.php#L91) and [https://github.com/nunomaduro/collision/blob/163d5c2bd8fe5072b942627980d20831dfd9de78/src/Adapters/Laravel/Commands/TestCommand.php#L108](https://github.com/nunomaduro/collision/blob/163d5c2bd8fe5072b942627980d20831dfd9de78/src/Adapters/Laravel/Commands/TestCommand.php#L108)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

