### PR TITLE
Fix `TestCase@expect` phpDoc

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -12,7 +12,7 @@ use Pest\TestSuite;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
- * @method \Pest\Expectation expect(mixed $value)
+ * @method \Pest\Expectations\Expectation expect(mixed $value)
  *
  * @internal
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #250

The current phpDoc refers to a type that doesn't exist, it's a mistake, I fixed it to the correct type.
