### PR TITLE
Add shorthand functions `xtest` and `xit` for skipping tests

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -72,6 +72,16 @@ function test(string $description = null, Closure $closure = null)
 }
 
 /**
+ * Shorthand function to skip the current test.
+ *
+ * @return TestCall|TestCase|mixed
+ */
+function xtest(string $description, Closure $closure = null): TestCall
+{
+    return test($description, $closure)->skip();
+}
+
+/**
  * Adds the given closure as a test. The first argument
  * is the test description; the second argument is
  * a closure that contains the test expectations.
@@ -83,6 +93,16 @@ function it(string $description, Closure $closure = null): TestCall
     $description = sprintf('it %s', $description);
 
     return test($description, $closure);
+}
+
+/**
+ * Shorthand function to skip the current test.
+ *
+ * @return TestCall|TestCase|mixed
+ */
+function xit(string $description, Closure $closure = null): TestCall
+{
+    return it($description, $closure)->skip();
 }
 
 /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -92,6 +92,8 @@
   ✓ it do not skips with falsy closure condition
   - it skips with condition and message → skipped because foo
   - it skips when skip after assertion
+  - it skips with shorthand
+  - test skips with shorthand
 
    PASS  Tests\Features\Test
   ✓ a test
@@ -188,5 +190,4 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  7 skipped, 108 passed
-  
+  Tests:  9 skipped, 108 passed

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -31,3 +31,9 @@ it('skips with condition and message')
 it('skips when skip after assertion')
     ->assertTrue(true)
     ->skip();
+
+xit('skips with shorthand')
+    ->assertTrue(false);
+
+xtest('test skips with shorthand')
+    ->assertTrue(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Adding shorthand for skipping tests by adding an `x` prefix to the test functions, e.g. `xtest()` and `xit()`.

Example:

```php
xit('has home', function () {
// ..
});
```

is the same as

```php
it('has home', function () {
// ..
})->skip();
```

This is equivalent to the aliases in Jest (see https://jestjs.io/docs/en/api#testskipname-fn).

Would love to see this feature merged, because I often find myself skipping a newly written test to do a small refactoring before I can solve the new test.