### PR TITLE
Reusable hooks

### DIFF
--- a/src/Concerns/TestCase.php
+++ b/src/Concerns/TestCase.php
@@ -56,6 +56,15 @@ trait TestCase
     }
 
     /**
+     * Add a shared/"global" before each test hook that will execute **before**
+     * the test defined `beforeEach` hook.
+     */
+    public function addBeforeEach(?Closure $hook): void
+    {
+        $this->beforeEach = $hook;
+    }
+
+    /**
      * Add dependencies to the test case and map them to instances of ExecutionOrderDependency.
      */
     public function addDependencies(array $tests): void
@@ -120,6 +129,10 @@ trait TestCase
         TestSuite::getInstance()->test = $this;
 
         parent::setUp();
+
+        if ($this->beforeEach instanceof Closure) {            
+            $this->__callClosure($this->beforeEach, func_get_args());
+        }
 
         $beforeEach = TestSuite::getInstance()->beforeEach->get(self::$__filename);
 

--- a/src/Concerns/TestCase.php
+++ b/src/Concerns/TestCase.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Pest\Concerns;
 
 use Closure;
-use Pest\Repositories\BeforeEachRepository;
-use Pest\Support\ExceptionTrace;
 use Pest\Support\ChainableClosure;
+use Pest\Support\ExceptionTrace;
 use Pest\TestSuite;
 use PHPUnit\Framework\ExecutionOrderDependency;
 use PHPUnit\Util\Test;
@@ -58,7 +57,7 @@ trait TestCase
     public function __construct(Closure $test, string $description, array $data)
     {
         $this->__test        = $test;
-        $this->__description = $description; 
+        $this->__description = $description;
 
         parent::__construct('__test', $data);
     }
@@ -173,7 +172,7 @@ trait TestCase
 
         $beforeEach = TestSuite::getInstance()->beforeEach->get(self::$__filename);
 
-        if ($this->beforeEach instanceof Closure) {            
+        if ($this->beforeEach instanceof Closure) {
             $beforeEach = ChainableClosure::from($this->beforeEach, $beforeEach);
         }
 
@@ -187,7 +186,7 @@ trait TestCase
     {
         $afterEach = TestSuite::getInstance()->afterEach->get(self::$__filename);
 
-        if ($this->afterEach instanceof Closure) {            
+        if ($this->afterEach instanceof Closure) {
             $afterEach = ChainableClosure::from($this->afterEach, $afterEach);
         }
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -90,8 +90,6 @@ final class Command extends BaseCommand
          */
         $this->arguments = AddsDefaults::to($this->arguments);
 
-        LoadStructure::in($this->testSuite->rootPath);
-
         $testRunner = new TestRunner($this->arguments['loader']);
         $testSuite  = $this->arguments['test'];
 
@@ -127,6 +125,8 @@ final class Command extends BaseCommand
      */
     public function run(array $argv, bool $exit = true): int
     {
+        LoadStructure::in($this->testSuite->rootPath);
+
         $result = parent::run($argv, false);
 
         /*

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\PendingObjects;
 
+use Closure;
 use Pest\Exceptions\InvalidUsesPath;
 use Pest\TestSuite;
 
@@ -12,6 +13,13 @@ use Pest\TestSuite;
  */
 final class UsesCall
 {
+    /**
+     * Contains a global before each hook closure to be executed.
+     *
+     * @var Closure
+     */
+    private $beforeEach;
+
     /**
      * Holds the class and traits.
      *
@@ -98,10 +106,25 @@ final class UsesCall
     }
 
     /**
+     * Sets the global beforeEach test hook
+     */
+    public function beforeEach(Closure $hook): UsesCall
+    {
+        $this->beforeEach = $hook;
+
+        return $this;
+    }
+
+    /**
      * Dispatch the creation of uses.
      */
     public function __destruct()
     {
-        TestSuite::getInstance()->tests->use($this->classAndTraits, $this->groups, $this->targets);
+        TestSuite::getInstance()->tests->use(
+            $this->classAndTraits,
+            $this->groups,
+            $this->targets,
+            $this->beforeEach,
+        );
     }
 }

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -16,9 +16,16 @@ final class UsesCall
     /**
      * Contains a global before each hook closure to be executed.
      *
-     * @var Closure
+     * Array indices here matter. They are mapped as follows:
+     *
+     * - `0` => `beforeAll`
+     * - `1` => `beforeEach`
+     * - `2` => `afterEach`
+     * - `3` => `afterAll`
+     *
+     * @var array<int, Closure>
      */
-    private $beforeEach;
+    private $hooks = [];
 
     /**
      * Holds the class and traits.
@@ -106,11 +113,41 @@ final class UsesCall
     }
 
     /**
-     * Sets the global beforeEach test hook
+     * Sets the global beforeAll test hook.
+     */
+    public function beforeAll(Closure $hook): UsesCall
+    {
+        $this->hooks[0] = $hook;
+
+        return $this;
+    }
+
+    /**
+     * Sets the global beforeEach test hook.
      */
     public function beforeEach(Closure $hook): UsesCall
     {
-        $this->beforeEach = $hook;
+        $this->hooks[1] = $hook;
+
+        return $this;
+    }
+
+    /**
+     * Sets the global afterEach test hook.
+     */
+    public function afterEach(Closure $hook): UsesCall
+    {
+        $this->hooks[2] = $hook;
+
+        return $this;
+    }
+
+    /**
+     * Sets the global afterAll test hook.
+     */
+    public function afterAll(Closure $hook): UsesCall
+    {
+        $this->hooks[3] = $hook;
 
         return $this;
     }
@@ -124,7 +161,7 @@ final class UsesCall
             $this->classAndTraits,
             $this->groups,
             $this->targets,
-            $this->beforeEach,
+            $this->hooks,
         );
     }
 }

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -47,9 +47,9 @@ final class TestRepository
         };
 
         foreach ($this->uses as $path => $uses) {
-            [$classOrTraits, $groups, $beforeEach] = $uses;
+            [$classOrTraits, $groups, $hooks] = $uses;
 
-            $setClassName = function (TestCaseFactory $testCase, string $key) use ($path, $classOrTraits, $groups, $startsWith, $beforeEach): void {
+            $setClassName = function (TestCaseFactory $testCase, string $key) use ($path, $classOrTraits, $groups, $startsWith, $hooks): void {
                 [$filename] = explode('@', $key);
 
                 if ((!is_dir($path) && $filename === $path) || (is_dir($path) && $startsWith($filename, $path))) {
@@ -65,8 +65,11 @@ final class TestRepository
                     }
 
                     // IDEA: Consider set the real lines on these.
-                    $testCase->factoryProxies->add($filename, 0, 'addBeforeEach', [$beforeEach]);
                     $testCase->factoryProxies->add($filename, 0, 'addGroups', [$groups]);
+                    // $testCase->factoryProxies->add($filename, 0, 'addBeforeAll', [$hooks[0] ?? null]);
+                    $testCase->factoryProxies->add($filename, 0, 'addBeforeEach', [$hooks[1] ?? null]);
+                    $testCase->factoryProxies->add($filename, 0, 'addAfterEach', [$hooks[2] ?? null]);
+                    // $testCase->factoryProxies->add($filename, 0, 'addAfterAll', [$hooks[3] ?? null]);
                 }
             };
 
@@ -96,9 +99,9 @@ final class TestRepository
      * @param array<int, string> $classOrTraits
      * @param array<int, string> $groups
      * @param array<int, string> $paths
-     * @param Closure|null $beforeEach
+     * @param array<intm Closure> $hooks
      */
-    public function use(array $classOrTraits, array $groups, array $paths, ?Closure $beforeEach): void
+    public function use(array $classOrTraits, array $groups, array $paths, array $hooks): void
     {
         foreach ($classOrTraits as $classOrTrait) {
             if (!class_exists($classOrTrait) && !trait_exists($classOrTrait)) {
@@ -111,10 +114,10 @@ final class TestRepository
                 $this->uses[$path] = [
                     array_merge($this->uses[$path][0], $classOrTraits),
                     array_merge($this->uses[$path][1], $groups),
-                    $this->uses[$path][2] ?? $beforeEach,
+                    $this->uses[$path][2] + $hooks,
                 ];
             } else {
-                $this->uses[$path] = [$classOrTraits, $groups, $beforeEach];
+                $this->uses[$path] = [$classOrTraits, $groups, $hooks];
             }
         }
     }

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -25,7 +25,7 @@ final class TestRepository
     private $state = [];
 
     /**
-     * @var array<string, array<int, array<int, string, Closure>>>
+     * @var array<string, array<int, array<int, string|Closure>>>
      */
     private $uses = [];
 
@@ -53,7 +53,7 @@ final class TestRepository
                 [$filename] = explode('@', $key);
 
                 if ((!is_dir($path) && $filename === $path) || (is_dir($path) && $startsWith($filename, $path))) {
-                    foreach ($classOrTraits as $class) {
+                    foreach ($classOrTraits as $class) { /** @var string $class */
                         if (class_exists($class)) {
                             if ($testCase->class !== TestCase::class) {
                                 throw new TestCaseAlreadyInUse($testCase->class, $class, $filename);
@@ -114,7 +114,7 @@ final class TestRepository
                 $this->uses[$path] = [
                     array_merge($this->uses[$path][0], $classOrTraits),
                     array_merge($this->uses[$path][1], $groups),
-                    $this->uses[$path][2] + $hooks,
+                    $this->uses[$path][2] + $hooks, // NOTE: array_merge will destroy numeric indices
                 ];
             } else {
                 $this->uses[$path] = [$classOrTraits, $groups, $hooks];

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -66,10 +66,10 @@ final class TestRepository
 
                     // IDEA: Consider set the real lines on these.
                     $testCase->factoryProxies->add($filename, 0, 'addGroups', [$groups]);
-                    // $testCase->factoryProxies->add($filename, 0, 'addBeforeAll', [$hooks[0] ?? null]);
+                    $testCase->factoryProxies->add($filename, 0, 'addBeforeAll', [$hooks[0] ?? null]);
                     $testCase->factoryProxies->add($filename, 0, 'addBeforeEach', [$hooks[1] ?? null]);
                     $testCase->factoryProxies->add($filename, 0, 'addAfterEach', [$hooks[2] ?? null]);
-                    // $testCase->factoryProxies->add($filename, 0, 'addAfterAll', [$hooks[3] ?? null]);
+                    $testCase->factoryProxies->add($filename, 0, 'addAfterAll', [$hooks[3] ?? null]);
                 }
             };
 

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -25,7 +25,7 @@ final class TestRepository
     private $state = [];
 
     /**
-     * @var array<string, array<int, array<int, string>>>
+     * @var array<string, array<int, array<int, string, Closure>>>
      */
     private $uses = [];
 
@@ -96,10 +96,10 @@ final class TestRepository
     /**
      * Uses the given `$testCaseClass` on the given `$paths`.
      *
-     * @param array<int, string> $classOrTraits
-     * @param array<int, string> $groups
-     * @param array<int, string> $paths
-     * @param array<intm Closure> $hooks
+     * @param array<int, string>  $classOrTraits
+     * @param array<int, string>  $groups
+     * @param array<int, string>  $paths
+     * @param array<int, Closure> $hooks
      */
     public function use(array $classOrTraits, array $groups, array $paths, array $hooks): void
     {

--- a/src/Support/ChainableClosure.php
+++ b/src/Support/ChainableClosure.php
@@ -12,7 +12,7 @@ use Closure;
 final class ChainableClosure
 {
     /**
-     * Calls the given `$closure` and chains the the `$next` closure.
+     * Calls the given `$closure` and chains the `$next` closure.
      */
     public static function from(Closure $closure, Closure $next): Closure
     {
@@ -24,6 +24,9 @@ final class ChainableClosure
         };
     }
 
+    /**
+     * Call the given static `$closure` and chains the `$next` closure.
+     */
     public static function fromStatic(Closure $closure, Closure $next): Closure
     {
         return static function () use ($closure, $next): void {

--- a/src/Support/ChainableClosure.php
+++ b/src/Support/ChainableClosure.php
@@ -23,4 +23,14 @@ final class ChainableClosure
             call_user_func_array(Closure::bind($next, $this, get_class($this)), func_get_args());
         };
     }
+
+    public static function fromStatic(Closure $closure, Closure $next): Closure
+    {
+        return static function () use ($closure, $next): void {
+            /* @phpstan-ignore-next-line */
+            call_user_func_array(Closure::bind($closure, null, self::class), func_get_args());
+            /* @phpstan-ignore-next-line */
+            call_user_func_array(Closure::bind($next, null, self::class), func_get_args());
+        };
+    }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -103,6 +103,18 @@
    PASS  Tests\Fixtures\ExampleTest
   ✓ it example 2
 
+   PASS  Tests\Hooks\AfterAllTest
+  ✓ global afterAll execution order
+
+   PASS  Tests\Hooks\AfterEachTest
+  ✓ global afterEach execution order
+
+   PASS  Tests\Hooks\BeforeAllTest
+  ✓ global beforeAll execution order
+
+   PASS  Tests\Hooks\BeforeEachTest
+  ✓ global beforeEach execution order
+
    PASS  Tests\PHPUnit\CustomAffixes\InvalidTestName
   ✓ it runs file names like `@#$%^&()-_=+.php`
 
@@ -209,5 +221,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  7 skipped, 115 passed
+  Tests:  7 skipped, 119 passed
   

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -8,4 +8,3 @@ afterAll(function () {
 
 test('global afterAll execution order', function () {
 });
-

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -1,10 +1,27 @@
 <?php
 
-uses()->afterAll(function () {
+global $globalHook;
+
+uses()->afterAll(function () use ($globalHook) {
+    expect($globalHook)
+        ->toHaveProperty('afterAll')
+        ->and($globalHook->afterAll)
+        ->toBe(0);
+
+    $globalHook->afterAll = 1;
 });
 
-afterAll(function () {
+afterAll(function () use ($globalHook) {
+    expect($globalHook)
+        ->toHaveProperty('afterAll')
+        ->and($globalHook->afterAll)
+        ->toBe(1);
+
+    $globalHook->afterAll = 2;
 });
 
-test('global afterAll execution order', function () {
+test('global afterAll execution order', function () use ($globalHook) {
+    expect($globalHook)
+        ->not()
+        ->toHaveProperty('afterAll');
 });

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -1,0 +1,11 @@
+<?php
+
+uses()->afterAll(function () {
+});
+
+afterAll(function () {
+});
+
+test('global afterAll execution order', function () {
+});
+

--- a/tests/Hooks/AfterEachTest.php
+++ b/tests/Hooks/AfterEachTest.php
@@ -21,4 +21,3 @@ test('global afterEach execution order', function () {
         ->not()
         ->toHaveProperty('ith');
 });
-

--- a/tests/Hooks/AfterEachTest.php
+++ b/tests/Hooks/AfterEachTest.php
@@ -1,0 +1,24 @@
+<?php
+
+uses()->afterEach(function () {
+    expect($this)
+        ->toHaveProperty('ith')
+        ->and($this->ith)
+        ->toBe(0);
+
+    $this->ith = 1;
+});
+
+afterEach(function () {
+    expect($this)
+        ->toHaveProperty('ith')
+        ->and($this->ith)
+        ->toBe(1);
+});
+
+test('global afterEach execution order', function () {
+    expect($this)
+        ->not()
+        ->toHaveProperty('ith');
+});
+

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -8,4 +8,3 @@ beforeAll(function () {
 
 test('global beforeAll execution order', function () {
 });
-

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -1,10 +1,28 @@
 <?php
 
-uses()->beforeAll(function () {
+global $globalHook;
+
+uses()->beforeAll(function () use ($globalHook) {
+    expect($globalHook)
+        ->toHaveProperty('beforeAll')
+        ->and($globalHook->beforeAll)
+        ->toBe(0);
+
+    $globalHook->beforeAll = 1;
 });
 
-beforeAll(function () {
+beforeAll(function () use ($globalHook) {
+    expect($globalHook)
+        ->toHaveProperty('beforeAll')
+        ->and($globalHook->beforeAll)
+        ->toBe(1);
+
+    $globalHook->beforeAll = 2;
 });
 
-test('global beforeAll execution order', function () {
+test('global beforeAll execution order', function () use ($globalHook) {
+    expect($globalHook)
+        ->toHaveProperty('beforeAll')
+        ->and($globalHook->beforeAll)
+        ->toBe(2);
 });

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -1,0 +1,11 @@
+<?php
+
+uses()->beforeAll(function () {
+});
+
+beforeAll(function () {
+});
+
+test('global beforeAll execution order', function () {
+});
+

--- a/tests/Hooks/BeforeEachTest.php
+++ b/tests/Hooks/BeforeEachTest.php
@@ -1,11 +1,27 @@
 <?php
 
-beforeEach(function (): void {
-    expect($this->baz)->toBe(1); // set from Pest.php global/shared hook
+uses()->beforeEach(function () {
+    expect($this)
+        ->toHaveProperty('baz')
+        ->and($this->baz)
+        ->toBe(0);
+
+    $this->baz = 1;
+});
+
+beforeEach(function () {
+    expect($this)
+        ->toHaveProperty('baz')
+        ->and($this->baz)
+        ->toBe(1);
 
     $this->baz = 2;
 });
 
-test('global before each', function (): void {
-    expect($this->baz)->toBe(2);
+test('global beforeEach execution order', function () {
+    expect($this)
+        ->toHaveProperty('baz')
+        ->and($this->baz)
+        ->toBe(2);
 });
+

--- a/tests/Hooks/BeforeEachTest.php
+++ b/tests/Hooks/BeforeEachTest.php
@@ -24,4 +24,3 @@ test('global beforeEach execution order', function () {
         ->and($this->baz)
         ->toBe(2);
 });
-

--- a/tests/Hooks/BeforeEachTest.php
+++ b/tests/Hooks/BeforeEachTest.php
@@ -1,0 +1,11 @@
+<?php
+
+beforeEach(function (): void {
+    expect($this->baz)->toBe(1); // set from Pest.php global/shared hook
+
+    $this->baz = 2;
+});
+
+test('global before each', function (): void {
+    expect($this->baz)->toBe(2);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,10 +10,9 @@ uses()
     //     dump(0);
     // })
     ->afterEach(function () {
-       $this->ith = 0;
+        $this->ith = 0;
     })
     // ->afterAll(function () {
     //     dump(0);
     // })
     ->in('Hooks');
-

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,17 +2,19 @@
 
 uses()->group('integration')->in('Visual');
 
+$globalHook = (object) []; // NOTE: global test value container to be mutated and checked across files, as needed
+
 uses()
     ->beforeEach(function () {
         $this->baz = 0;
     })
-    // ->beforeAll(function () {
-    //     dump(0);
-    // })
+    ->beforeAll(function () use ($globalHook) {
+        $globalHook->beforeAll = 0;
+    })
     ->afterEach(function () {
         $this->ith = 0;
     })
-    // ->afterAll(function () {
-    //     dump(0);
-    // })
+    ->afterAll(function () use ($globalHook) {
+        $globalHook->afterAll = 0;
+    })
     ->in('Hooks');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,6 @@
 <?php
 
 uses()->group('integration')->in('Visual');
+uses()->beforeEach(function (): void {
+    $this->baz = 1;
+})->in('Hooks');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,19 @@
 <?php
 
 uses()->group('integration')->in('Visual');
-uses()->beforeEach(function (): void {
-    $this->baz = 1;
-})->in('Hooks');
+
+uses()
+    ->beforeEach(function () {
+        $this->baz = 0;
+    })
+    // ->beforeAll(function () {
+    //     dump(0);
+    // })
+    ->afterEach(function () {
+       $this->ith = 0;
+    })
+    // ->afterAll(function () {
+    //     dump(0);
+    // })
+    ->in('Hooks');
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | `no`
| New feature?  | `yes`
| Fixed tickets | #255 

- add global/shared hooks that are configurable in `Pest.php` similar to `groups` through the `uses()` function;
    - `beforeEach(Closure $hook)`
    - `beforeAll(Closure $hook)`
    - `afterEach(Closure $hook)`
    - `afterAll(Closure $hook)`
- add new helper function to `ChainableClosure` to create static instances;
    - `fromStatic(Closure $closure, Closure $next): Closure`
- load test structure in `run` before we calling the parent's `run` method, instead of in `createRunner`
- add tests for each new uses hook;