### PR TITLE
make test directory configurable

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -28,11 +28,12 @@ use Symfony\Component\Console\Output\OutputInterface;
     (new Provider())->register();
 
     // get $rootPath based on $autoloadPath
-    $rootPath =  dirname($autoloadPath, 2);
+    $rootPath = dirname($autoloadPath, 2);
+    $argv = new ArgvInput();
 
-    $testSuite = TestSuite::getInstance($rootPath);
+    $testSuite = TestSuite::getInstance($rootPath, $argv->getParameterOption('--test-directory', 'tests'));
 
-    $isDecorated = (new ArgvInput())->getParameterOption('--colors', 'always') !== 'never';
+    $isDecorated = $argv->getParameterOption('--colors', 'always') !== 'never';
     $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);
 
     $container = Container::getInstance();
@@ -40,6 +41,15 @@ use Symfony\Component\Console\Output\OutputInterface;
     $container->add(OutputInterface::class, $output);
 
     ValidatesEnvironment::in($testSuite);
+
+    // lets remove any arguments that PHPUnit does not understand
+    if ($argv->hasParameterOption('--test-directory')) {
+        foreach ($_SERVER['argv'] as $key => $value) {
+            if (strpos($value, '--test-directory') !== false) {
+                unset($_SERVER['argv'][$key]);
+            }
+        }
+    }
 
     exit($container->get(Command::class)->run($_SERVER['argv']));
 })();

--- a/src/Actions/LoadStructure.php
+++ b/src/Actions/LoadStructure.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Actions;
 
 use Pest\Support\Str;
+use function Pest\testDirectory;
 use PHPUnit\TextUI\Configuration\Configuration;
 use PHPUnit\Util\FileLoader;
 use RecursiveDirectoryIterator;
@@ -33,7 +34,7 @@ final class LoadStructure
      */
     public static function in(string $rootPath): void
     {
-        $testsPath = $rootPath . DIRECTORY_SEPARATOR . 'tests';
+        $testsPath = $rootPath . DIRECTORY_SEPARATOR . testDirectory();
 
         $load = function ($filename): bool {
             return file_exists($filename) && (bool) FileLoader::checkAndLoad($filename);

--- a/src/Laravel/Commands/PestDatasetCommand.php
+++ b/src/Laravel/Commands/PestDatasetCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Pest\Exceptions\InvalidConsoleArgument;
+use function Pest\testDirectory;
 
 /**
  * @internal
@@ -36,7 +37,7 @@ final class PestDatasetCommand extends Command
         /** @var string $name */
         $name = $this->argument('name');
 
-        $relativePath   = sprintf('tests/Datasets/%s.php', ucfirst($name));
+        $relativePath   = sprintf(testDirectory('Datasets/%s.php'), ucfirst($name));
 
         /* @phpstan-ignore-next-line */
         $target         = base_path($relativePath);

--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Console\Thanks;
 use Pest\Exceptions\InvalidConsoleArgument;
+use function Pest\testDirectory;
 
 /**
  * @internal
@@ -34,7 +35,7 @@ final class PestInstallCommand extends Command
     public function handle(): void
     {
         /* @phpstan-ignore-next-line */
-        $pest    = base_path('tests/Pest.php');
+        $pest    = base_path(testDirectory('Pest.php'));
         $stubs   = 'stubs/Laravel';
 
         if (File::exists($pest)) {

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Exceptions\InvalidConsoleArgument;
 use Pest\Support\Str;
+use function Pest\testDirectory;
 
 /**
  * @internal
@@ -38,7 +39,7 @@ final class PestTestCommand extends Command
 
         $type = ((bool) $this->option('unit')) ? 'Unit' : (((bool) $this->option('dusk')) ? 'Browser' : 'Feature');
 
-        $relativePath = sprintf('tests/%s/%s.php',
+        $relativePath = sprintf(testDirectory('%s/%s.php'),
             $type,
             ucfirst($name)
         );

--- a/src/Pest.php
+++ b/src/Pest.php
@@ -11,5 +11,5 @@ function version(): string
 
 function testDirectory(string $file = ''): string
 {
-    return TestSuite::getInstance()->testPath . $file;
+    return TestSuite::getInstance()->testPath . '/' . $file;
 }

--- a/src/Pest.php
+++ b/src/Pest.php
@@ -8,3 +8,8 @@ function version(): string
 {
     return '1.0.4';
 }
+
+function testDirectory(string $file = ''): string
+{
+    return TestSuite::getInstance()->testPath . $file;
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,7 +22,7 @@ final class Plugin
     public static function uses(string ...$traits): void
     {
         self::$callables[] = function () use ($traits): void {
-            uses(...$traits)->in(TestSuite::getInstance()->rootPath . DIRECTORY_SEPARATOR . 'tests');
+            uses(...$traits)->in(TestSuite::getInstance()->rootPath . DIRECTORY_SEPARATOR . testDirectory());
         };
     }
 }

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -67,6 +67,13 @@ final class TestSuite
     public $rootPath;
 
     /**
+     * Holds the test path.
+     *
+     * @var string
+     */
+    public $testPath;
+
+    /**
      * Holds an instance of the test suite.
      *
      * @var TestSuite
@@ -76,7 +83,7 @@ final class TestSuite
     /**
      * Creates a new instance of the test suite.
      */
-    public function __construct(string $rootPath)
+    public function __construct(string $rootPath, string $testPath)
     {
         $this->beforeAll  = new BeforeAllRepository();
         $this->beforeEach = new BeforeEachRepository();
@@ -85,15 +92,16 @@ final class TestSuite
         $this->afterAll   = new AfterAllRepository();
 
         $this->rootPath = (string) realpath($rootPath);
+        $this->testPath = $testPath;
     }
 
     /**
      * Returns the current instance of the test suite.
      */
-    public static function getInstance(string $rootPath = null): TestSuite
+    public static function getInstance(string $rootPath = null, string $testPath = null): TestSuite
     {
-        if (is_string($rootPath)) {
-            self::$instance = new TestSuite($rootPath);
+        if (is_string($rootPath) && is_string($testPath)) {
+            self::$instance = new TestSuite($rootPath, $testPath);
 
             foreach (Plugin::$callables as $callable) {
                 $callable();

--- a/tests/Unit/Actions/AddsTests.php
+++ b/tests/Unit/Actions/AddsTests.php
@@ -18,7 +18,7 @@ test('default php unit tests', function () {
     $testSuite->addTest($phpUnitTestCase);
     expect($testSuite->tests())->toHaveCount(1);
 
-    AddsTests::to($testSuite, new \Pest\TestSuite(getcwd()));
+    AddsTests::to($testSuite, new \Pest\TestSuite(getcwd(), 'tests'));
     expect($testSuite->tests())->toHaveCount(1);
 });
 
@@ -27,6 +27,6 @@ it('removes warnings', function () {
     $warningTestCase = new WarningTestCase('No tests found in class "Pest\TestCase".');
     $testSuite->addTest($warningTestCase);
 
-    AddsTests::to($testSuite, new \Pest\TestSuite(getcwd()));
+    AddsTests::to($testSuite, new \Pest\TestSuite(getcwd(), 'tests'));
     expect($testSuite->tests())->toHaveCount(0);
 });

--- a/tests/Unit/Support/Container.php
+++ b/tests/Unit/Support/Container.php
@@ -38,6 +38,7 @@ it('creates an instance and resolves also sub parameters', function () {
 
 it('can resolve builtin value types', function () {
     $this->container->add('rootPath', getcwd());
+    $this->container->add('testPath', 'tests');
 
     $instance = $this->container->get(TestSuite::class);
     expect($instance)->toBeInstanceOf(TestSuite::class);

--- a/tests/Unit/TestSuite.php
+++ b/tests/Unit/TestSuite.php
@@ -4,7 +4,7 @@ use Pest\Exceptions\TestAlreadyExist;
 use Pest\TestSuite;
 
 it('does not allow to add the same test description twice', function () {
-    $testSuite = new TestSuite(getcwd());
+    $testSuite = new TestSuite(getcwd(), 'tests');
     $test = function () {};
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
     $this->expectException(TestAlreadyExist::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #194

> This is an implementation to make the test directory configurable as requested in https://github.com/pestphp/pest/issues/194.

It does so by introducing a new `--test-directory` argument. If this flag is set you can call `Pest\testDirectory` which will return the path value and optionally concatenate it with a filename. Calling `testDirectory('directory/File.php')` will return `tests/directory/File.php` by default.

```php
// When using an invalid directory
❯ bin/pest --test-directory=blarbs

   Pest\Exceptions\InvalidUsesPath

  The path `/Users/brian/Work/fork/blarbs` is not valid.
```