### PR TITLE
feat: adds built-in mocking

### DIFF
--- a/src/Exceptions/MissingDependency.php
+++ b/src/Exceptions/MissingDependency.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use InvalidArgumentException;
+use NunoMaduro\Collision\Contracts\RenderlessEditor;
+use NunoMaduro\Collision\Contracts\RenderlessTrace;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+
+/**
+ * @internal
+ */
+final class MissingDependency extends InvalidArgumentException implements ExceptionInterface, RenderlessEditor, RenderlessTrace
+{
+    /**
+     * Creates a new instance of missing dependency.
+     */
+    public function __construct(string $feature, string $dependency)
+    {
+        parent::__construct(sprintf('The feature "%s" requires "%s".', $feature, $dependency));
+    }
+}

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Pest\Datasets;
+use Pest\Mock;
 use Pest\PendingObjects\AfterEachCall;
 use Pest\PendingObjects\BeforeEachCall;
 use Pest\PendingObjects\TestCall;
@@ -103,4 +104,16 @@ function afterEach(Closure $closure = null): AfterEachCall
 function afterAll(Closure $closure): void
 {
     TestSuite::getInstance()->afterAll->set($closure);
+}
+
+if (!function_exists('mock')) {
+    /**
+     * Creates a new mock with the given class or object.
+     *
+     * @param string|object $object
+     */
+    function mock($object): Mock
+    {
+        return new Mock($object);
+    }
 }

--- a/src/Mock.php
+++ b/src/Mock.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest;
+
+use Mockery;
+use Pest\Exceptions\MissingDependency;
+
+/**
+ * @mixin \Mockery\MockInterface
+ */
+final class Mock
+{
+    /**
+     * The object being mocked.
+     *
+     * @readonly
+     *
+     * @var \Mockery\MockInterface|\Mockery\LegacyMockInterface
+     */
+    private $mock;
+
+    /**
+     * Creates a new mock instance.
+     *
+     * @param string|object $object
+     */
+    public function __construct($object)
+    {
+        if (!class_exists(Mockery::class)) {
+            throw new MissingDependency('Mocking', 'mockery/mockery');
+        }
+
+        $this->mock = Mockery::mock($object);
+    }
+
+    /**
+     * Define mock expectations.
+     *
+     * @param mixed ...$methods
+     *
+     * @return \Mockery\MockInterface|\Mockery\LegacyMockInterface
+     */
+    public function expect(...$methods)
+    {
+        foreach ($methods as $method => $result) {
+            /* @phpstan-ignore-next-line */
+            $this->mock
+                ->shouldReceive((string) $method)
+                ->andReturn($result);
+        }
+
+        return $this->mock;
+    }
+
+    /**
+     * Proxies calls to the original mock object.
+     *
+     * @param array<int, mixed> $arguments
+     *
+     * @return mixed
+     */
+    public function __call(string $method, array $arguments)
+    {
+        /* @phpstan-ignore-next-line */
+        return $this->mock->{$method}($arguments);
+    }
+}

--- a/src/Mock.php
+++ b/src/Mock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest;
 
+use InvalidArgumentException;
 use Mockery;
 use Pest\Exceptions\MissingDependency;
 
@@ -44,11 +45,17 @@ final class Mock
      */
     public function expect(...$methods)
     {
-        foreach ($methods as $method => $result) {
+        foreach ($methods as $method => $expectation) {
             /* @phpstan-ignore-next-line */
-            $this->mock
+            $method = $this->mock
                 ->shouldReceive((string) $method)
-                ->andReturn($result);
+                ->once();
+
+            if (!is_callable($expectation)) {
+                throw new InvalidArgumentException(sprintf('Method %s from %s expects a callable as expectation.', $method, $method->mock()->mockery_getName(), ));
+            }
+
+            $method->andReturnUsing($expectation);
         }
 
         return $this->mock;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -223,9 +223,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-<<<<<<< HEAD
-  Tests:  7 skipped, 119 passed
-=======
-  Tests:  7 skipped, 117 passed
->>>>>>> feat(mock): adds work in progress
+  Tests:  7 skipped, 121 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -79,7 +79,7 @@
 
    PASS  Tests\Features\Mocks
   ✓ it can mock methods
-  ✓ access to the mock object
+  ✓ it allows access to the underlying mockery mock
 
    PASS  Tests\Features\PendingHigherOrderTests
   ✓ get 'foo' → get 'bar' → expect true → toBeTrue 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -63,6 +63,7 @@
   ✓ it allows to call underlying protected/private methods
   ✓ it throws error if method do not exist
   ✓ it can forward unexpected calls to any global function
+  ✓ it can use helpers from helpers file
 
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
@@ -77,7 +78,8 @@
   ✓ it will throw exception from call if no macro exists
 
    PASS  Tests\Features\Mocks
-  ✓ it has bar
+  ✓ it can mock methods
+  ✓ access to the mock object
 
    PASS  Tests\Features\PendingHigherOrderTests
   ✓ get 'foo' → get 'bar' → expect true → toBeTrue 
@@ -221,5 +223,9 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
+<<<<<<< HEAD
   Tests:  7 skipped, 119 passed
+=======
+  Tests:  7 skipped, 117 passed
+>>>>>>> feat(mock): adds work in progress
   

--- a/tests/Features/Helpers.php
+++ b/tests/Features/Helpers.php
@@ -42,3 +42,5 @@ it('throws error if method do not exist', function () {
 })->throws(\ReflectionException::class, 'Call to undefined method PHPUnit\Framework\TestCase::name()');
 
 it('can forward unexpected calls to any global function')->_assertThat();
+
+it('can use helpers from helpers file')->myAssertTrue(true);

--- a/tests/Features/Mocks.php
+++ b/tests/Features/Mocks.php
@@ -16,6 +16,14 @@ it('can mock methods', function () {
     expect($mock->get())->toBe('foo');
 })->skip(((float) phpversion()) < 8.0);
 
+it('can access to arguments', function () {
+    $mock = mock(Http::class)->expect(
+        get: fn ($foo) => $foo,
+    );
+
+    expect($mock->get('foo'))->toBe('foo');
+})->skip(((float) phpversion()) < 8.0);
+
 it('allows access to the underlying mockery mock', function () {
     $mock = mock(Http::class);
 

--- a/tests/Features/Mocks.php
+++ b/tests/Features/Mocks.php
@@ -1,17 +1,24 @@
 <?php
 
-use function Tests\mock;
+use Mockery\CompositeExpectation;
+use Mockery\MockInterface;
 
-interface Foo
+interface Http
 {
-    public function bar(): int;
+    public function get(): string;
 }
 
-it('has bar', function () {
-    $mock = mock(Foo::class);
-    $mock->shouldReceive('bar')
-        ->times(1)
-        ->andReturn(2);
+it('can mock methods', function () {
+    $mock = mock(Http::class)->expect(
+        get: 'foo',
+    );
 
-    $mock->bar();
-});
+    expect($mock->get())->toBe('foo');
+})->skip(((float) phpversion()) < 8.0);
+
+test('access to the mock object', function () {
+    $mock = mock(Http::class);
+    expect($mock->expect())->toBeInstanceOf(MockInterface::class);
+
+    expect($mock->shouldReceive())->toBeInstanceOf(CompositeExpectation::class);
+})->skip(((float) phpversion()) < 8.0);

--- a/tests/Features/Mocks.php
+++ b/tests/Features/Mocks.php
@@ -10,15 +10,15 @@ interface Http
 
 it('can mock methods', function () {
     $mock = mock(Http::class)->expect(
-        get: 'foo',
+        get: fn () => 'foo',
     );
 
     expect($mock->get())->toBe('foo');
 })->skip(((float) phpversion()) < 8.0);
 
-test('access to the mock object', function () {
+it('allows access to the underlying mockery mock', function () {
     $mock = mock(Http::class);
-    expect($mock->expect())->toBeInstanceOf(MockInterface::class);
 
+    expect($mock->expect())->toBeInstanceOf(MockInterface::class);
     expect($mock->shouldReceive())->toBeInstanceOf(CompositeExpectation::class);
 })->skip(((float) phpversion()) < 8.0);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,11 +1,6 @@
 <?php
 
-namespace Tests;
-
-use Mockery;
-use Mockery\MockInterface;
-
-function mock(string $class): MockInterface
+function myAssertTrue($value)
 {
-    return Mockery::mock($class);
+    test()->assertTrue($value);
 }


### PR DESCRIPTION
**Note: Fell free to ask me if you would like to keep working on this pull request. This is just a POC, that I've done in 10 minutes. I may have no time to work on this in the future.**

This pull request adds a POC about what could eventually be built-in mocks in Pest. At this time, the code doesn't do much. But the goal is to provide the following API:

```php
it('can mock methods', function () {
    $mock = mock(Http::class)->expect(
        get: 'foo',
    );

    expect($mock->get())->toBe('foo');
});;
```

Of course, this is multiple questions here: like how to provide and method expectation without return values, how to define the number of times a method expectation should happen, etc.