### PR TITLE
Add bat file for windows users

### DIFF
--- a/bin/pest.bat
+++ b/bin/pest.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+setlocal DISABLEDELAYEDEXPANSION
+SET BIN_TARGET=%~dp0/../pestphp/pest/bin/pest
+php "%BIN_TARGET%" %*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets |

This PR adds a .bat file so windows users can run pest with same command line as linux users:

```
.\vendor\bin\pest
```

This also allows other packages that doesn't prepend `php` on the command line to run pest on windows (ex: `grumphp` runs just `.\vendor\bin\pest` and on windows this throws an error `"[full_path_to]\vendor\bin\pest" is not recognized as an internal or external command`)

