### PR TITLE
fix: resolve test directory before function call

### DIFF
--- a/src/Laravel/Commands/PestDatasetCommand.php
+++ b/src/Laravel/Commands/PestDatasetCommand.php
@@ -36,7 +36,8 @@ final class PestDatasetCommand extends Command
      */
     public function handle(): void
     {
-        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+        /* @phpstan-ignore-next-line */
+        TestSuite::getInstance(base_path(), $this->option('test-directory'));
 
         /** @var string $name */
         $name = $this->argument('name');

--- a/src/Laravel/Commands/PestDatasetCommand.php
+++ b/src/Laravel/Commands/PestDatasetCommand.php
@@ -8,8 +8,8 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Pest\Exceptions\InvalidConsoleArgument;
-use Pest\TestSuite;
 use function Pest\testDirectory;
+use Pest\TestSuite;
 
 /**
  * @internal

--- a/src/Laravel/Commands/PestDatasetCommand.php
+++ b/src/Laravel/Commands/PestDatasetCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Pest\Exceptions\InvalidConsoleArgument;
+use Pest\TestSuite;
 use function Pest\testDirectory;
 
 /**
@@ -20,7 +21,8 @@ final class PestDatasetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pest:dataset {name : The name of the dataset}';
+    protected $signature = 'pest:dataset {name : The name of the dataset}
+                                         {--test-directory=tests : The name of the tests directory}';
 
     /**
      * The console command description.
@@ -34,6 +36,8 @@ final class PestDatasetCommand extends Command
      */
     public function handle(): void
     {
+        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+
         /** @var string $name */
         $name = $this->argument('name');
 

--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Console\Thanks;
 use Pest\Exceptions\InvalidConsoleArgument;
+use Pest\TestSuite;
 use function Pest\testDirectory;
 
 /**
@@ -20,7 +21,7 @@ final class PestInstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pest:install';
+    protected $signature = 'pest:install {--test-directory=tests : The name of the tests directory}';
 
     /**
      * The console command description.
@@ -34,6 +35,8 @@ final class PestInstallCommand extends Command
      */
     public function handle(): void
     {
+        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+
         /* @phpstan-ignore-next-line */
         $pest    = base_path(testDirectory('Pest.php'));
         $stubs   = 'stubs/Laravel';

--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -8,8 +8,8 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Console\Thanks;
 use Pest\Exceptions\InvalidConsoleArgument;
-use Pest\TestSuite;
 use function Pest\testDirectory;
+use Pest\TestSuite;
 
 /**
  * @internal

--- a/src/Laravel/Commands/PestInstallCommand.php
+++ b/src/Laravel/Commands/PestInstallCommand.php
@@ -35,7 +35,8 @@ final class PestInstallCommand extends Command
      */
     public function handle(): void
     {
-        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+        /* @phpstan-ignore-next-line */
+        TestSuite::getInstance(base_path(), $this->option('test-directory'));
 
         /* @phpstan-ignore-next-line */
         $pest    = base_path(testDirectory('Pest.php'));

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -8,8 +8,8 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Exceptions\InvalidConsoleArgument;
 use Pest\Support\Str;
-use Pest\TestSuite;
 use function Pest\testDirectory;
+use Pest\TestSuite;
 
 /**
  * @internal

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Exceptions\InvalidConsoleArgument;
 use Pest\Support\Str;
+use Pest\TestSuite;
 use function Pest\testDirectory;
 
 /**
@@ -20,7 +21,7 @@ final class PestTestCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test}';
+    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory}';
 
     /**
      * The console command description.
@@ -34,12 +35,15 @@ final class PestTestCommand extends Command
      */
     public function handle(): void
     {
+        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+
         /** @var string $name */
         $name = $this->argument('name');
 
         $type = ((bool) $this->option('unit')) ? 'Unit' : (((bool) $this->option('dusk')) ? 'Browser' : 'Feature');
 
-        $relativePath = sprintf(testDirectory('%s/%s.php'),
+        $relativePath = sprintf(
+            testDirectory('%s/%s.php'),
             $type,
             ucfirst($name)
         );

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -35,7 +35,8 @@ final class PestTestCommand extends Command
      */
     public function handle(): void
     {
-        TestSuite::getInstance(base_path(), $this->option('test-directory', 'tests'));
+        /* @phpstan-ignore-next-line */
+        TestSuite::getInstance(base_path(), $this->option('test-directory'));
 
         /** @var string $name */
         $name = $this->argument('name');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

This should resolve the issue with all Pest Laravel commands (except `pest:dusk` as far as I know) failing.