### PR TITLE
hides dataset values if they have a name

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -111,8 +111,10 @@ final class Datasets
     {
         $exporter = new Exporter();
 
-        $nameInsert = is_string($key) ? \sprintf('data set "%s" ', $key) : '';
+        if(is_int($key)){
+            return \sprintf(' with (%s)', $exporter->shortenedRecursiveExport($data));
+        }
 
-        return \sprintf(' with %s(%s)', $nameInsert, $exporter->shortenedRecursiveExport($data));
+        return \sprintf(' with data set "%s"', $key);
     }
 }

--- a/tests/Unit/Datasets.php
+++ b/tests/Unit/Datasets.php
@@ -2,12 +2,22 @@
 
 use Pest\Datasets;
 
-it('show the names of named datasets in their description', function () {
+it('show only the names of named datasets in their description', function () {
     $descriptions = array_keys(Datasets::resolve('test description', [
         'one' => [1],
         'two' => [[2]],
     ]));
 
-    expect($descriptions[0])->toBe('test description with data set "one" (1)');
-    expect($descriptions[1])->toBe('test description with data set "two" (array(2))');
+    expect($descriptions[0])->toBe('test description with data set "one"');
+    expect($descriptions[1])->toBe('test description with data set "two"');
+});
+
+it('show the actual dataset of non-named datasets in their description', function () {
+    $descriptions = array_keys(Datasets::resolve('test description', [
+        [1],
+        [[2]],
+    ]));
+
+    expect($descriptions[0])->toBe('test description with (1)');
+    expect($descriptions[1])->toBe('test description with (array(2))');
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #238 

**This PR implements the solution proposed by @Ilyes512, all the credits goes to him**

As described in #238 , for complex datasets, for the sake of readability it should be better to display the dataset name over the actual values, in order to avoid some unreadable log:

![image](https://user-images.githubusercontent.com/8792274/119274733-a72ad480-bc11-11eb-8c04-e14ed05f75f4.png)

The issue was closed even if after a while the solution was accepted as fine by @owenvoke (https://github.com/pestphp/pest/issues/238#issuecomment-750400639) and marked as an enhancement.

I think the closed status could have caused the enhancement to be "forgotten", so I think it could be a nice idea to bring it back up.

@Ilyes512 solution is simple: showing the dataset name if it is present, otherwise showing the actual dataset values.

this is done by changing the `Dataset::getDataSetDescription()` static method from:

```php
private static function getDataSetDescription($key, array $data): string    {        
    $exporter = new Exporter();

    $nameInsert = is_string($key) ? \sprintf('data set "%s" ', $key) : '';

    return \sprintf(' with %s(%s)', $nameInsert, $exporter-&gt;shortenedRecursiveExport($data));    
}
```

to

```php
private static function getDataSetDescription($key, array $data): string
{
    $exporter = new Exporter();

    if(is_int($key)){
        return \sprintf(' with (%s)', $exporter->shortenedRecursiveExport($data));
    }

    return \sprintf(' with data set "%s', $key);
}
```

hope to have done an helping action by bringing this proposal back to life. If not, please forgive me