### PR TITLE
Ensure that generated tests name has the Test suffix

### DIFF
--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -39,7 +39,7 @@ final class PestTestCommand extends Command
         TestSuite::getInstance(base_path(), $this->option('test-directory'));
 
         /** @var string $name */
-        $name = $this->argument('name');
+        $name = Str::finish($this->argument('name'), 'Test');
 
         $type = ((bool) $this->option('unit')) ? 'Unit' : (((bool) $this->option('dusk')) ? 'Browser' : 'Feature');
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -48,4 +48,14 @@ final class Str
 
         return substr($target, -$length) === $search;
     }
+
+    /**
+     * Ensures that `$target` ends with a single instance of the given `$cap`.
+     */
+    public static function finish($target, $cap)
+    {
+        $quoted = preg_quote($cap, '/');
+
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $target).$cap;
+    }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -52,7 +52,7 @@ final class Str
     /**
      * Ensures that `$target` ends with a single instance of the given `$cap`.
      */
-    public static function finish($target, $cap)
+    public static function finish(string $target, string $cap)
     {
         $quoted = preg_quote($cap, '/');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR ensures that tests generated via `php artisan pest:test` follow the standard nomenclature and have the `Test` suffix in their name.

