### PR TITLE
chore(deps): update minimum plugin versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "nunomaduro/collision": "^5.0",
         "pestphp/pest-plugin": "^1.0",
         "pestphp/pest-plugin-coverage": "^1.0",
-        "pestphp/pest-plugin-expectations": "^1.0",
-        "pestphp/pest-plugin-init": "^1.0",
+        "pestphp/pest-plugin-expectations": "^1.3",
+        "pestphp/pest-plugin-init": "^1.1",
         "phpunit/phpunit": ">= 9.3.7 <= 9.5.4"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This is mainly to lock the Expectations plugin to `^1.3` as anything that uses `^1.0` of Pest, with `--prefer-lowest` and is using the `sequence()` method will fail due to an undefined method.

This makes sure that in the next version of Pest, people wanting to use the `sequence()` expectation can just require Pest `^1.4` or whatever.

The alternative would be for them to require `pestphp/pest-plugin-expectations:^1.3` in their own `composer.json`, but as a 1st-party plugin I thought it would be good to add it here.