### PR TITLE
Fix/test key separator

### DIFF
--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -20,6 +20,11 @@ use PHPUnit\Framework\TestCase;
 final class TestRepository
 {
     /**
+     * @var string
+     */
+    private const SEPARATOR = '>>>';
+
+    /**
      * @var array<string, TestCaseFactory>
      */
     private $state = [];
@@ -50,7 +55,7 @@ final class TestRepository
             [$classOrTraits, $groups, $hooks] = $uses;
 
             $setClassName = function (TestCaseFactory $testCase, string $key) use ($path, $classOrTraits, $groups, $startsWith, $hooks): void {
-                [$filename] = explode('@', $key);
+                [$filename] = explode(self::SEPARATOR, $key);
 
                 if ((!is_dir($path) && $filename === $path) || (is_dir($path) && $startsWith($filename, $path))) {
                     foreach ($classOrTraits as $class) { /** @var string $class */
@@ -131,10 +136,10 @@ final class TestRepository
             throw ShouldNotHappen::fromMessage('Trying to create a test without description.');
         }
 
-        if (array_key_exists(sprintf('%s@%s', $test->filename, $test->description), $this->state)) {
+        if (array_key_exists(sprintf('%s%s%s', $test->filename, self::SEPARATOR, $test->description), $this->state)) {
             throw new TestAlreadyExist($test->filename, $test->description);
         }
 
-        $this->state[sprintf('%s@%s', $test->filename, $test->description)] = $test;
+        $this->state[sprintf('%s%s%s', $test->filename, self::SEPARATOR, $test->description)] = $test;
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -122,6 +122,10 @@
    PASS  Tests\PHPUnit\CustomAffixes\AdditionalFileExtensionspec
   ✓ it runs file names like `AdditionalFileExtension.spec.php`
 
+   PASS  Tests\PHPUnit\CustomAffixes\FolderWithAn\ExampleTest
+  ✓ custom traits can be used
+  ✓ trait applied in this file
+
    PASS  Tests\PHPUnit\CustomAffixes\ManyExtensionsclasstest
   ✓ it runs file names like `ManyExtensions.class.test.php`
 
@@ -220,5 +224,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  7 skipped, 120 passed
+  Tests:  7 skipped, 122 passed
   

--- a/tests/PHPUnit/CustomAffixes/FolderWithAn@/ExampleTest.php
+++ b/tests/PHPUnit/CustomAffixes/FolderWithAn@/ExampleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+class MyCustomClassTest extends PHPUnit\Framework\TestCase
+{
+    public function assertTrueIsTrue()
+    {
+        $this->assertTrue(true);
+    }
+}
+
+uses(MyCustomClassTest::class);
+
+test('custom traits can be used', function () {
+    $this->assertTrueIsTrue();
+});
+
+test('trait applied in this file')->assertTrueIsTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #307

This PR introduces a more specific separator for the tests keys to avoid matching a potential folder name. The separator is changed from `@` to `@@@@` as it has more chance to not match anything in the test file absolute path. Maybe this value could be more complex?

