### PR TITLE
feat: add support for using Finder objects for `uses()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "illuminate/console": "^8.47.0",
         "illuminate/support": "^8.47.0",
         "laravel/dusk": "^6.15.0",
-        "pestphp/pest-dev-tools": "dev-master"
+        "pestphp/pest-dev-tools": "dev-master",
+        "symfony/finder": "^5.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -84,5 +85,8 @@
                 "Pest\\Laravel\\PestServiceProvider"
             ]
         }
+    },
+    "suggest": {
+        "symfony/finder": "If using `uses()->inFinder($finder)` for class or trait usage declaration. (^5.2)"
     }
 }

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Pest\PendingObjects;
 
 use Closure;
+use Pest\Exceptions\ShouldNotHappen;
 use Pest\TestSuite;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @internal
@@ -98,6 +100,23 @@ final class UsesCall
 
             return $accumulator;
         }, []);
+    }
+
+    /** @param Finder $finder */
+    public function inFinder($finder): void
+    {
+        if (!class_exists(Finder::class)) {
+            throw ShouldNotHappen::fromMessage(sprintf(
+                'Unable to find the `%s` class, please install `symfony/finder`',
+                Finder::class
+            ));
+        }
+
+        $paths = \array_map(function (\Symfony\Component\Finder\SplFileInfo $item): string {
+            return $item->getRealPath();
+        }, \iterator_to_array($finder));
+
+        $this->in(...$paths);
     }
 
     /**

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -106,14 +106,16 @@ final class UsesCall
     public function inFinder($finder): void
     {
         if (!class_exists(Finder::class)) {
-            throw ShouldNotHappen::fromMessage(sprintf(
-                'Unable to find the `%s` class, please install `symfony/finder`',
-                Finder::class
-            ));
+            throw ShouldNotHappen::fromMessage(sprintf('Unable to find the `%s` class, please install `symfony/finder`', Finder::class));
+        }
+
+        /* @phpstan-ignore-next-line */
+        if (!($finder instanceof Finder)) {
+            throw new \InvalidArgumentException(sprintf('Invalid object `%s` passed to `uses()->inFinder()`', get_class($finder)));
         }
 
         $paths = \array_map(function (\Symfony\Component\Finder\SplFileInfo $item): string {
-            return $item->getRealPath();
+            return (string) $item->getRealPath();
         }, \iterator_to_array($finder));
 
         $this->in(...$paths);

--- a/src/PendingObjects/UsesCall.php
+++ b/src/PendingObjects/UsesCall.php
@@ -108,9 +108,9 @@ final class UsesCall
     }
 
     /**
-     * @param array<Finder> $targets
+     * @param array<int, Finder> $targets
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     private function convertFinderToPaths(array $targets): array
     {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -422,8 +422,13 @@
   ✓ a test
   ✓ higher order message test
 
-   PASS  Tests\Features\Uses\Finder\Uses
+   PASS  Tests\Features\Uses\Finder\MultipleUses
   ✓ it uses the right trait by using Symfony Finder call
+  ✓ it uses the additional trait from the Symfony Finder call
+
+   PASS  Tests\Features\Uses\Finder\SingleUses
+  ✓ it uses the right trait by using Symfony Finder call
+  ✓ it does not use the additional trait from the Symfony Finder call
 
    PASS  Tests\Fixtures\DirectoryWithTests\ExampleTest
   ✓ it example 1
@@ -557,5 +562,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 341 passed
+  Tests:  4 incompleted, 7 skipped, 344 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -422,6 +422,9 @@
   ✓ a test
   ✓ higher order message test
 
+   PASS  Tests\Features\Uses\Finder\Uses
+  ✓ it uses the right trait by using Symfony Finder call
+
    PASS  Tests\Fixtures\DirectoryWithTests\ExampleTest
   ✓ it example 1
 
@@ -554,5 +557,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 340 passed
+  Tests:  4 incompleted, 7 skipped, 341 passed
   

--- a/tests/Features/Uses/Finder/MultipleUses.php
+++ b/tests/Features/Uses/Finder/MultipleUses.php
@@ -1,0 +1,9 @@
+<?php
+
+it('uses the right trait by using Symfony Finder call', function () {
+    expect(class_uses($this))->toContain(TestTraitUsedByFinder::class);
+});
+
+it('uses the additional trait from the Symfony Finder call', function () {
+    expect(class_uses($this))->toContain(MultipleTestTraitUsedByFinder::class);
+});

--- a/tests/Features/Uses/Finder/SingleUses.php
+++ b/tests/Features/Uses/Finder/SingleUses.php
@@ -1,0 +1,9 @@
+<?php
+
+it('uses the right trait by using Symfony Finder call', function () {
+    expect(class_uses($this))->toContain(TestTraitUsedByFinder::class);
+});
+
+it('does not use the additional trait from the Symfony Finder call', function () {
+    expect(class_uses($this))->not->toContain(MultipleTestTraitUsedByFinder::class);
+});

--- a/tests/Features/Uses/Finder/Uses.php
+++ b/tests/Features/Uses/Finder/Uses.php
@@ -1,0 +1,5 @@
+<?php
+
+it('uses the right trait by using Symfony Finder call', function () {
+    expect(class_uses($this))->toContain(TestTraitUsedByFinder::class);
+});

--- a/tests/Features/Uses/Finder/Uses.php
+++ b/tests/Features/Uses/Finder/Uses.php
@@ -1,5 +1,0 @@
-<?php
-
-it('uses the right trait by using Symfony Finder call', function () {
-    expect(class_uses($this))->toContain(TestTraitUsedByFinder::class);
-});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -23,9 +23,18 @@ trait TestTraitUsedByFinder
 {
 }
 
+trait MultipleTestTraitUsedByFinder
+{
+}
+
 uses(TestTraitUsedByFinder::class)->in(
     Symfony\Component\Finder\Finder::create()
-        ->in(__DIR__.'/Features/Uses')
+        ->in(__DIR__ . '/Features/Uses')
         ->name('Finder')
-        ->directories()
+);
+
+uses(MultipleTestTraitUsedByFinder::class)->in(
+    Symfony\Component\Finder\Finder::create()
+        ->in(__DIR__ . '/Features/Uses/Finder')
+        ->notName('SingleUses.php')
 );

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,3 +18,14 @@ uses()
         $globalHook->afterAll = 0;
     })
     ->in('Hooks');
+
+trait TestTraitUsedByFinder
+{
+}
+
+uses(TestTraitUsedByFinder::class)->in(
+    Symfony\Component\Finder\Finder::create()
+        ->in(__DIR__.'/Features/Uses')
+        ->name('Finder')
+        ->directories()
+);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This came up [on Discord](https://discord.com/channels/705126275232038944/710642595705126923/851535915016519740) where it was asked whether it was possible to provide something such as globs (e.g. `**/Feature`) to the `uses()->in()` call. This will basically throw a `ShouldNotHappen` exception if the `Finder` class doesn't exist, and the usual `uses()->in()` call can be used as normal.

For example, here's how you could specify all `Feature` subdirectories to use a specific testcase class.

```php
use Symfony\Component\Finder\Finder;

uses(Tests\TestCase::class)->inFinder(
    Finder::create()
        ->name('Feature')
        ->directories()
        ->in(__DIR__)
);
```