### PR TITLE
feat: move init command out of external plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@
 .gitattributes           export-ignore
 .gitignore               export-ignore
 phpstan.neon             export-ignore
-phpunit.xml              export-ignore
+/phpunit.xml             export-ignore
 CHANGELOG.md             export-ignore
 CONTRIBUTING.md          export-ignore
 README.md                export-ignore

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "pestphp/pest-plugin": "^1.0",
         "pestphp/pest-plugin-coverage": "^1.0",
         "pestphp/pest-plugin-expectations": "^1.6",
-        "pestphp/pest-plugin-init": "^1.1",
         "phpunit/phpunit": ">= 9.3.7 <= 9.5.5"
     },
     "autoload": {
@@ -77,6 +76,7 @@
         },
         "pest": {
             "plugins": [
+                "Pest\\Plugins\\Init",
                 "Pest\\Plugins\\Version"
             ]
         },

--- a/src/Plugins/Init.php
+++ b/src/Plugins/Init.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Plugins;
+
+use Pest\Console\Thanks;
+use Pest\Contracts\Plugins\HandlesArguments;
+use Pest\TestSuite;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Init implements HandlesArguments
+{
+    /**
+     * The option the triggers the init job.
+     */
+    private const INIT_OPTION = '--init';
+
+    /**
+     * The files that will be created.
+     */
+    private const STUBS = [
+        'phpunit.xml'     => 'phpunit.xml',
+        'Pest.php'        => 'tests/Pest.php',
+        'ExampleTest.php' => 'tests/ExampleTest.php',
+    ];
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var TestSuite
+     */
+    private $testSuite;
+
+    /**
+     * Creates a new Plugin instance.
+     */
+    public function __construct(TestSuite $testSuite, OutputInterface $output)
+    {
+        $this->testSuite = $testSuite;
+        $this->output    = $output;
+    }
+
+    public function handleArguments(array $arguments): array
+    {
+        if (!array_key_exists(1, $arguments) || $arguments[1] !== self::INIT_OPTION) {
+            return $arguments;
+        }
+
+        unset($arguments[1]);
+
+        $this->init();
+
+        return array_values($arguments);
+    }
+
+    private function init(): void
+    {
+        $testsBaseDir = "{$this->testSuite->rootPath}/tests";
+
+        if (!is_dir($testsBaseDir)) {
+            if (!mkdir($testsBaseDir) && !is_dir($testsBaseDir)) {
+                $this->output->writeln(sprintf(
+                    "\n  <fg=white;bg=red;options=bold> ERROR </> Directory `%s` was not created.</>",
+                    $testsBaseDir
+                ));
+
+                return;
+            }
+
+            $this->output->writeln(
+                '  <fg=black;bg=green;options=bold> DONE </> Created `tests` directory.</>',
+            );
+        }
+
+        foreach (self::STUBS as $from => $to) {
+            $fromPath = __DIR__ . "/../../stubs/init/{$from}";
+            $toPath   = "{$this->testSuite->rootPath}/{$to}";
+
+            if (file_exists($toPath)) {
+                $this->output->writeln(sprintf(
+                    '  <fg=black;bg=yellow;options=bold> INFO </> File `%s` already exists, skipped.</>',
+                    $to
+                ));
+
+                continue;
+            }
+
+            if ($from === 'phpunit.xml' && file_exists($toPath . '.dist')) {
+                $this->output->writeln(sprintf(
+                    '  <fg=black;bg=yellow;options=bold> INFO </> File `%s` already exists, skipped.</>',
+                    $to . '.dist'
+                ));
+
+                continue;
+            }
+
+            if (!copy($fromPath, $toPath)) {
+                $this->output->writeln(sprintf(
+                    '<fg=black;bg=red>[WARNING] Failed to copy stub `%s` to `%s`</>',
+                    $from,
+                    $toPath
+                ));
+
+                continue;
+            }
+
+            $this->output->writeln(sprintf(
+                '  <fg=black;bg=green;options=bold> DONE </> Created `%s` file.</>',
+                $to
+            ));
+        }
+
+        $this->output->writeln(
+            "\n  <fg=black;bg=green;options=bold> DONE </> Pest initialised.</>\n",
+        );
+
+        (new Thanks($this->output))();
+
+        exit(0);
+    }
+}

--- a/stubs/init/ExampleTest.php
+++ b/stubs/init/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/stubs/init/Pest.php
+++ b/stubs/init/Pest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/stubs/init/phpunit.xml
+++ b/stubs/init/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

This moves the Pest Init plugin into Pest core.

Part of https://github.com/pestphp/pest/issues/316.