### PR TITLE
Datasets key extraction

### DIFF
--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -17,6 +17,12 @@
   ✓ it gets executed before each test
   ✓ it gets executed before each test once again
 
+   PASS  Tests\Features\Coverage
+  ✓ it has plugin
+  ✓ it adds coverage if --coverage exist
+  ✓ it adds coverage if --min exist
+  ✓ it generates coverage based on file input
+
    PASS  Tests\Features\Datasets
   ✓ it throws exception if dataset does not exist
   ✓ it throws exception if dataset already exist
@@ -284,5 +290,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 176 passed
+  Tests:  4 incompleted, 7 skipped, 180 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -90,6 +90,14 @@
   ✓ more than two datasets with (2) / (4) / (5)
   ✓ more than two datasets with (2) / (4) / (6)
   ✓ more than two datasets did the job right
+  ✓ it can generate test with extracted dataset with data set "Nuno"
+  ✓ it can generate test with extracted dataset with data set "Fabio"
+  ✓ it can generate test with extracted dataset with data set "Oliver"
+  ✓ it extracts keys from lazy dataset
+  ✓ it extracts keys from eager dataset
+  ✓ it trims extract dataset keys
+  ✓ it replaces missing keys with null
+  ✓ it ignores empty keys
 
    PASS  Tests\Features\Exceptions
   ✓ it gives access the the underlying expectException
@@ -276,5 +284,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 168 passed
+  Tests:  4 incompleted, 7 skipped, 176 passed
   

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -223,3 +223,172 @@ test('more than two datasets', function ($text_a, $text_b, $text_c) use ($state,
 test('more than two datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('121212121212131423241314232411122122111221221112212213142324135136145146235236245246');
 });
+
+$people = [
+    'Nuno'   => [
+        'name'    => 'Nuno',
+        'country' => 'Portugal',
+        'role'    => 'Owner',
+    ],
+    'Fabio'  => [
+        'name'    => 'Fabio',
+        'country' => 'Italy',
+        'role'    => 'Member',
+    ],
+    'Oliver' => [
+        'name'    => 'Oliver',
+        'country' => 'Denmark',
+        'role'    => 'Maintainer',
+    ],
+];
+dataset('people', $people);
+
+it('can generate test with extracted dataset', function ($role, $name) use ($people) {
+    expect($people)->toHaveKey($name);
+    expect($name)->toEqual($people[$name]['name']);
+    expect($role)->toEqual($people[$name]['role']);
+})->with('people:role,name');
+
+it('extracts keys from lazy dataset', function () {
+    Datasets::set('dataset', [
+        [
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ],
+        [
+            'foo' => 4,
+            'bar' => 5,
+            'baz' => 6,
+        ],
+    ]);
+
+    expect(Datasets::get('dataset:baz,bar'))->toMatchArray([
+        [
+            'baz' => 3,
+            'bar' => 2,
+        ],
+        [
+            'baz' => 6,
+            'bar' => 5,
+        ],
+    ]);
+
+    Datasets::unset('dataset');
+});
+
+it('extracts keys from eager dataset', function () {
+    Datasets::set('dataset', function () {
+        return [
+            [
+                'foo' => 1,
+                'bar' => 2,
+                'baz' => 3,
+            ],
+            [
+                'foo' => 4,
+                'bar' => 5,
+                'baz' => 6,
+            ],
+        ];
+    });
+
+    expect(Datasets::get('dataset:baz,foo'))->toMatchArray([
+        [
+            'baz' => 3,
+            'foo' => 1,
+        ],
+        [
+            'baz' => 6,
+            'foo' => 4,
+        ],
+    ]);
+
+    Datasets::unset('dataset');
+});
+
+it('trims extract dataset keys', function () {
+    Datasets::set('dataset', [
+        [
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ],
+        [
+            'foo' => 4,
+            'bar' => 5,
+            'baz' => 6,
+        ],
+    ]);
+
+    expect(Datasets::get(' dataset : baz , bar '))->toMatchArray([
+        [
+            'baz' => 3,
+            'bar' => 2,
+        ],
+        [
+            'baz' => 6,
+            'bar' => 5,
+        ],
+    ]);
+
+    Datasets::unset('dataset');
+});
+
+it('replaces missing keys with null', function () {
+    Datasets::set('dataset', [
+        [
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ],
+        [
+            'foo' => 4,
+            'bar' => 5,
+            'baz' => 6,
+        ],
+    ]);
+
+    expect(Datasets::get('dataset:baz,bar,wee'))->toMatchArray([
+        [
+            'baz' => 3,
+            'bar' => 2,
+            'wee' => null,
+        ],
+        [
+            'baz' => 6,
+            'bar' => 5,
+            'wee' => null,
+        ],
+    ]);
+
+    Datasets::unset('dataset');
+});
+
+it('ignores empty keys', function () {
+    Datasets::set('dataset', [
+        [
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ],
+        [
+            'foo' => 4,
+            'bar' => 5,
+            'baz' => 6,
+        ],
+    ]);
+
+    expect(Datasets::get('dataset:baz, ,bar'))->toMatchArray([
+        [
+            'baz' => 3,
+            'bar' => 2,
+        ],
+        [
+            'baz' => 6,
+            'bar' => 5,
+        ],
+    ]);
+
+    Datasets::unset('dataset');
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

This PR aims at defining way to extract specific keys from a dataset and using them in a test, eg.

given a dataset: 

```php
dataset('people', [
    [
        'name'    => 'Nuno',
        'country' => 'Portugal',
        'role'    => 'Owner',
    ],
    [
        'name'    => 'Fabio',
        'country' => 'Italy',
        'role'    => 'Member',
    ],
    [
        'name'    => 'Oliver',
        'country' => 'Denmark',
        'role'    => 'Maintainer',
    ],
]);
```

with this implementation is it possible to use it for more specific tests:

```php
it('retrieves people role from names', function($name, $expected_role){
    expect(RoleResolver::resolve($name))->toBe($expected_role);
})->with('people:name,role');

it('retrieves people country from names', function($name, $expected_country){
    expect(CountryResolver::resolve($name))->toBe($expected_country);
})->with('people:name,country');
```

this will allow to write a dataset that could be used in a wider range of tests

**bonus**

_keys order can be customized_

```php
it('extracts keys in arbitrary order', function($role, $name){
    expect(RoleResolver::resolve($name))->toBe($expected_role);
})->with('people:role, name');
```


**credits**

thanks to @olivernybroe  for the dataset naming idea (`->with('people:role, name')`)