### PR TITLE
Add user-friendly exception message for missing test inputs

### DIFF
--- a/src/Exceptions/DatasetMissing.php
+++ b/src/Exceptions/DatasetMissing.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use BadFunctionCallException;
+use NunoMaduro\Collision\Contracts\RenderlessEditor;
+use NunoMaduro\Collision\Contracts\RenderlessTrace;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+
+/**
+ * Creates a new instance of dataset is not present for test that has arguments
+ *
+ * @internal
+ */
+final class DatasetMissing extends BadFunctionCallException implements ExceptionInterface, RenderlessEditor, RenderlessTrace
+{
+    /**
+     * Create new exception instance.
+     *
+     * @param array<string, string> $args A map of argument names to their typee
+     */
+    public function __construct(string $file, string $name, array $args)
+    {
+        parent::__construct(sprintf(
+            "A test with the description '%s' has %d argument(s) ([%s]) and no dataset(s) provided in %s",
+            $name,
+            count($args),
+            implode(', ', array_map(static function (string $arg, string $type): string {
+                return sprintf('%s $%s', $type, $arg);
+            }, array_keys($args), $args)),
+            $file,
+        ));
+    }
+}

--- a/src/Exceptions/DatasetMissing.php
+++ b/src/Exceptions/DatasetMissing.php
@@ -10,7 +10,7 @@ use NunoMaduro\Collision\Contracts\RenderlessTrace;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 
 /**
- * Creates a new instance of dataset is not present for test that has arguments
+ * Creates a new instance of dataset is not present for test that has arguments.
  *
  * @internal
  */

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -67,13 +67,6 @@ final class TestCaseFactory
     public $datasets = [];
 
     /**
-     * Has the current test been marked dependent on others?
-     *
-     * @var bool
-     */
-    public $dependent = false;
-
-    /**
      * The FQN of the test case class.
      *
      * @var string
@@ -241,6 +234,7 @@ final class TestCaseFactory
      */
     public function receivesArguments(): bool
     {
-        return $this->dependent === true || count($this->datasets) > 0;
+        return count($this->datasets) > 0
+            || $this->factoryProxies->count('addDependencies') > 0;
     }
 }

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -67,6 +67,13 @@ final class TestCaseFactory
     public $datasets = [];
 
     /**
+     * Has the current test been marked dependent on others?
+     *
+     * @var bool
+     */
+    public $dependent = false;
+
+    /**
      * The FQN of the test case class.
      *
      * @var string

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -235,4 +235,12 @@ final class TestCaseFactory
 
         return $classFQN;
     }
+
+    /**
+     * Determine if the test case will receive argument input from Pest, or not.
+     */
+    public function receivesArguments(): bool
+    {
+        return $this->dependent === true || count($this->datasets) > 0;
+    }
 }

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -97,6 +97,8 @@ final class TestCall
             ->factoryProxies
             ->add(Backtrace::file(), Backtrace::line(), 'addDependencies', [$tests]);
 
+        $this->testCaseFactory->dependent = true;
+
         return $this;
     }
 

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -102,8 +102,6 @@ final class TestCall
             ->factoryProxies
             ->add(Backtrace::file(), Backtrace::line(), 'addDependencies', [$tests]);
 
-        $this->testCaseFactory->dependent = true;
-
         return $this;
     }
 

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Pest\Repositories;
 
 use Closure;
+use Pest\Exceptions\DatasetMissing;
 use Pest\Exceptions\ShouldNotHappen;
 use Pest\Exceptions\TestAlreadyExist;
 use Pest\Exceptions\TestCaseAlreadyInUse;
 use Pest\Exceptions\TestCaseClassOrTraitNotFound;
 use Pest\Factories\TestCaseFactory;
+use Pest\Support\Reflection;
 use Pest\Support\Str;
 use Pest\TestSuite;
 use PHPUnit\Framework\TestCase;
@@ -138,6 +140,14 @@ final class TestRepository
 
         if (array_key_exists(sprintf('%s%s%s', $test->filename, self::SEPARATOR, $test->description), $this->state)) {
             throw new TestAlreadyExist($test->filename, $test->description);
+        }
+
+        if ($test->dependent === false && count($test->datasets) === 0) {
+            $arguments = Reflection::getFunctionArguments($test->test);
+
+            if (count($arguments) > 0) {
+                throw new DatasetMissing($test->filename, $test->description, $arguments);
+            }
         }
 
         $this->state[sprintf('%s%s%s', $test->filename, self::SEPARATOR, $test->description)] = $test;

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -142,7 +142,7 @@ final class TestRepository
             throw new TestAlreadyExist($test->filename, $test->description);
         }
 
-        if ($test->dependent === false && count($test->datasets) === 0) {
+        if (!$test->receivesArguments()) {
             $arguments = Reflection::getFunctionArguments($test->test);
 
             if (count($arguments) > 0) {

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -53,4 +53,20 @@ final class HigherOrderMessageCollection
             $message->call($target);
         }
     }
+
+    /**
+     * Count the number of messages with the given name.
+     *
+     * @param string $name A higher order message name (usually a method name)
+     */
+    public function count(string $name): int
+    {
+        return array_reduce(
+            $this->messages,
+            static function (int $total, HigherOrderMessage $message) use ($name): int {
+                return $total + (int) ($name === $message->name);
+            },
+            0,
+        );
+    }
 }

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -165,7 +165,7 @@ final class Reflection
         $arguments  = [];
 
         foreach ($parameters as $parameter) {
-            $arguments[$parameter->getName()] = ($parameter->hasType()) ? $parameter->getType() : 'mixed';
+            $arguments[$parameter->getName()] = ($parameter->hasType()) ? (string) $parameter->getType() : 'mixed';
         }
 
         return $arguments;

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -153,4 +153,21 @@ final class Reflection
 
         return $name;
     }
+
+    /**
+     * Receive a map of function argument names to their types.
+     *
+     * @return array<string, string>
+     */
+    public static function getFunctionArguments(Closure $function): array
+    {
+        $parameters = (new ReflectionFunction($function))->getParameters();
+        $arguments = [];
+
+        foreach ($parameters as $parameter) {
+            $arguments[$parameter->getName()] = ($parameter->hasType()) ? $parameter->getType() : 'mixed';
+        }
+
+        return $arguments;
+    }
 }

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -162,7 +162,7 @@ final class Reflection
     public static function getFunctionArguments(Closure $function): array
     {
         $parameters = (new ReflectionFunction($function))->getParameters();
-        $arguments = [];
+        $arguments  = [];
 
         foreach ($parameters as $parameter) {
             $arguments[$parameter->getName()] = ($parameter->hasType()) ? $parameter->getType() : 'mixed';

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -165,7 +165,9 @@ final class Reflection
         $arguments  = [];
 
         foreach ($parameters as $parameter) {
-            $arguments[$parameter->getName()] = ($parameter->hasType()) ? (string) $parameter->getType() : 'mixed';
+            /** @var ReflectionNamedType|null $type */
+            $type                             = ($parameter->hasType()) ? $parameter->getType() : null;
+            $arguments[$parameter->getName()] = (is_null($type)) ? 'mixed' : $type->getName();
         }
 
         return $arguments;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -527,6 +527,7 @@
 
    PASS  Tests\Unit\TestSuite
   ✓ it does not allow to add the same test description twice
+  ✓ it alerts users about tests with arguments but no input
 
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
@@ -554,5 +555,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 340 passed
+  Tests:  4 incompleted, 7 skipped, 341 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -580,5 +580,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 363 passed
+  Tests:  4 incompleted, 7 skipped, 364 passed
   

--- a/tests/Unit/TestSuite.php
+++ b/tests/Unit/TestSuite.php
@@ -8,15 +8,17 @@ it('does not allow to add the same test description twice', function () {
     $testSuite = new TestSuite(getcwd(), 'tests');
     $test = function () {};
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
-    $this->expectException(TestAlreadyExist::class);
-    $this->expectExceptionMessage(sprintf('A test with the description `%s` already exist in the filename `%s`.', 'foo', __FILE__));
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
-});
+})->throws(
+    TestAlreadyExist::class,
+    sprintf('A test with the description `%s` already exist in the filename `%s`.', 'foo', __FILE__),
+);
 
 it('alerts users about tests with arguments but no input', function () {
     $testSuite = new TestSuite(getcwd(), 'tests');
     $test = function (int $arg) {};
-    $this->expectException(DatasetMissing::class);
-    $this->expectExceptionMessage(sprintf("A test with the description '%s' has %d argument(s) ([%s]) and no dataset(s) provided in %s", 'foo', 1, 'int $arg', __FILE__));
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
-});
+})->throws(
+    DatasetMissing::class,
+    sprintf("A test with the description '%s' has %d argument(s) ([%s]) and no dataset(s) provided in %s", 'foo', 1, 'int $arg', __FILE__),
+);

--- a/tests/Unit/TestSuite.php
+++ b/tests/Unit/TestSuite.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pest\Exceptions\DatasetMissing;
 use Pest\Exceptions\TestAlreadyExist;
 use Pest\TestSuite;
 
@@ -9,5 +10,13 @@ it('does not allow to add the same test description twice', function () {
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
     $this->expectException(TestAlreadyExist::class);
     $this->expectExceptionMessage(sprintf('A test with the description `%s` already exist in the filename `%s`.', 'foo', __FILE__));
+    $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
+});
+
+it('alerts users about tests with arguments but no input', function () {
+    $testSuite = new TestSuite(getcwd(), 'tests');
+    $test = function (int $arg) {};
+    $this->expectException(DatasetMissing::class);
+    $this->expectExceptionMessage(sprintf("A test with the description '%s' has %d argument(s) ([%s]) and no dataset(s) provided in %s", 'foo', 1, 'int $arg', __FILE__));
     $testSuite->tests->set(new \Pest\Factories\TestCaseFactory(__FILE__, 'foo', $test));
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #249 

### Overview

- add a new exception type, `DatasetMissing`;
- add the new `bool $dependent` property to the test factory to indicate `depends` has been called;
    - defaults to `false`;
    - we set it to `true` after adding the `addDependencies` factory proxy message from the `TestCall::depends` method;
- make check for datasets within the `TestRepository::set` method;
    - we throw the new exception with user-friendly message when all the following are true;
        - the test has no dependencies;
        - the test has no datasets;
        - the test closure has an argument list greater than 0 (checked via reflection);
- add new `Reflection::getFunctionArguments` helper method to return a map of argument names to their types;
    - used to double for exception message formatting as well as argument list length checks;
    - handles PHP 8 union types as well;

### Examples

![image](https://user-images.githubusercontent.com/18744334/122166593-7704d900-ce3f-11eb-8350-5d3f647d0664.png)

![image](https://user-images.githubusercontent.com/18744334/122166639-8421c800-ce3f-11eb-8332-dbcfed920495.png)

![image](https://user-images.githubusercontent.com/18744334/122166516-5dfc2800-ce3f-11eb-9986-6c942a538a50.png)
