### PR TITLE
Sequenced expectations can now be passed as non-callable values

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -110,7 +110,7 @@ final class Expectation
 
         if (is_callable($callback)) {
             foreach ($this->value as $item) {
-                $callback(expect($item));
+                $callback(new Expectation($item));
             }
         }
 
@@ -119,8 +119,10 @@ final class Expectation
 
     /**
      * Allows you to specify a sequential set of expectations for each item in a iterable "value".
+     *
+     * @param mixed ...$callbacks
      */
-    public function sequence(callable ...$callbacks): Expectation
+    public function sequence(...$callbacks): Expectation
     {
         if (!is_iterable($this->value)) {
             throw new BadMethodCallException('Expectation value is not iterable.');
@@ -138,7 +140,12 @@ final class Expectation
         }
 
         foreach ($values as $key => $item) {
-            call_user_func($callbacks[$key], expect($item), expect($keys[$key]));
+            if (is_callable($callbacks[$key])) {
+                call_user_func($callbacks[$key], new Expectation($item), new Expectation($keys[$key]));
+                continue;
+            }
+
+            (new Expectation($item))->toEqual($callbacks[$key]);
         }
 
         return $this;

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -128,9 +128,10 @@ final class Expectation
     }
 
     /**
+     * @template TValue
      * Allows you to specify a sequential set of expectations for each item in a iterable "value".
      *
-     * @param callable(Expectation, Expectation): void|mixed ...$callbacks
+     * @param callable(Expectation, Expectation): void|TValue ...$callbacks
      */
     public function sequence(...$callbacks): Expectation
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -120,7 +120,7 @@ final class Expectation
     /**
      * Allows you to specify a sequential set of expectations for each item in a iterable "value".
      *
-     * @param mixed ...$callbacks
+     * @param callable(Expectation, Expectation): void|mixed ...$callbacks
      */
     public function sequence(...$callbacks): Expectation
     {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -156,6 +156,8 @@
   ✓ loops back to the start if it runs out of sequence items
   ✓ it works if the number of items in the iterable is smaller than the number of expectations
   ✓ it works with associative arrays
+  ✓ it can be passed non-callable values
+  ✓ it can be passed a mixture of value types
 
    PASS  Tests\Features\Expect\toBe
   ✓ strict comparisons
@@ -573,5 +575,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 357 passed
+  Tests:  4 incompleted, 7 skipped, 359 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -152,6 +152,8 @@
   ✓ loops back to the start if it runs out of sequence items
   ✓ it works if the number of items in the iterable is smaller than the number of expectations
   ✓ it works with associative arrays
+  ✓ it can be passed non-callable values
+  ✓ it can be passed a mixture of value types
 
    PASS  Tests\Features\Expect\toBe
   ✓ strict comparisons
@@ -554,5 +556,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 340 passed
+  Tests:  4 incompleted, 7 skipped, 342 passed
   

--- a/tests/Features/Expect/sequence.php
+++ b/tests/Features/Expect/sequence.php
@@ -44,3 +44,19 @@ test('it works with associative arrays', function () {
             function ($expectation, $key) { $expectation->toEqual('boom'); $key->toEqual('baz'); },
         );
 });
+
+test('it can be passed non-callable values', function () {
+    expect(['foo', 'bar', 'baz'])->sequence('foo', 'bar', 'baz');
+
+    expect(static::getCount())->toBe(3);
+});
+
+test('it can be passed a mixture of value types', function () {
+    expect(['foo', 'bar', 'baz'])->sequence(
+        'foo',
+        function ($expectation) { $expectation->toEqual('bar')->toBeString(); },
+        'baz'
+    );
+
+    expect(static::getCount())->toBe(4);
+});


### PR DESCRIPTION
This is a port of https://github.com/pestphp/pest-plugin-expectations/pull/16 after plugins were merged into core.