### PR TITLE
Method json() to parse JSON strings

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -61,7 +61,7 @@ final class Expectation
     }
 
     /**
-     * Parses Json String to Array.
+     * Creates a new expectation with the decoded JSON value.
      */
     public function json(): Expectation
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -65,10 +65,7 @@ final class Expectation
      */
     public function json(): Expectation
     {
-        Assert::assertIsString($this->value);
-        Assert::assertJson($this->value);
-
-        return new self(json_decode($this->value, true));
+        return $this->toBeJson()->and(json_decode($this->value, true));
     }
 
     /**

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -61,6 +61,17 @@ final class Expectation
     }
 
     /**
+     * Parses Json String to Array.
+     */
+    public function json(): Expectation
+    {
+        Assert::assertIsString($this->value);
+        Assert::assertJson($this->value);
+
+        return new self(json_decode($this->value, true));
+    }
+
+    /**
      * Dump the expectation value and end the script.
      *
      * @param mixed $arguments

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -140,6 +140,10 @@
   ✓ it macros true is true with argument
   ✓ it macros false is not true with argument
 
+   PASS  Tests\Features\Expect\json
+  ✓ it properly parses json string
+  ✓ fails with broken json string
+
    PASS  Tests\Features\Expect\not
   ✓ not property calls
 
@@ -569,5 +573,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 355 passed
+  Tests:  4 incompleted, 7 skipped, 357 passed
   

--- a/tests/Features/Expect/json.php
+++ b/tests/Features/Expect/json.php
@@ -1,0 +1,14 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('it properly parses json string', function () {
+    expect('{"name":"Nuno"}')
+        ->json()
+        ->name
+        ->toBe('Nuno');
+});
+
+test('fails with broken json string', function () {
+    expect('{":"Nuno"}')->json();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... 

Allows to parse a JSON string to array and access it when using Higher Order expectations.

```php

//Propose
expect('{"name":"Nuno"}')->json()->name->toBe('Nuno');

//Instead of 
expect(json_decode('{"name":"Nuno"}'), true)->name->toBe('Nuno');
```
