### PR TITLE
Allows `and` in Higher Order Expectations.

### DIFF
--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -64,6 +64,16 @@ final class HigherOrderExpectation
     }
 
     /**
+     * Creates a new expectation.
+     *
+     * @param mixed $value
+     */
+    public function and($value): HigherOrderExpectation
+    {
+        return new self($this->expect($value), $value);
+    }
+
+    /**
      * Dynamically calls methods on the class with the given arguments.
      *
      * @param array<int, mixed> $arguments

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -66,11 +66,15 @@ final class HigherOrderExpectation
     /**
      * Creates a new expectation.
      *
-     * @param mixed $value
+     * @template TValue
+     *
+     * @param TValue $value
+     *
+     * @return Expectation<TValue>
      */
-    public function and($value): HigherOrderExpectation
+    public function and($value): Expectation
     {
-        return new self($this->expect($value), $value);
+        return $this->expect($value);
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -116,6 +116,7 @@
    PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
   ✓ it can access methods and properties
   ✓ it can handle nested methods and properties
+  ✓ it can start a new higher order expectation using the and syntax
 
    PASS  Tests\Features\Expect\HigherOrder\properties
   ✓ it allows properties to be accessed from the value
@@ -578,5 +579,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 362 passed
+  Tests:  4 incompleted, 7 skipped, 363 passed
   

--- a/tests/Features/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Features/Expect/HigherOrder/methodsAndProperties.php
@@ -22,6 +22,17 @@ it('can handle nested methods and properties', function () {
         ->newInstance()->books()->toBeArray();
 });
 
+it('can start a new higher order expectation using the and syntax', function () {
+    expect(new HasMethodsAndProperties())
+        ->toBeInstanceOf(HasMethodsAndProperties::class)
+        ->meta->toBeArray
+        ->and(['foo' => 'bar'])
+        ->toBeArray()
+        ->foo->toEqual('bar');
+
+    expect(static::getCount())->toEqual(4);
+});
+
 class HasMethodsAndProperties
 {
     public $name = 'Has Methods and Properties';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes

This is kind of a bug fix, but I prefer to think of it as a new feature 😆 

Previously, calling the `and` method in a Higher Order expectation would fail because the original Higher Order expectation was still the target. This PR now allows for the following:

```php
it('can start a new higher order expectation using the and syntax', function () {
    expect(new HasMethodsAndProperties())
        ->toBeInstanceOf(HasMethodsAndProperties::class)
        ->meta->toBeArray
        ->and(['foo' => 'bar'])
        ->toBeArray()
        ->foo->toEqual('bar');
});
```
