### PR TITLE
Adds a new `tap` method to Higher Order tests

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -11,7 +11,8 @@ use Pest\Support\NullClosure;
 use Pest\TestSuite;
 use SebastianBergmann\Exporter\Exporter;
 
-/**
+/*
+ * @mixin \Pest\Support\HigherOrderCallables
  * @method \Pest\Expectations\Expectation expect(mixed $value)
  *
  * @internal

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -7,15 +7,15 @@ namespace Pest\PendingObjects;
 use Closure;
 use Pest\Factories\TestCaseFactory;
 use Pest\Support\Backtrace;
+use Pest\Support\HigherOrderCallables;
 use Pest\Support\NullClosure;
 use Pest\TestSuite;
 use SebastianBergmann\Exporter\Exporter;
 
-/*
- * @mixin \Pest\Support\HigherOrderCallables
- * @method \Pest\Expectations\Expectation expect(mixed $value)
- *
+/**
  * @internal
+ *
+ * @mixin HigherOrderCallables
  */
 final class TestCall
 {

--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -81,7 +81,6 @@ final class Coverage implements AddsOutput, HandlesArguments
         }
 
         if ($input->getOption(self::MIN_OPTION) !== null) {
-            /* @phpstan-ignore-next-line */
             $this->coverageMin = (float) $input->getOption(self::MIN_OPTION);
         }
 

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+/**
+ * @internal
+ */
+final class HigherOrderCallables
+{
+    /**
+     * @var object
+     */
+    private $target;
+
+    public function __construct(object $target)
+    {
+        $this->target = $target;
+    }
+
+    /**
+     * @template TValue
+     *
+     * @param callable(): TValue $callable
+     *
+     * @return TValue|object
+     */
+    public function tap(callable $callable)
+    {
+        return Reflection::bindCallable($callable) ?? $this->target;
+    }
+}

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Support;
 
+use Pest\Expectation;
+
 /**
  * @internal
  */
@@ -22,12 +24,42 @@ final class HigherOrderCallables
     /**
      * @template TValue
      *
+     * Create a new expectation. Callable values will be executed prior to returning the new expectation.
+     *
+     * @param callable|TValue $value
+     *
+     * @return Expectation<TValue>
+     */
+    public function expect($value)
+    {
+        return new Expectation(is_callable($value) ? Reflection::bindCallable($value) : $value);
+    }
+
+    /**
+     * @template TValue
+     *
+     * Create a new expectation. Callable values will be executed prior to returning the new expectation.
+     *
+     * @param callable|TValue $value
+     *
+     * @return Expectation<TValue>
+     */
+    public function and($value)
+    {
+        return $this->expect($value);
+    }
+
+    /**
+     * @template TValue
+     *
      * @param callable(): TValue $callable
      *
      * @return TValue|object
      */
     public function tap(callable $callable)
     {
-        return Reflection::bindCallable($callable) ?? $this->target;
+        Reflection::bindCallable($callable);
+
+        return $this->target;
     }
 }

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -70,8 +70,9 @@ final class HigherOrderMessage
      */
     public function call(object $target)
     {
-        if (($value = $this->retrieveHigherOrderCallable($target)) !== null) {
-            return $value;
+        if ($this->hasHigherOrderCallable()) {
+            /* @phpstan-ignore-next-line */
+            return (new HigherOrderCallables($target))->{$this->methodName}(...$this->arguments);
         }
 
         try {
@@ -93,18 +94,13 @@ final class HigherOrderMessage
     }
 
     /**
-     * Attempts to call one of the available Higher Order callables if it exists.
+     * Determines whether or not there exists a higher order callable with the message name.
      *
-     * @return mixed|null
+     * @return bool
      */
-    private function retrieveHigherOrderCallable(object $target)
+    private function hasHigherOrderCallable()
     {
-        if (in_array($this->methodName, get_class_methods(HigherOrderCallables::class), true)) {
-            /* @phpstan-ignore-next-line */
-            return (new HigherOrderCallables($target))->{$this->methodName}(...$this->arguments);
-        }
-
-        return null;
+        return in_array($this->methodName, get_class_methods(HigherOrderCallables::class), true);
     }
 
     private static function getUndefinedMethodMessage(object $target, string $methodName): string

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -70,6 +70,10 @@ final class HigherOrderMessage
      */
     public function call(object $target)
     {
+        if (($value = $this->retrieveHigherOrderCallable($target)) !== null) {
+            return $value;
+        }
+
         try {
             return Reflection::call($target, $this->methodName, $this->arguments);
         } catch (Throwable $throwable) {
@@ -86,6 +90,21 @@ final class HigherOrderMessage
 
             throw $throwable;
         }
+    }
+
+    /**
+     * Attempts to call one of the available Higher Order callables if it exists.
+     *
+     * @return mixed|null
+     */
+    private function retrieveHigherOrderCallable(object $target)
+    {
+        if (in_array($this->methodName, get_class_methods(HigherOrderCallables::class), true)) {
+            /* @phpstan-ignore-next-line */
+            return (new HigherOrderCallables($target))->{$this->methodName}(...$this->arguments);
+        }
+
+        return null;
     }
 
     private static function getUndefinedMethodMessage(object $target, string $methodName): string

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -41,13 +41,23 @@ final class Reflection
             }
 
             if (is_callable($method)) {
-                return Closure::fromCallable($method)->bindTo(
-                    TestSuite::getInstance()->test
-                )(...$args);
+                return static::bindCallable($method, $args);
             }
 
             throw $exception;
         }
+    }
+
+    /**
+     * Bind a callable to the TestCase and return the result.
+     *
+     * @param array<int, mixed> $args
+     *
+     * @return mixed
+     */
+    public static function bindCallable(callable $callable, array $args = [])
+    {
+        return Closure::fromCallable($callable)->bindTo(TestSuite::getInstance()->test)(...$args);
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -409,6 +409,8 @@
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
   ✓ it is capable doing multiple assertions
+  ✓ it can tap into the test
+  ✓ it can use the returned instance from a tap
 
    WARN  Tests\Features\Incompleted
   … incompleted
@@ -578,5 +580,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 362 passed
+  Tests:  4 incompleted, 7 skipped, 364 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -410,6 +410,8 @@
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
   ✓ it is capable doing multiple assertions
+  ✓ it can tap into the test
+  ✓ it can use the returned instance from a tap
 
    WARN  Tests\Features\Incompleted
   … incompleted
@@ -579,5 +581,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 363 passed
+  Tests:  4 incompleted, 7 skipped, 365 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -410,8 +410,8 @@
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
   ✓ it is capable doing multiple assertions
+  ✓ it resolves expect callables correctly
   ✓ it can tap into the test
-  ✓ it can use the returned instance from a tap
 
    WARN  Tests\Features\Incompleted
   … incompleted

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -10,14 +10,18 @@ it('is capable doing multiple assertions')
     ->assertTrue(true)
     ->assertFalse(false);
 
-it('can tap into the test')
-    ->expect('foo')->toBeString()->toBe('foo')
-    ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })
-    ->and('hello world')->toBeString();
+it('resolves expect callables correctly')
+    ->expect(function () { return 'foo'; })
+    ->toBeString()
+    ->toBe('foo')
+    ->and('bar')
+    ->toBeString()
+    ->toBe('bar');
 
-it('can use the returned instance from a tap')
-    ->expect('foo')->toBeString()->toBe('foo')
-    ->tap(function () { return expect($this); })
-    ->toBeInstanceOf(TestCase::class);
+it('can tap into the test')
+    ->expect('foo')->toBeString()
+    ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })
+    ->toBe('foo')
+    ->and('hello world')->toBeString();
 
 afterEach()->assertTrue(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 beforeEach()->assertTrue(true);
 
 it('proxies calls to object')->assertTrue(true);
@@ -8,7 +10,14 @@ it('is capable doing multiple assertions')
     ->assertTrue(true)
     ->assertFalse(false);
 
-//it('can tap into the test')
+it('can tap into the test')
+    ->expect('foo')->toBeString()->toBe('foo')
+    ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })
+    ->and('hello world')->toBeString();
 
+it('can use the returned instance from a tap')
+    ->expect('foo')->toBeString()->toBe('foo')
+    ->tap(function () { return expect($this); })
+    ->toBeInstanceOf(TestCase::class);
 
 afterEach()->assertTrue(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -8,4 +8,7 @@ it('is capable doing multiple assertions')
     ->assertTrue(true)
     ->assertFalse(false);
 
+//it('can tap into the test')
+
+
 afterEach()->assertTrue(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Let's face it, Higher Order tests are the bomb. I love them. But occasionally, I'll need to nip into the test case for something or call a method that can't be called immediately (like the `route` method in Laravel).

This PR adds a new `tap` method, which provides this functionality:

```php
it('can tap into the test')
    ->expect('foo')->toBeString()->toBe('foo')
    ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })
    ->and('hello world')->toBeString();
```

If you return from the `tap` method, you can actually springboard off of that for the rest of the higher order test:

```php
it('can return from a tap')
    ->tap(fn () => expect(route('welcome')))
    ->toStartWith('https://');
```

Excited to hear your thoughts!
