### PR TITLE
add toBeCollection()

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -405,6 +405,16 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is an instance of Illuminate\Support\Collection.
+     */
+    public function toBeCollection(): Expectation
+    {
+        $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is of type bool.
      */
     public function toBeBool(): Expectation

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -183,6 +183,11 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Features\Expect\toBeCollection
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Features\Expect\toBeDirectory
   ✓ pass
   ✓ failures
@@ -579,5 +584,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 363 passed
+  Tests:  4 incompleted, 7 skipped, 366 passed
   

--- a/tests/Features/Expect/toBeCollection.php
+++ b/tests/Features/Expect/toBeCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect(collect([1, 2, 3]))->toBeCollection();
+    expect('1, 2, 3')->not->toBeCollection();
+});
+
+test('failures', function () {
+    expect((object) [])->toBeCollection();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(collect(['a', 'b', 'c']))->not->toBeCollection();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

`expect(...)->toBeCollection();`

instead of

`expect(...)->toBeInstanceOf(\Illuminate\Support\Collection::class);`


I don't think the Pest community would say no to that.

Thanks

