### PR TITLE
Closures passed to the `skip` method are now bound to the test case

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -143,11 +143,9 @@ final class TestCall
             ? $conditionOrMessage
             : $message;
 
-        if ($condition() !== false) {
-            $this->testCaseFactory
-                ->chains
-                ->add(Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
-        }
+        $this->testCaseFactory
+            ->chains
+            ->addWhen($condition, Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
 
         return $this;
     }

--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -81,7 +81,6 @@ final class Coverage implements AddsOutput, HandlesArguments
         }
 
         if ($input->getOption(self::MIN_OPTION) !== null) {
-            /* @phpstan-ignore-next-line */
             $this->coverageMin = (float) $input->getOption(self::MIN_OPTION);
         }
 

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Support;
 
+use Closure;
+use const PHP_MAJOR_VERSION;
 use ReflectionClass;
 use Throwable;
 
@@ -51,6 +53,13 @@ final class HigherOrderMessage
     public $arguments;
 
     /**
+     * An optional condition that will determine if the message will be executed.
+     *
+     * @var callable|null
+     */
+    public $condition = null;
+
+    /**
      * Creates a new higher order message.
      *
      * @param array<int, mixed> $arguments
@@ -70,6 +79,11 @@ final class HigherOrderMessage
      */
     public function call(object $target)
     {
+        /* @phpstan-ignore-next-line */
+        if (is_callable($this->condition) && call_user_func(Closure::bind($this->condition, $target)) === false) {
+            return $target;
+        }
+
         try {
             return Reflection::call($target, $this->methodName, $this->arguments);
         } catch (Throwable $throwable) {
@@ -88,9 +102,16 @@ final class HigherOrderMessage
         }
     }
 
+    public function when(callable $condition): self
+    {
+        $this->condition = $condition;
+
+        return $this;
+    }
+
     private static function getUndefinedMethodMessage(object $target, string $methodName): string
     {
-        if (\PHP_MAJOR_VERSION >= 8) {
+        if (PHP_MAJOR_VERSION >= 8) {
             return sprintf(sprintf(self::UNDEFINED_METHOD, sprintf('%s::%s()', get_class($target), $methodName)));
         }
 

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -55,7 +55,7 @@ final class HigherOrderMessage
     /**
      * An optional condition that will determine if the message will be executed.
      *
-     * @var callable|null
+     * @var callable(): bool|null
      */
     public $condition = null;
 
@@ -102,6 +102,11 @@ final class HigherOrderMessage
         }
     }
 
+    /**
+     * Indicates that this message should only be called when the given condition is true.
+     *
+     * @param callable(): bool $condition
+     */
     public function when(callable $condition): self
     {
         $this->condition = $condition;

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -25,6 +25,16 @@ final class HigherOrderMessageCollection
     }
 
     /**
+     * Adds a new higher order message to the collection if the callable condition is does not return false.
+     *
+     * @param array<int, mixed> $arguments
+     */
+    public function addWhen(callable $condition, string $filename, int $line, string $methodName, array $arguments): void
+    {
+        $this->messages[] = (new HigherOrderMessage($filename, $line, $methodName, $arguments))->when($condition);
+    }
+
+    /**
      * Proxy all the messages starting from the target.
      */
     public function chain(object $target): void

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -1,5 +1,9 @@
 <?php
 
+beforeEach(function () {
+    $this->shouldSkip = true;
+});
+
 it('do not skips')
     ->skip(false)
     ->assertTrue(true);
@@ -31,3 +35,7 @@ it('skips with condition and message')
 it('skips when skip after assertion')
     ->assertTrue(true)
     ->skip();
+
+it('can use something in the test case as a condition')
+    ->skip(function () { return $this->shouldSkip; }, 'This test was skipped')
+    ->assertTrue(false);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -39,3 +39,8 @@ it('skips when skip after assertion')
 it('can use something in the test case as a condition')
     ->skip(function () { return $this->shouldSkip; }, 'This test was skipped')
     ->assertTrue(false);
+
+it('can user higher order callables and skip')
+    ->skip(function () { return $this->shouldSkip; })
+    ->expect(function () { return $this->shouldSkip; })
+    ->toBeFalse();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Hey y'all,

something that came up in the stream yesterday was this:

```php
public function requiresPostgreSQL(): void
{
    if (DB::getDriverName() !== 'pgsql') {
        $this->markTestSkipped('This test requires a PostgreSQL database connection');
    }
}
```

Obviously, this condition requires the test case setup method to already have been run, so you wouldn't be able to write it in Pest's `skip` method. This PR enables this functionality by moving the conditional logic into the HigherOrderMessage itself, and binding the conditional closure to the test case.

```php
it('works when using PostgreSQL', function() {
    expect(true)->toBeTrue();
})->skip(fn() => DB::getDriverName() !== 'pgsql', 'This test requires a PostgreSQL database connection');
```

This feature actually opens up the potential for other bound callable too, because now when adding to a HigherOrderMessage, you can simply use the newly built `when` method and pass a conditional; it will always be bound to the test case.

Kind Regards,
Luke
