### PR TITLE
Allows you to just specify an exception message when calling `throws`.

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -61,9 +61,13 @@ final class TestCall
      */
     public function throws(string $exceptionClass, string $exceptionMessage = null): TestCall
     {
-        $this->testCaseFactory
-            ->proxies
-            ->add(Backtrace::file(), Backtrace::line(), 'expectException', [$exceptionClass]);
+        if (class_exists($exceptionClass)) {
+            $this->testCaseFactory
+                ->proxies
+                ->add(Backtrace::file(), Backtrace::line(), 'expectException', [$exceptionClass]);
+        } else {
+            $exceptionMessage = $exceptionClass;
+        }
 
         if (is_string($exceptionMessage)) {
             $this->testCaseFactory

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -59,14 +59,14 @@ final class TestCall
     /**
      * Asserts that the test throws the given `$exceptionClass` when called.
      */
-    public function throws(string $exceptionClass, string $exceptionMessage = null): TestCall
+    public function throws(string $exception, string $exceptionMessage = null): TestCall
     {
-        if (class_exists($exceptionClass)) {
+        if (class_exists($exception)) {
             $this->testCaseFactory
                 ->proxies
-                ->add(Backtrace::file(), Backtrace::line(), 'expectException', [$exceptionClass]);
+                ->add(Backtrace::file(), Backtrace::line(), 'expectException', [$exception]);
         } else {
-            $exceptionMessage = $exceptionClass;
+            $exceptionMessage = $exception;
         }
 
         if (is_string($exceptionMessage)) {

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -13,3 +13,7 @@ it('catch exceptions', function () {
 it('catch exceptions and messages', function () {
     throw new Exception('Something bad happened');
 })->throws(Exception::class, 'Something bad happened');
+
+it('can just define the message', function () {
+    throw new Exception('Something bad happened');
+})->throws('Something bad happened');


### PR DESCRIPTION
This PR comes from a discussion with @nunomaduro 

It allows for a user to omit the exception type from a `throws` call and just specify an exception message instead:

```php
it('can just define the message', function () {
    throw new Exception('Something bad happened');
})->throws('Something bad happened');
```