### PR TITLE
Better tap type hinting

### DIFF
--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Pest\Expectation;
+use Pest\PendingObjects\TestCall;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
@@ -50,11 +52,9 @@ final class HigherOrderCallables
     }
 
     /**
-     * @template TValue
+     * Tap into the test case to perform an action and return the test case.
      *
-     * @param callable(): TValue $callable
-     *
-     * @return TValue|object
+     * @return TestCall|TestCase|object
      */
     public function tap(callable $callable)
     {

--- a/src/Support/HigherOrderTapProxy.php
+++ b/src/Support/HigherOrderTapProxy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Support;
 
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Throwable;
 
@@ -17,16 +18,14 @@ final class HigherOrderTapProxy
     /**
      * The target being tapped.
      *
-     * @var mixed
+     * @var TestCase
      */
     public $target;
 
     /**
      * Create a new tap proxy instance.
-     *
-     * @param mixed $target
      */
-    public function __construct($target)
+    public function __construct(TestCase $target)
     {
         $this->target = $target;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Previously, calling `tap` in a higher order test would provide no IDE autocomplete suggestions afterwards. This PR resolves that. It also enforces a `TestCase` being passed to the `HigherOrderTapProxy`, because the logic dictates that it would always be a `TestCase` by the time a proxy is resolved.
