### PR TITLE
Adds support for Higher Order Expectations in Higher Order Tests

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -156,11 +156,29 @@ final class TestCall
     }
 
     /**
+     * Saves the property accessors to be used on the target.
+     */
+    public function __get(string $name): self
+    {
+        return $this->addChain($name);
+    }
+
+    /**
      * Saves the calls to be used on the target.
      *
      * @param array<int, mixed> $arguments
      */
     public function __call(string $name, array $arguments): self
+    {
+        return $this->addChain($name, $arguments);
+    }
+
+    /**
+     * Add a chain to the test case factory. Omitting the arguments will treat it as a property accessor.
+     *
+     * @param array<int, mixed>|null $arguments
+     */
+    private function addChain(string $name, array $arguments = null): self
     {
         $this->testCaseFactory
             ->chains
@@ -171,7 +189,9 @@ final class TestCall
             if ($this->testCaseFactory->description !== null) {
                 $this->testCaseFactory->description .= ' → ';
             }
-            $this->testCaseFactory->description .= sprintf('%s %s', $name, $exporter->shortenedRecursiveExport($arguments));
+            $this->testCaseFactory->description .= $arguments === null
+                ? $name
+                : sprintf('%s %s', $name, $exporter->shortenedRecursiveExport($arguments));
         }
 
         return $this;

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -17,21 +17,21 @@ final class HigherOrderMessageCollection
     /**
      * Adds a new higher order message to the collection.
      *
-     * @param array<int, mixed> $arguments
+     * @param array<int, mixed>|null $arguments
      */
-    public function add(string $filename, int $line, string $methodName, array $arguments): void
+    public function add(string $filename, int $line, string $name, array $arguments = null): void
     {
-        $this->messages[] = new HigherOrderMessage($filename, $line, $methodName, $arguments);
+        $this->messages[] = new HigherOrderMessage($filename, $line, $name, $arguments);
     }
 
     /**
      * Adds a new higher order message to the collection if the callable condition is does not return false.
      *
-     * @param array<int, mixed> $arguments
+     * @param array<int, mixed>|null $arguments
      */
-    public function addWhen(callable $condition, string $filename, int $line, string $methodName, array $arguments): void
+    public function addWhen(callable $condition, string $filename, int $line, string $name, array $arguments = null): void
     {
-        $this->messages[] = (new HigherOrderMessage($filename, $line, $methodName, $arguments))->when($condition);
+        $this->messages[] = (new HigherOrderMessage($filename, $line, $name, $arguments))->when($condition);
     }
 
     /**

--- a/tests/Features/Expect/HigherOrder/methods.php
+++ b/tests/Features/Expect/HigherOrder/methods.php
@@ -67,6 +67,13 @@ it('can handle nested method calls', function () {
         ->books()->each->toBeArray();
 });
 
+it('works with higher order tests')
+    ->expect(new HasMethods())
+    ->newInstance()->newInstance()->name()->toEqual('Has Methods')->toBeString()
+    ->newInstance()->name()->toEqual('Has Methods')->not->toBeArray
+    ->name()->toEqual('Has Methods')
+    ->books()->each->toBeArray;
+
 class HasMethods
 {
     public function name()

--- a/tests/Features/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Features/Expect/HigherOrder/methodsAndProperties.php
@@ -22,6 +22,13 @@ it('can handle nested methods and properties', function () {
         ->newInstance()->books()->toBeArray();
 });
 
+it('works with higher order tests')
+    ->expect(new HasMethodsAndProperties())
+    ->meta->foo->bar->toBeString()->toEqual('baz')->not->toBeInt
+    ->newInstance()->meta->foo->toBeArray
+    ->newInstance()->multiply(2, 2)->toEqual(4)->not->toEqual(5)
+    ->newInstance()->books()->toBeArray();
+
 it('can start a new higher order expectation using the and syntax', function () {
     expect(new HasMethodsAndProperties())
         ->toBeInstanceOf(HasMethodsAndProperties::class)
@@ -32,6 +39,14 @@ it('can start a new higher order expectation using the and syntax', function () 
 
     expect(static::getCount())->toEqual(4);
 });
+
+it('can start a new higher order expectation using the and syntax in higher order tests')
+    ->expect(new HasMethodsAndProperties())
+    ->toBeInstanceOf(HasMethodsAndProperties::class)
+    ->meta->toBeArray
+    ->and(['foo' => 'bar'])
+    ->toBeArray()
+    ->foo->toEqual('bar');
 
 class HasMethodsAndProperties
 {

--- a/tests/Features/Expect/HigherOrder/properties.php
+++ b/tests/Features/Expect/HigherOrder/properties.php
@@ -64,6 +64,11 @@ it('works with nested properties', function () {
         ->posts->toBeArray()->toHaveCount(2);
 });
 
+it('works with higher order tests')
+    ->expect(new HasProperties())
+    ->nested->foo->bar->toBeString()->toEqual('baz')
+    ->posts->toBeArray()->toHaveCount(2);
+
 class HasProperties
 {
     public $name = 'foo';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Alrighty,

Up until now, Higher Order Expectations weren't possible in Higher Order Tests. This is because the TestCall had no idea how to handle properties. It also meant that property style expectations didn't work (eg: `expect('foo')->toBeString`).

This PR adds full support for property access in Higher Order Tests, allowing for tests to be written like this:

```php
it('can start a new higher order expectation using the and syntax in higher order tests')
    ->expect(new HasMethodsAndProperties())
    ->toBeInstanceOf(HasMethodsAndProperties::class)
    ->meta->toBeArray
    ->and(['foo' => 'bar'])
    ->toBeArray()
    ->foo->toEqual('bar');
```

Happy Friday!

Luke
