### PR TITLE
Forces higher order test callable expects to be closures

### DIFF
--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Support;
 
+use Closure;
 use Pest\Expectation;
 use Pest\PendingObjects\TestCall;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +35,7 @@ final class HigherOrderCallables
      */
     public function expect($value)
     {
-        return new Expectation(is_callable($value) ? Reflection::bindCallable($value) : $value);
+        return new Expectation($value instanceof Closure ? Reflection::bindCallable($value) : $value);
     }
 
     /**

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -18,6 +18,9 @@ it('resolves expect callables correctly')
     ->toBeString()
     ->toBe('bar');
 
+test('does not treat method names as callables')
+    ->expect('it')->toBeString();
+
 it('can tap into the test')
     ->expect('foo')->toBeString()
     ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #343

In the case that the value passed to your `expect` method in higher order tests was an existing function name, the test would fail because that string was callable and the logic used the `is_callable` function. This instead ensures that the value is a `Closure` before treating it as one and binding it to the class.