### PR TITLE
Fixes the assertion output showing as 0 in the TeamCity logger

### DIFF
--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Logging;
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\PhptTestCase;
 use function getmypid;
 use Pest\Concerns\Testable;
 use PHPUnit\Framework\AssertionFailedError;
@@ -135,6 +137,12 @@ final class TeamCity extends DefaultResultPrinter
             $this->phpunitTeamCity->endTest($test, $time);
 
             return;
+        }
+
+        if ($test instanceof TestCase) {
+            $this->numAssertions += $test->getNumAssertions();
+        } elseif ($test instanceof PhptTestCase) {
+            $this->numAssertions++;
         }
 
         $this->printEvent('testFinished', [

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Pest\Logging;
 
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\PhptTestCase;
 use function getmypid;
 use Pest\Concerns\Testable;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
+use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\DefaultResultPrinter;
 use function round;
 use function str_replace;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Previously, PhpUnit would show 0 assertions when using the TeamCity test runner:

<img width="456" alt="Screenshot 2021-07-16 at 13 11 34" src="https://user-images.githubusercontent.com/12202279/125945388-590850a5-0313-41f4-a2a7-430e6f4c698a.png">

This was caused by the custom `endTest` method not adding the number of assertions to the logger.

This PR rectifies this:

<img width="456" alt="Screenshot 2021-07-16 at 13 11 45" src="https://user-images.githubusercontent.com/12202279/125945487-88fe0430-dc4e-45ad-a7de-04cc7ceb9310.png">

