### PR TITLE
Teamcity styling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "scripts": {
         "lint": "php-cs-fixer fix -v",
         "test:lint": "php-cs-fixer fix -v --dry-run",
-        "test:types": "phpstan analyse --ansi --memory-limit=0",
+        "test:types": "phpstan analyse --ansi --memory-limit=-1",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration",
         "test:integration": "php bin/pest --colors=always --group=integration",
         "update:snapshots": "REBUILD_SNAPSHOTS=true php bin/pest --colors=always",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.3 || ^8.0",
         "nunomaduro/collision": "^5.4.0",
         "pestphp/pest-plugin": "^1.0.0",
-        "phpunit/phpunit": "^9.3.7"
+        "phpunit/phpunit": "^9.5.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Actions/AddsDefaults.php
+++ b/src/Actions/AddsDefaults.php
@@ -30,7 +30,7 @@ final class AddsDefaults
         }
 
         if ($arguments[self::PRINTER] === \PHPUnit\Util\Log\TeamCity::class) {
-            $arguments[self::PRINTER] = new TeamCity(null, $arguments['verbose'] ?? false, $arguments['colors'] ?? DefaultResultPrinter::COLOR_ALWAYS);
+            $arguments[self::PRINTER] = new TeamCity($arguments['verbose'] ?? false, $arguments['colors'] ?? DefaultResultPrinter::COLOR_ALWAYS);
         }
 
         // Load our junit logger instead.

--- a/src/Actions/AddsDefaults.php
+++ b/src/Actions/AddsDefaults.php
@@ -30,7 +30,7 @@ final class AddsDefaults
         }
 
         if ($arguments[self::PRINTER] === \PHPUnit\Util\Log\TeamCity::class) {
-            $arguments[self::PRINTER] = new TeamCity($arguments['verbose'] ?? false, $arguments['colors'] ?? DefaultResultPrinter::COLOR_ALWAYS);
+            $arguments[self::PRINTER] = new TeamCity(null, $arguments['verbose'] ?? false, $arguments['colors'] ?? DefaultResultPrinter::COLOR_ALWAYS);
         }
 
         // Load our junit logger instead.

--- a/src/Concerns/Logging/WritesToConsole.php
+++ b/src/Concerns/Logging/WritesToConsole.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Concerns\Logging;
+
+/**
+ * @internal
+ */
+trait WritesToConsole
+{
+    private function writeSuccess(string $message): void
+    {
+        $this->writePestTestOutput($message, 'fg-green, bold', '✓');
+    }
+
+    private function writeError(string $message): void
+    {
+        $this->writePestTestOutput($message, 'fg-red, bold', '⨯');
+    }
+
+    private function writeWarning(string $message): void
+    {
+        $this->writePestTestOutput($message, 'fg-yellow, bold', '-');
+    }
+
+    private function writePestTestOutput(string $message, string $color, string $symbol): void
+    {
+        $this->writeWithColor($color, "$symbol ", false);
+        $this->write($message);
+        $this->writeNewLine();
+    }
+}

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pest\Logging;
 
-use ReflectionClass;
-use ReflectionProperty;
 use function getmypid;
 use Pest\Concerns\Testable;
 use function Pest\version;
@@ -17,6 +15,7 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\DefaultResultPrinter;
+use ReflectionProperty;
 use function round;
 use function str_replace;
 use function strlen;
@@ -309,6 +308,10 @@ final class TeamCity extends DefaultResultPrinter
 
     private function removePestFromStackTrace(Throwable $e): void
     {
+        if (!property_exists($e, 'serializableTrace')) {
+            return;
+        }
+
         $property = new ReflectionProperty($e, 'serializableTrace');
         $property->setAccessible(true);
         $trace = $property->getValue($e);

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -249,9 +249,7 @@ final class TeamCity extends DefaultResultPrinter
     public function endTest(Test $test, float $time): void
     {
         if (!TeamCity::isPestTest($test)) {
-            $this->phpunitTeamCity->endTest($test, $time);
-
-            return;
+            parent::endTest($test, $time);
         }
 
         $this->printEvent('testFinished', [

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -42,17 +42,10 @@ final class TeamCity extends DefaultResultPrinter
     /**
      * @param resource|string|null $out
      */
-    public function __construct($out, bool $verbose, string $colors)
+    public function __construct(bool $verbose, string $colors)
     {
-        parent::__construct($out, $verbose, $colors, false, 80, false);
-        $this->phpunitTeamCity = new \PHPUnit\Util\Log\TeamCity(
-            $out,
-            $verbose,
-            $colors,
-            false,
-            80,
-            false
-        );
+        parent::__construct(null, $verbose, $colors);
+        $this->phpunitTeamCity = new \PHPUnit\Util\Log\TeamCity(null, $verbose, $colors);
 
         $this->logo();
     }

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -168,7 +168,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     private function printEvent(string $eventName, array $params = []): void
     {
-        $this->write("\n##teamcity[{$eventName}");
+        $this->write("##teamcity[{$eventName}");
 
         if ($this->flowId !== 0) {
             $params['flowId'] = $this->flowId;

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -122,6 +122,8 @@ final class TeamCity extends DefaultResultPrinter
             $this->writeWithColor('fg-white, bold', '  ' . $suite->getName());
         }
 
+        $this->writeNewLine();
+
         $this->flowId = (int) getmypid();
 
         if (!$this->isSummaryTestCountPrinted) {
@@ -254,6 +256,8 @@ final class TeamCity extends DefaultResultPrinter
         if (!$this->lastTestFailed) {
             $this->writePestTestOutput($test->getName(), 'fg-green, bold', '✓');
         }
+
+        $this->writeNewLine();
 
         if ($test instanceof TestCase) {
             $this->numAssertions += $test->getNumAssertions();

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -37,7 +37,12 @@ final class TeamCity extends DefaultResultPrinter
     /** @var \PHPUnit\Util\Log\TeamCity */
     private $phpunitTeamCity;
 
-    /** @var array<callable> */
+    /**
+     * A stack of error messages and test failures to be displayed
+     * once the test suite has finished running.
+     *
+     * @var array<callable>
+     */
     protected $outputStack = [];
 
     public function __construct(bool $verbose, string $colors)
@@ -55,6 +60,9 @@ final class TeamCity extends DefaultResultPrinter
         $this->logo();
     }
 
+    /**
+     * Outputs Pest's logo and version number at the top of the output.
+     */
     private function logo(): void
     {
         $this->writeNewLine();
@@ -72,7 +80,7 @@ final class TeamCity extends DefaultResultPrinter
     public function startTestSuite(TestSuite $suite): void
     {
         if (str_starts_with($suite->getName(), 'P\\')) {
-            $this->writeWithColor('bg-white, fg-black, bold', ' ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
+            $this->writeWithColor('fg-white, bold', ' ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
         }
 
         $this->flowId = (int) getmypid();

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -119,6 +119,8 @@ final class TeamCity extends DefaultResultPrinter
     {
         if (static::isPestTestSuite($suite)) {
             $this->writeWithColor('fg-white, bold', '  '.substr_replace($suite->getName(), '', 0, 2).' ');
+        } else {
+            $this->writeWithColor('fg-white, bold', '  '.$suite->getName());
         }
 
         $this->flowId = (int) getmypid();
@@ -194,6 +196,8 @@ final class TeamCity extends DefaultResultPrinter
     public function endTestSuite(TestSuite $suite): void
     {
         $suiteName = $suite->getName();
+
+        $this->writeNewLine();
         $this->writeNewLine();
 
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -22,11 +22,11 @@ use Throwable;
 
 final class TeamCity extends DefaultResultPrinter
 {
-    private const PROTOCOL = 'pest_qn://';
-    private const NAME = 'name';
-    private const LOCATION_HINT = 'locationHint';
-    private const DURATION = 'duration';
-    private const TEST_SUITE_STARTED = 'testSuiteStarted';
+    private const PROTOCOL            = 'pest_qn://';
+    private const NAME                = 'name';
+    private const LOCATION_HINT       = 'locationHint';
+    private const DURATION            = 'duration';
+    private const TEST_SUITE_STARTED  = 'testSuiteStarted';
     private const TEST_SUITE_FINISHED = 'testSuiteFinished';
 
     /** @var int */
@@ -39,7 +39,7 @@ final class TeamCity extends DefaultResultPrinter
     private $phpunitTeamCity;
 
     /**
-     * @param  resource|string|null  $out
+     * @param resource|string|null $out
      */
     public function __construct($out, bool $verbose, string $colors)
     {
@@ -59,7 +59,7 @@ final class TeamCity extends DefaultResultPrinter
     private function logo(): void
     {
         $this->writeNewLine();
-        $this->write('Pest '.version());
+        $this->write('Pest ' . version());
         $this->writeNewLine();
     }
 
@@ -73,12 +73,12 @@ final class TeamCity extends DefaultResultPrinter
         $this->writeProgress('Tests:  ');
 
         $results = [
-            'failed' => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
-            'skipped' => ['count' => $result->skippedCount(), 'color' => 'fg-cyan'],
-            'warned' => ['count' => $result->warningCount(), 'color' => 'fg-cyan'],
-            'risked' => ['count' => $result->riskyCount(), 'color' => 'fg-cyan'],
+            'failed'     => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
+            'skipped'    => ['count' => $result->skippedCount(), 'color' => 'fg-cyan'],
+            'warned'     => ['count' => $result->warningCount(), 'color' => 'fg-cyan'],
+            'risked'     => ['count' => $result->riskyCount(), 'color' => 'fg-cyan'],
             'incomplete' => ['count' => $result->notImplementedCount(), 'color' => 'fg-cyan'],
-            'passed' => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
+            'passed'     => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
         ];
 
         $filteredResults = array_filter($results, function ($item): bool {
@@ -86,7 +86,7 @@ final class TeamCity extends DefaultResultPrinter
         });
 
         foreach ($filteredResults as $key => $info) {
-            $this->writeProgressWithColor($info['color'], $info['count']." $key");
+            $this->writeProgressWithColor($info['color'], $info['count'] . " $key");
 
             if ($key !== array_reverse(array_keys($filteredResults))[0]) {
                 $this->write(', ');
@@ -117,9 +117,9 @@ final class TeamCity extends DefaultResultPrinter
     public function startTestSuite(TestSuite $suite): void
     {
         if (static::isPestTestSuite($suite)) {
-            $this->writeWithColor('fg-white, bold', '  '.substr_replace($suite->getName(), '', 0, 2).' ');
+            $this->writeWithColor('fg-white, bold', '  ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
         } else {
-            $this->writeWithColor('fg-white, bold', '  '.$suite->getName());
+            $this->writeWithColor('fg-white, bold', '  ' . $suite->getName());
         }
 
         $this->flowId = (int) getmypid();
@@ -137,8 +137,8 @@ final class TeamCity extends DefaultResultPrinter
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {
             $this->printEvent(
                 self::TEST_SUITE_STARTED, [
-                self::NAME => $suiteName,
-                self::LOCATION_HINT => self::PROTOCOL.$suiteName,
+                self::NAME          => $suiteName,
+                self::LOCATION_HINT => self::PROTOCOL . $suiteName,
             ]);
 
             return;
@@ -148,15 +148,15 @@ final class TeamCity extends DefaultResultPrinter
 
         $this->printEvent(
             self::TEST_SUITE_STARTED, [
-            self::NAME => substr($suiteName, 2),
-            self::LOCATION_HINT => self::PROTOCOL.$fileName,
+            self::NAME          => substr($suiteName, 2),
+            self::LOCATION_HINT => self::PROTOCOL . $fileName,
         ]);
     }
 
     /**
      * Verify that the given test suite is a valid Pest suite.
      *
-     * @param  TestSuite<Test>  $suite
+     * @param TestSuite<Test> $suite
      */
     private static function isPestTestSuite(TestSuite $suite): bool
     {
@@ -164,7 +164,7 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param  array<string, string|int>  $params
+     * @param array<string, string|int> $params
      */
     private function printEvent(string $eventName, array $params = []): void
     {
@@ -202,8 +202,8 @@ final class TeamCity extends DefaultResultPrinter
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {
             $this->printEvent(
                 self::TEST_SUITE_FINISHED, [
-                self::NAME => $suiteName,
-                self::LOCATION_HINT => self::PROTOCOL.$suiteName,
+                self::NAME          => $suiteName,
+                self::LOCATION_HINT => self::PROTOCOL . $suiteName,
             ]);
 
             return;
@@ -216,7 +216,7 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param  Test|Testable  $test
+     * @param Test|Testable $test
      */
     public function startTest(Test $test): void
     {
@@ -229,7 +229,7 @@ final class TeamCity extends DefaultResultPrinter
         $this->printEvent('testStarted', [
             self::NAME => $test->getName(),
             // @phpstan-ignore-next-line
-            self::LOCATION_HINT => self::PROTOCOL.$test->toString(),
+            self::LOCATION_HINT => self::PROTOCOL . $test->toString(),
         ]);
     }
 
@@ -242,12 +242,12 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param  Test|Testable  $test
+     * @param Test|Testable $test
      */
     public function endTest(Test $test, float $time): void
     {
         $this->printEvent('testFinished', [
-            self::NAME => $test->getName(),
+            self::NAME     => $test->getName(),
             self::DURATION => self::toMilliseconds($time),
         ]);
 
@@ -281,7 +281,7 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param  Test|Testable  $test
+     * @param Test|Testable $test
      */
     public function addError(Test $test, Throwable $t, float $time): void
     {
@@ -302,7 +302,7 @@ final class TeamCity extends DefaultResultPrinter
     /**
      * @phpstan-ignore-next-line
      *
-     * @param  Test|Testable  $test
+     * @param Test|Testable $test
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -22,11 +22,11 @@ use Throwable;
 
 final class TeamCity extends DefaultResultPrinter
 {
-    private const PROTOCOL            = 'pest_qn://';
-    private const NAME                = 'name';
-    private const LOCATION_HINT       = 'locationHint';
-    private const DURATION            = 'duration';
-    private const TEST_SUITE_STARTED  = 'testSuiteStarted';
+    private const PROTOCOL = 'pest_qn://';
+    private const NAME = 'name';
+    private const LOCATION_HINT = 'locationHint';
+    private const DURATION = 'duration';
+    private const TEST_SUITE_STARTED = 'testSuiteStarted';
     private const TEST_SUITE_FINISHED = 'testSuiteFinished';
 
     /** @var int */
@@ -39,7 +39,7 @@ final class TeamCity extends DefaultResultPrinter
     private $phpunitTeamCity;
 
     /**
-     * @param resource|string|null $out
+     * @param  resource|string|null  $out
      */
     public function __construct($out, bool $verbose, string $colors)
     {
@@ -59,7 +59,7 @@ final class TeamCity extends DefaultResultPrinter
     private function logo(): void
     {
         $this->writeNewLine();
-        $this->write('Pest ' . version());
+        $this->write('Pest '.version());
         $this->writeNewLine();
     }
 
@@ -74,12 +74,12 @@ final class TeamCity extends DefaultResultPrinter
         $this->writeProgress('Tests:  ');
 
         $results = [
-            'failed'     => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
-            'skipped'    => ['count' => $result->skippedCount(), 'color' => 'fg-cyan'],
-            'warned'     => ['count' => $result->warningCount(), 'color' => 'fg-cyan'],
-            'risked'     => ['count' => $result->riskyCount(), 'color' => 'fg-cyan'],
+            'failed' => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
+            'skipped' => ['count' => $result->skippedCount(), 'color' => 'fg-cyan'],
+            'warned' => ['count' => $result->warningCount(), 'color' => 'fg-cyan'],
+            'risked' => ['count' => $result->riskyCount(), 'color' => 'fg-cyan'],
             'incomplete' => ['count' => $result->notImplementedCount(), 'color' => 'fg-cyan'],
-            'passed'     => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
+            'passed' => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
         ];
 
         $filteredResults = array_filter($results, function ($item): bool {
@@ -87,7 +87,7 @@ final class TeamCity extends DefaultResultPrinter
         });
 
         foreach ($filteredResults as $key => $info) {
-            $this->writeProgressWithColor($info['color'], $info['count'] . " $key");
+            $this->writeProgressWithColor($info['color'], $info['count']." $key");
 
             if ($key !== array_reverse(array_keys($filteredResults))[0]) {
                 $this->write(', ');
@@ -118,9 +118,7 @@ final class TeamCity extends DefaultResultPrinter
     public function startTestSuite(TestSuite $suite): void
     {
         if (static::isPestTestSuite($suite)) {
-            $this->writeWithColor('fg-white, bold', '  ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
-        } else {
-            $this->writeWithColor('fg-white, bold', '  ' . $suite->getName());
+            $this->writeWithColor('fg-white, bold', '  '.substr_replace($suite->getName(), '', 0, 2).' ');
         }
 
         $this->flowId = (int) getmypid();
@@ -138,8 +136,8 @@ final class TeamCity extends DefaultResultPrinter
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {
             $this->printEvent(
                 self::TEST_SUITE_STARTED, [
-                self::NAME          => $suiteName,
-                self::LOCATION_HINT => self::PROTOCOL . $suiteName,
+                self::NAME => $suiteName,
+                self::LOCATION_HINT => self::PROTOCOL.$suiteName,
             ]);
 
             return;
@@ -149,15 +147,15 @@ final class TeamCity extends DefaultResultPrinter
 
         $this->printEvent(
             self::TEST_SUITE_STARTED, [
-            self::NAME          => substr($suiteName, 2),
-            self::LOCATION_HINT => self::PROTOCOL . $fileName,
+            self::NAME => substr($suiteName, 2),
+            self::LOCATION_HINT => self::PROTOCOL.$fileName,
         ]);
     }
 
     /**
      * Verify that the given test suite is a valid Pest suite.
      *
-     * @param TestSuite<Test> $suite
+     * @param  TestSuite<Test>  $suite
      */
     private static function isPestTestSuite(TestSuite $suite): bool
     {
@@ -165,7 +163,7 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param array<string, string|int> $params
+     * @param  array<string, string|int>  $params
      */
     private function printEvent(string $eventName, array $params = []): void
     {
@@ -196,16 +194,13 @@ final class TeamCity extends DefaultResultPrinter
     public function endTestSuite(TestSuite $suite): void
     {
         $suiteName = $suite->getName();
-
-        if (static::isPestTestSuite($suite)) {
-            $this->writeNewLine();
-        }
+        $this->writeNewLine();
 
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {
             $this->printEvent(
                 self::TEST_SUITE_FINISHED, [
-                self::NAME          => $suiteName,
-                self::LOCATION_HINT => self::PROTOCOL . $suiteName,
+                self::NAME => $suiteName,
+                self::LOCATION_HINT => self::PROTOCOL.$suiteName,
             ]);
 
             return;
@@ -215,12 +210,10 @@ final class TeamCity extends DefaultResultPrinter
             self::TEST_SUITE_FINISHED, [
             self::NAME => substr($suiteName, 2),
         ]);
-
-        $this->writeNewLine();
     }
 
     /**
-     * @param Test|Testable $test
+     * @param  Test|Testable  $test
      */
     public function startTest(Test $test): void
     {
@@ -233,7 +226,7 @@ final class TeamCity extends DefaultResultPrinter
         $this->printEvent('testStarted', [
             self::NAME => $test->getName(),
             // @phpstan-ignore-next-line
-            self::LOCATION_HINT => self::PROTOCOL . $test->toString(),
+            self::LOCATION_HINT => self::PROTOCOL.$test->toString(),
         ]);
     }
 
@@ -246,12 +239,12 @@ final class TeamCity extends DefaultResultPrinter
     }
 
     /**
-     * @param Test|Testable $test
+     * @param  Test|Testable  $test
      */
     public function endTest(Test $test, float $time): void
     {
         $this->printEvent('testFinished', [
-            self::NAME     => $test->getName(),
+            self::NAME => $test->getName(),
             self::DURATION => self::toMilliseconds($time),
         ]);
 
@@ -268,6 +261,11 @@ final class TeamCity extends DefaultResultPrinter
         $this->lastTestFailed = false;
     }
 
+    private static function toMilliseconds(float $time): int
+    {
+        return (int) round($time * 1000);
+    }
+
     private function writePestTestOutput(string $message, string $color, string $symbol, string $suffix = null): void
     {
         $this->writeProgressWithColor($color, "$symbol ");
@@ -279,13 +277,8 @@ final class TeamCity extends DefaultResultPrinter
         }
     }
 
-    private static function toMilliseconds(float $time): int
-    {
-        return (int) round($time * 1000);
-    }
-
     /**
-     * @param Test|Testable $test
+     * @param  Test|Testable  $test
      */
     public function addError(Test $test, Throwable $t, float $time): void
     {
@@ -306,7 +299,7 @@ final class TeamCity extends DefaultResultPrinter
     /**
      * @phpstan-ignore-next-line
      *
-     * @param Test|Testable $test
+     * @param  Test|Testable  $test
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -294,10 +294,10 @@ final class TeamCity extends DefaultResultPrinter
 
         $results = [
             'failed'     => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
-            'skipped'    => ['count' => $result->skippedCount(), 'color' => 'fg-yellow'],
-            'warned'     => ['count' => $result->warningCount(), 'color' => 'fg-yellow'],
-            'risked'     => ['count' => $result->riskyCount(), 'color' => 'fg-yellow'],
-            'incomplete' => ['count' => $result->notImplementedCount(), 'color' => 'fg-yellow'],
+            'skipped'    => ['count' => $result->skippedCount(), 'color' => 'fg-cyan'],
+            'warned'     => ['count' => $result->warningCount(), 'color' => 'fg-cyan'],
+            'risked'     => ['count' => $result->riskyCount(), 'color' => 'fg-cyan'],
+            'incomplete' => ['count' => $result->notImplementedCount(), 'color' => 'fg-cyan'],
             'passed'     => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
         ];
 

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -118,7 +118,7 @@ final class TeamCity extends DefaultResultPrinter
     {
         if (static::isPestTestSuite($suite)) {
             $this->writeWithColor('fg-white, bold', '  '.substr_replace($suite->getName(), '', 0, 2).' ');
-        } elseif ($suite->count() === 1) {
+        } else {
             $this->writeWithColor('fg-white, bold', '  '.$suite->getName());
         }
 

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -119,6 +119,8 @@ final class TeamCity extends DefaultResultPrinter
     {
         if (static::isPestTestSuite($suite)) {
             $this->writeWithColor('fg-white, bold', '  ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
+        } else {
+            $this->writeWithColor('fg-white, bold', '  ' . $suite->getName());
         }
 
         $this->flowId = (int) getmypid();

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -70,7 +70,6 @@ final class TeamCity extends DefaultResultPrinter
 
     protected function printFooter(TestResult $result): void
     {
-        $this->writeNewLine();
         $this->writeProgress('Tests:  ');
 
         $results = [

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -31,6 +31,8 @@ final class TeamCity extends DefaultResultPrinter
     private const TEST_SUITE_STARTED  = 'testSuiteStarted';
     private const TEST_SUITE_FINISHED = 'testSuiteFinished';
     private const TEST_COUNT          = 'testCount';
+    private const TEST_STARTED        = 'testStarted';
+    private const TEST_FINISHED       = 'testFinished';
 
     /** @var int */
     private $flowId;
@@ -187,7 +189,7 @@ final class TeamCity extends DefaultResultPrinter
             return;
         }
 
-        $this->printEvent('testStarted', [
+        $this->printEvent(self::TEST_STARTED, [
             self::NAME => $test->getName(),
             // @phpstan-ignore-next-line
             self::LOCATION_HINT => self::PROTOCOL . $test->toString(),
@@ -227,7 +229,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function endTest(Test $test, float $time): void
     {
-        $this->printEvent('testFinished', [
+        $this->printEvent(self::TEST_FINISHED, [
             self::NAME     => $test->getName(),
             self::DURATION => self::toMilliseconds($time),
         ]);

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -60,9 +60,6 @@ final class TeamCity extends DefaultResultPrinter
         $this->logo();
     }
 
-    /**
-     * Outputs Pest's logo and version number at the top of the output.
-     */
     private function logo(): void
     {
         $this->writeNewLine();

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -118,7 +118,7 @@ final class TeamCity extends DefaultResultPrinter
     {
         if (static::isPestTestSuite($suite)) {
             $this->writeWithColor('fg-white, bold', '  '.substr_replace($suite->getName(), '', 0, 2).' ');
-        } else {
+        } elseif ($suite->count() === 1) {
             $this->writeWithColor('fg-white, bold', '  '.$suite->getName());
         }
 

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -71,7 +71,7 @@ final class TeamCity extends DefaultResultPrinter
     /** @phpstan-ignore-next-line */
     public function startTestSuite(TestSuite $suite): void
     {
-        if (!str_contains($suite->getName(), '.php')) {
+        if (str_starts_with($suite->getName(), 'P\\')) {
             $this->writeWithColor('bg-white, fg-black, bold', ' ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
         }
 
@@ -110,6 +110,10 @@ final class TeamCity extends DefaultResultPrinter
     public function endTestSuite(TestSuite $suite): void
     {
         $suiteName = $suite->getName();
+
+        if (str_starts_with($suiteName, 'P\\')) {
+            $this->writeNewLine();
+        }
 
         if (file_exists($suiteName) || !method_exists($suiteName, '__getFileName')) {
             $this->printEvent(

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -77,7 +77,7 @@ final class TeamCity extends DefaultResultPrinter
     public function startTestSuite(TestSuite $suite): void
     {
         if (str_starts_with($suite->getName(), 'P\\')) {
-            $this->writeWithColor('fg-white, bold', ' ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
+            $this->writeWithColor('fg-white, bold', '  ' . substr_replace($suite->getName(), '', 0, 2) . ' ');
         }
 
         $this->flowId = (int) getmypid();

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -250,10 +250,6 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function endTest(Test $test, float $time): void
     {
-        if (!TeamCity::isPestTest($test)) {
-            parent::endTest($test, $time);
-        }
-
         $this->printEvent('testFinished', [
             self::NAME     => $test->getName(),
             self::DURATION => self::toMilliseconds($time),

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -213,6 +213,8 @@ final class TeamCity extends DefaultResultPrinter
             self::TEST_SUITE_FINISHED, [
             self::NAME => substr($suiteName, 2),
         ]);
+
+        $this->writeNewLine();
     }
 
     /**

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -333,6 +333,8 @@ final class TeamCity extends DefaultResultPrinter
     public function addWarning(Test $test, Warning $e, float $time): void
     {
         $this->lastTestFailed = true;
+
+        $this->removePestFromStackTrace($e);
         $this->writeWarning($test, $e);
     }
 
@@ -344,18 +346,24 @@ final class TeamCity extends DefaultResultPrinter
     public function addIncompleteTest(Test $test, Throwable $t, float $time): void
     {
         $this->lastTestFailed = true;
+
+        $this->removePestFromStackTrace($t);
         $this->writeWarning($test, $t);
     }
 
     public function addRiskyTest(Test $test, Throwable $t, float $time): void
     {
         $this->lastTestFailed = true;
+
+        $this->removePestFromStackTrace($t);
         $this->writeWarning($test, $t);
     }
 
     public function addSkippedTest(Test $test, Throwable $t, float $time): void
     {
         $this->lastTestFailed = true;
+
+        $this->removePestFromStackTrace($t);
         $this->writeWarning($test, $t);
         $this->phpunitTeamCity->printIgnoredTest($test->getName(), $t, $time);
     }

--- a/src/Support/ExceptionTrace.php
+++ b/src/Support/ExceptionTrace.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Closure;
+use ReflectionProperty;
 use Throwable;
 
 /**
@@ -35,5 +36,31 @@ final class ExceptionTrace
 
             throw $throwable;
         }
+    }
+
+    /**
+     * Removes any item from the stack trace referencing Pest so as not to
+     * crowd the error log for the end user.
+     */
+    public static function removePestReferences(Throwable $t): void
+    {
+        if (!property_exists($t, 'serializableTrace')) {
+            return;
+        }
+
+        $property = new ReflectionProperty($t, 'serializableTrace');
+        $property->setAccessible(true);
+        $trace = $property->getValue($t);
+
+        $cleanedTrace = [];
+        foreach ($trace as $item) {
+            if (key_exists('file', $item) && mb_strpos($item['file'], 'vendor/pestphp/pest/') > 0) {
+                continue;
+            }
+
+            $cleanedTrace[] = $item;
+        }
+
+        $property->setValue($t, $cleanedTrace);
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -578,6 +578,9 @@
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
 
+   PASS  Tests\Visual\JUnit
+  ✓ it is can successfully call all public methods
+
    PASS  Tests\Visual\SingleTestOrDirectory
   ✓ allows to run a single test
   ✓ allows to run a directory
@@ -586,6 +589,9 @@
 
    WARN  Tests\Visual\Success
   - visual snapshot of test suite on success
+
+   PASS  Tests\Visual\TeamCity
+  ✓ it is can successfully call all public methods
 
    PASS  Tests\Features\Depends
   ✓ first
@@ -601,5 +607,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 381 passed
+  Tests:  4 incompleted, 9 skipped, 383 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -585,6 +585,9 @@
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
 
+   PASS  Tests\Visual\JUnit
+  ✓ it is can successfully call all public methods
+
    PASS  Tests\Visual\SingleTestOrDirectory
   ✓ allows to run a single test
   ✓ allows to run a directory
@@ -593,6 +596,9 @@
 
    WARN  Tests\Visual\Success
   - visual snapshot of test suite on success
+
+   PASS  Tests\Visual\TeamCity
+  ✓ it is can successfully call all public methods
 
    PASS  Tests\Features\Depends
   ✓ first
@@ -608,5 +614,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 388 passed
+  Tests:  4 incompleted, 9 skipped, 390 passed
   

--- a/tests/Features/Expect/json.php
+++ b/tests/Features/Expect/json.php
@@ -9,6 +9,11 @@ test('it properly parses json string', function () {
         ->toBe('uno');
 });
 
+it('is incomplete');
+
+it('doesnt do anything', function () {
+});
+
 test('fails with broken json string', function () {
     expect('{":"Nuno"}')->json();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/json.php
+++ b/tests/Features/Expect/json.php
@@ -6,7 +6,7 @@ test('it properly parses json string', function () {
     expect('{"name":"Nuno"}')
         ->json()
         ->name
-        ->toBe('Nuno');
+        ->toBe('uno');
 });
 
 test('fails with broken json string', function () {

--- a/tests/Features/Expect/json.php
+++ b/tests/Features/Expect/json.php
@@ -6,12 +6,7 @@ test('it properly parses json string', function () {
     expect('{"name":"Nuno"}')
         ->json()
         ->name
-        ->toBe('uno');
-});
-
-it('is incomplete');
-
-it('doesnt do anything', function () {
+        ->toBe('Nuno');
 });
 
 test('fails with broken json string', function () {

--- a/tests/Visual/JUnit.php
+++ b/tests/Visual/JUnit.php
@@ -1,0 +1,29 @@
+<?php
+
+use Pest\Logging\JUnit;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+
+beforeEach(function () {
+    file_put_contents(__DIR__ . '/junit.html', '');
+});
+
+it('is can successfully call all public methods', function () {
+    $junit = new JUnit(__DIR__ . '/junit.html');
+    $junit->startTestSuite(new TestSuite());
+    $junit->startTest($this);
+    $junit->addError($this, new Exception(), 0);
+    $junit->addFailure($this, new AssertionFailedError(), 0);
+    $junit->addWarning($this, new Warning(), 0);
+    $junit->addIncompleteTest($this, new Exception(), 0);
+    $junit->addRiskyTest($this, new Exception(), 0);
+    $junit->addSkippedTest($this, new Exception(), 0);
+    $junit->endTest($this, 0);
+    $junit->endTestSuite(new TestSuite());
+    $this->expectNotToPerformAssertions();
+});
+
+afterEach(function () {
+    unlink(__DIR__ . '/junit.html');
+});

--- a/tests/Visual/TeamCity.php
+++ b/tests/Visual/TeamCity.php
@@ -1,0 +1,32 @@
+<?php
+
+use Pest\Logging\TeamCity;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\TextUI\DefaultResultPrinter;
+
+beforeEach(function () {
+    file_put_contents(__DIR__ . '/output.txt', '');
+});
+
+it('is can successfully call all public methods', function () {
+    $teamCity = new TeamCity(__DIR__ . '/output.txt', false, DefaultResultPrinter::COLOR_ALWAYS);
+    expect($teamCity::isPestTest($this))->toBeTrue();
+    $teamCity->startTestSuite(new TestSuite());
+    $teamCity->startTest($this);
+    $teamCity->addError($this, new Exception('Don\'t worry about this error. Its purposeful.'), 0);
+    $teamCity->addFailure($this, new AssertionFailedError('Don\'t worry about this error. Its purposeful.'), 0);
+    $teamCity->addWarning($this, new Warning(), 0);
+    $teamCity->addIncompleteTest($this, new Exception(), 0);
+    $teamCity->addRiskyTest($this, new Exception(), 0);
+    $teamCity->addSkippedTest($this, new Exception(), 0);
+    $teamCity->endTest($this, 0);
+    $teamCity->printResult(new TestResult());
+    $teamCity->endTestSuite(new TestSuite());
+});
+
+afterEach(function () {
+    unlink(__DIR__ . '/output.txt');
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR aims to add Pest styling to the PhpStorm `TeamCity` Logger. Here are some output examples:

<img width="1622" alt="Screenshot 2021-07-16 at 17 53 09" src="https://user-images.githubusercontent.com/12202279/125982350-77417550-551c-4bd2-a848-416a1f103c7a.png">

<img width="1622" alt="Screenshot 2021-07-16 at 17 53 50" src="https://user-images.githubusercontent.com/12202279/125982438-886b672f-999b-43ee-8ffb-64e55efb940f.png">

<img width="552" alt="Screenshot 2021-07-16 at 17 54 09" src="https://user-images.githubusercontent.com/12202279/125982478-06d5b7cc-a945-4c33-b38c-1631843a7ba2.png">

<img width="862" alt="Screenshot 2021-07-16 at 17 55 19" src="https://user-images.githubusercontent.com/12202279/125982624-6e2f90a6-5efb-44c3-bc89-744b9611daa3.png">

<img width="1712" alt="Screenshot 2021-07-16 at 17 55 57" src="https://user-images.githubusercontent.com/12202279/125982757-461e7b7f-b8db-4679-b379-e119e1e23f0e.png">

