### PR TITLE
Higher order callable datasets

### DIFF
--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -35,7 +35,7 @@ final class HigherOrderCallables
      */
     public function expect($value)
     {
-        return new Expectation($value instanceof Closure ? Reflection::bindCallable($value) : $value);
+        return new Expectation($value instanceof Closure ? Reflection::bindCallableWithData($value) : $value);
     }
 
     /**
@@ -59,7 +59,7 @@ final class HigherOrderCallables
      */
     public function tap(callable $callable)
     {
-        Reflection::bindCallable($callable);
+        Reflection::bindCallableWithData($callable);
 
         return $this->target;
     }

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -61,6 +61,21 @@ final class Reflection
     }
 
     /**
+     * Bind a callable to the TestCase and return the result,
+     * passing in the current dataset values as arguments.
+     *
+     * @return mixed
+     */
+    public static function bindCallableWithData(callable $callable)
+    {
+        $test = TestSuite::getInstance()->test;
+
+        return $test === null
+            ? static::bindCallable($callable)
+            : Closure::fromCallable($callable)->bindTo($test)(...$test->getProvidedData());
+    }
+
+    /**
      * Infers the file name from the given closure.
      */
     public static function getFileNameFromClosure(Closure $closure): string

--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -109,10 +109,6 @@ final class Reflection
             }
         }
 
-        if ($reflectionProperty === null) {
-            throw ShouldNotHappen::fromMessage('Reflection property not found.');
-        }
-
         $reflectionProperty->setAccessible(true);
 
         return $reflectionProperty->getValue($object);
@@ -141,10 +137,6 @@ final class Reflection
                     throw new ShouldNotHappen($reflectionException);
                 }
             }
-        }
-
-        if ($reflectionProperty === null) {
-            throw ShouldNotHappen::fromMessage('Reflection property not found.');
         }
 
         $reflectionProperty->setAccessible(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -27,4 +27,13 @@ it('can tap into the test')
     ->toBe('foo')
     ->and('hello world')->toBeString();
 
+it('can pass datasets into the expect callables')
+    ->with([[1, 2, 3]])
+    ->expect(function (...$numbers) { return $numbers; })->toBe([1, 2, 3])
+    ->and(function (...$numbers) { return $numbers; })->toBe([1, 2, 3]);
+
+it('can pass datasets into the tap callable')
+    ->with([[1, 2, 3]])
+    ->tap(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
+
 afterEach()->assertTrue(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -37,10 +37,10 @@ it('can pass datasets into the tap callable')
     ->tap(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
 
 it('can pass shared datasets into callables')
-    ->with('numbers.closure.wrapped')
     ->expect(function ($value) { return $value; })
     ->and(function ($value) { return $value; })
     ->tap(function ($value) { expect($value)->toBeInt(); })
-    ->toBeInt();
+    ->toBeInt()
+    ->with('numbers.closure.wrapped');
 
 afterEach()->assertTrue(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -36,4 +36,11 @@ it('can pass datasets into the tap callable')
     ->with([[1, 2, 3]])
     ->tap(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
 
+it('can pass shared datasets into callables')
+    ->with('numbers.closure.wrapped')
+    ->expect(function ($value) { return $value; })
+    ->and(function ($value) { return $value; })
+    ->tap(function ($value) { expect($value)->toBeInt(); })
+    ->toBeInt();
+
 afterEach()->assertTrue(true);

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -37,10 +37,10 @@ it('can pass datasets into the tap callable')
     ->tap(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
 
 it('can pass shared datasets into callables')
+    ->with('numbers.closure.wrapped')
     ->expect(function ($value) { return $value; })
     ->and(function ($value) { return $value; })
     ->tap(function ($value) { expect($value)->toBeInt(); })
-    ->toBeInt()
-    ->with('numbers.closure.wrapped');
+    ->toBeInt();
 
 afterEach()->assertTrue(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Howdy all!

Something that came up in the stream yesterday was the inability to combine higher order tests with datasets. For simplistic tests, this can be quite frustrating. 

This PR updates the higher order callable methods so that they always receive dataset values if available:

```php
it('should throw an InvalidArgumentException')
    ->with('invalidNames')
    ->throws(InvalidArgumentException::class)
    ->tap(fn($name) => ValidatesModuleName::handle($name));

it('converts the markdown to html')
    ->with('markdownExamples')
    ->expect(fn($markdown) => MarkdownToHtml::convert($markdown))
    ->toBeString()
    ->toStartWith('<p>');
```

Kind Regards,
Luke
