### PR TITLE
Add --force flag to pest:test command

### DIFF
--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -56,7 +56,7 @@ final class PestTestCommand extends Command
             File::makeDirectory(dirname($target), 0777, true, true);
         }
 
-        if (File::exists($target) and !$this->option('force')) {
+        if (File::exists($target) and !(bool) $this->option('force')) {
             throw new InvalidConsoleArgument(sprintf('%s already exist', $target));
         }
 

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -21,7 +21,7 @@ final class PestTestCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory}';
+    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory} {--force : Force create}';
 
     /**
      * The console command description.
@@ -56,7 +56,7 @@ final class PestTestCommand extends Command
             File::makeDirectory(dirname($target), 0777, true, true);
         }
 
-        if (File::exists($target)) {
+        if (File::exists($target) and !$this->option('force')) {
             throw new InvalidConsoleArgument(sprintf('%s already exist', $target));
         }
 

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -21,7 +21,7 @@ final class PestTestCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory} {--force : Force create}';
+    protected $signature = 'pest:test {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory} {--force : Overwrite the existing test file with the same name}';
 
     /**
      * The console command description.


### PR DESCRIPTION
From now on with this PR we will be able to create a test with `--flag` and recreate the test file.