### PR TITLE
Higher order test expect escape and skip fix

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -8,7 +8,6 @@ use Closure;
 use Pest\Factories\TestCaseFactory;
 use Pest\Support\Backtrace;
 use Pest\Support\HigherOrderCallables;
-use Pest\Support\NullClosure;
 use Pest\TestSuite;
 use SebastianBergmann\Exporter\Exporter;
 
@@ -135,21 +134,15 @@ final class TestCall
     public function skip($conditionOrMessage = true, string $message = ''): TestCall
     {
         $condition = is_string($conditionOrMessage)
-            ? NullClosure::create()
+            ? true
             : $conditionOrMessage;
-
-        $condition = $condition instanceof Closure
-            ? $condition
-            : function () use ($condition) { /* @phpstan-ignore-line */
-                return $condition;
-            };
 
         $message = is_string($conditionOrMessage)
             ? $conditionOrMessage
             : $message;
 
         $this->testCaseFactory
-            ->chains
+            ->proxies
             ->addWhen($condition, Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
 
         return $this;

--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -138,7 +138,7 @@ final class TestCall
             ? NullClosure::create()
             : $conditionOrMessage;
 
-        $condition = is_callable($condition)
+        $condition = $condition instanceof Closure
             ? $condition
             : function () use ($condition) { /* @phpstan-ignore-line */
                 return $condition;

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Closure;
+use Error;
+use Pest\TestSuite;
+use const PHP_MAJOR_VERSION;
 use ReflectionClass;
 use Throwable;
 
@@ -72,14 +75,14 @@ final class HigherOrderMessage
     }
 
     /**
-     * Re-throws the given `$throwable` with the good line and filename.
+     * Attempt to call the given name as a property or method on the target.
      *
      * @return mixed
      */
     public function call(object $target)
     {
         /* @phpstan-ignore-next-line */
-        if (is_callable($this->condition) && call_user_func(Closure::bind($this->condition, $target)) === false) {
+        if ($this->condition instanceof Closure && call_user_func(Closure::bind($this->condition, $target)) === false) {
             return $target;
         }
 
@@ -91,21 +94,35 @@ final class HigherOrderMessage
         try {
             return is_array($this->arguments)
                 ? Reflection::call($target, $this->name, $this->arguments)
-                : $target->{$this->name}; /* @phpstan-ignore-line */
-        } catch (Throwable $throwable) {
-            Reflection::setPropertyValue($throwable, 'file', $this->filename);
-            Reflection::setPropertyValue($throwable, 'line', $this->line);
-
-            if ($throwable->getMessage() === self::getUndefinedMethodMessage($target, $this->name)) {
-                /** @var ReflectionClass $reflection */
-                $reflection = new ReflectionClass($target);
-                /* @phpstan-ignore-next-line */
-                $reflection = $reflection->getParentClass() ?: $reflection;
-                Reflection::setPropertyValue($throwable, 'message', sprintf('Call to undefined method %s::%s()', $reflection->getName(), $this->name));
+                : $target->{$this->name}; // @phpstan-ignore-line
+        } catch (Error $throwable) {
+            if (($test = TestSuite::getInstance()->test) === null) {
+                throw $this->descriptiveException($target, $throwable);
             }
 
-            throw $throwable;
+            return $this->call($test);
+        } catch (Throwable $throwable) {
+            throw $this->descriptiveException($target, $throwable);
         }
+    }
+
+    /**
+     * Update the given `$throwable` so that it points to the correct file and line number.
+     */
+    private function descriptiveException(object $target, Throwable $throwable): Throwable
+    {
+        Reflection::setPropertyValue($throwable, 'file', $this->filename);
+        Reflection::setPropertyValue($throwable, 'line', $this->line);
+
+        if ($throwable->getMessage() === self::getUndefinedMethodMessage($target, $this->name)) {
+            /** @var ReflectionClass $reflection */
+            $reflection = new ReflectionClass($target);
+            /* @phpstan-ignore-next-line */
+            $reflection = $reflection->getParentClass() ?: $reflection;
+            Reflection::setPropertyValue($throwable, 'message', sprintf('Call to undefined method %s::%s()', $reflection->getName(), $this->name));
+        }
+
+        return $throwable;
     }
 
     /**
@@ -132,7 +149,7 @@ final class HigherOrderMessage
 
     private static function getUndefinedMethodMessage(object $target, string $methodName): string
     {
-        if (\PHP_MAJOR_VERSION >= 8) {
+        if (PHP_MAJOR_VERSION >= 8) {
             return sprintf(sprintf(self::UNDEFINED_METHOD, sprintf('%s::%s()', get_class($target), $methodName)));
         }
 

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -27,9 +27,10 @@ final class HigherOrderMessageCollection
     /**
      * Adds a new higher order message to the collection if the callable condition is does not return false.
      *
+     * @param callable(): bool|bool  $condition
      * @param array<int, mixed>|null $arguments
      */
-    public function addWhen(callable $condition, string $filename, int $line, string $name, array $arguments = null): void
+    public function addWhen($condition, string $filename, int $line, string $name, array $arguments = null): void
     {
         $this->messages[] = (new HigherOrderMessage($filename, $line, $name, $arguments))->when($condition);
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -101,6 +101,7 @@
   ✓ it gives access the the underlying expectException
   ✓ it catch exceptions
   ✓ it catch exceptions and messages
+  ✓ it can just define the message
 
    PASS  Tests\Features\Expect\HigherOrder\methods
   ✓ it can access methods
@@ -112,11 +113,14 @@
   ✓ it works with sequence
   ✓ it can compose complex expectations
   ✓ it can handle nested method calls
+  ✓ it works with higher order tests
 
    PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
   ✓ it can access methods and properties
   ✓ it can handle nested methods and properties
+  ✓ it works with higher order tests
   ✓ it can start a new higher order expectation using the and syntax
+  ✓ it can start a new higher order expectation using the and syntax in higher order tests
 
    PASS  Tests\Features\Expect\HigherOrder\properties
   ✓ it allows properties to be accessed from the value
@@ -128,6 +132,7 @@
   ✓ it can compose complex expectations
   ✓ it works with objects
   ✓ it works with nested properties
+  ✓ it works with higher order tests
 
    PASS  Tests\Features\Expect\each
   ✓ an exception is thrown if the the type is not iterable
@@ -411,7 +416,10 @@
   ✓ it proxies calls to object
   ✓ it is capable doing multiple assertions
   ✓ it resolves expect callables correctly
+  ✓ does not treat method names as callables
   ✓ it can tap into the test
+  ✓ it can call global methods after an expect chain
+  ✓ it can call test methods after an expect chain
 
    WARN  Tests\Features\Incompleted
   … incompleted
@@ -444,6 +452,8 @@
   ✓ it do not skips with falsy closure condition
   - it skips with condition and message → skipped because foo
   - it skips when skip after assertion
+  - it can use something in the test case as a condition → This test was skipped
+  - it can user higher order callables and skip
 
    PASS  Tests\Features\Test
   ✓ a test
@@ -581,5 +591,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 7 skipped, 365 passed
+  Tests:  4 incompleted, 9 skipped, 373 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -418,6 +418,10 @@
   ✓ it resolves expect callables correctly
   ✓ does not treat method names as callables
   ✓ it can tap into the test
+  ✓ it can pass datasets into the expect callables with (1, 2, 3)
+  ✓ it can pass datasets into the tap callable with (1, 2, 3)
+  ✓ it can pass shared datasets into callables with (1)
+  ✓ it can pass shared datasets into callables with (2)
   ✓ it can call global methods after an expect chain
   ✓ it can call test methods after an expect chain
 
@@ -591,5 +595,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 373 passed
+  Tests:  4 incompleted, 9 skipped, 377 passed
   

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -27,4 +27,14 @@ it('can tap into the test')
     ->toBe('foo')
     ->and('hello world')->toBeString();
 
+it('can call global methods after an expect chain')
+    ->expect('foo')
+    ->toBeString()->toBe('foo')
+    ->test();
+
+it('can call test methods after an expect chain')
+    ->expect('foo')
+    ->toBeString()->toBe('foo')
+    ->getNumAssertions();
+
 afterEach()->assertTrue(true);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -5,7 +5,7 @@ beforeEach(function () {
 });
 
 it('do not skips')
-    ->skip(false)
+    ->skip(false, 'here')
     ->assertTrue(true);
 
 it('skips with truthy')
@@ -33,7 +33,7 @@ it('skips with condition and message')
     ->assertTrue(false);
 
 it('skips when skip after assertion')
-    ->assertTrue(true)
+    ->assertTrue(false)
     ->skip();
 
 it('can use something in the test case as a condition')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Hi guys,

## Higher Order Tests quirk fix

So something that bothered me the other day was the fact that in higher order tests, when using expect chains, I got stuck in the chain and couldn't back out again. This was because expect thought we were working with higher order expectations and so tried to call the method/property on that, but no fallback was in place for the use-case where you actually want to move onto another method call.

```php
// This would previously fail, because `getNumAssertions` isn't available to the string 'foo'
it('can call test methods after an expect chain')
    ->expect('foo')
    ->toBeString()->toBe('foo')
    ->getNumAssertions();
```

This PR fixes that issue by catching the error exception and trying again on the test object. It allows you to chain global functions and test case methods onto the end of an exception chain in higher order tests.

## Skip fix

Something I noticed whilst working on this PR was that the skip methods weren't working correctly, specifically this:

```php
it('do not skips')
    ->skip(false, 'here')
    ->assertTrue(true);
```

The test suite was exiting with an unknown error. After some digging, it seems to be related to wrapping the passed value in a callable, which doesn't seem to retain its original state when fired in the proxy calls. I've also moved the skip method from a `chain` to a `proxy`, which fixes this test which was passing before but only because it had been written incorrectly:

```php
it('skips when skip after assertion')
    ->assertTrue(false)
    ->skip();
```

Let me know what you think 👍

Kind Regards,
Luke