### PR TITLE
Fix static hooks

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -73,7 +73,8 @@ trait Testable
     {
         $this->__test        = $test;
         $this->__description = $description;
-        self::$beforeAll     = self::$afterAll = null;
+        self::$beforeAll     = null;
+        self::$afterAll      = null;
 
         parent::__construct('__test', $data);
     }

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -73,6 +73,7 @@ trait Testable
     {
         $this->__test        = $test;
         $this->__description = $description;
+        self::$beforeAll     = self::$afterAll = null;
 
         parent::__construct('__test', $data);
     }

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -2,26 +2,50 @@
 
 global $globalHook;
 
+// NOTE: this test does not have a $globalHook->calls offset since it is first
+// in the directory and thus will always run before the others. See also the
+// BeforeAllTest.php for details.
+
 uses()->afterAll(function () use ($globalHook) {
     expect($globalHook)
         ->toHaveProperty('afterAll')
         ->and($globalHook->afterAll)
-        ->toBe(0);
+        ->toBe(0)
+        ->and($globalHook->calls)
+        ->afterAll
+        ->toBe(1);
 
     $globalHook->afterAll = 1;
+    $globalHook->calls->afterAll++;
 });
 
 afterAll(function () use ($globalHook) {
     expect($globalHook)
         ->toHaveProperty('afterAll')
         ->and($globalHook->afterAll)
-        ->toBe(1);
+        ->toBe(1)
+        ->and($globalHook->calls)
+        ->afterAll
+        ->toBe(2);
 
     $globalHook->afterAll = 2;
+    $globalHook->calls->afterAll++;
 });
 
 test('global afterAll execution order', function () use ($globalHook) {
     expect($globalHook)
         ->not()
-        ->toHaveProperty('afterAll');
+        ->toHaveProperty('afterAll')
+        ->and($globalHook->calls)
+        ->afterAll
+        ->toBe(0);
+});
+
+test('it only gets called once per file', function () use ($globalHook) {
+    expect($globalHook)
+        ->not()
+        ->toHaveProperty('afterAll')
+        ->and($globalHook->calls)
+        ->afterAll
+        ->toBe(0);
 });

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -41,7 +41,7 @@ test('global afterAll execution order', function () use ($globalHook) {
         ->toBe(0);
 });
 
-test('it only gets called once per file', function () use ($globalHook) {
+it('only gets called once per file', function () use ($globalHook) {
     expect($globalHook)
         ->not()
         ->toHaveProperty('afterAll')

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -1,28 +1,56 @@
 <?php
 
+use Pest\Support\Str;
+
 global $globalHook;
 
-uses()->beforeAll(function () use ($globalHook) {
+// HACK: we have to determine our $globalHook->calls baseline. This is because
+// two other tests are executed before this one due to filename ordering.
+$args = $_SERVER['argv'] ?? [];
+$single = isset($args[1]) && Str::endsWith(__FILE__, $args[1]);
+$offset = $single ? 0 : 2;
+
+uses()->beforeAll(function () use ($globalHook, $offset) {
     expect($globalHook)
         ->toHaveProperty('beforeAll')
         ->and($globalHook->beforeAll)
-        ->toBe(0);
+        ->toBe(0)
+        ->and($globalHook->calls)
+        ->beforeAll
+        ->toBe(1 + $offset);
 
     $globalHook->beforeAll = 1;
+    $globalHook->calls->beforeAll++;
 });
 
-beforeAll(function () use ($globalHook) {
+beforeAll(function () use ($globalHook, $offset) {
     expect($globalHook)
         ->toHaveProperty('beforeAll')
         ->and($globalHook->beforeAll)
-        ->toBe(1);
+        ->toBe(1)
+        ->and($globalHook->calls)
+        ->beforeAll
+        ->toBe(2 + $offset);
 
     $globalHook->beforeAll = 2;
+    $globalHook->calls->beforeAll++;
 });
 
-test('global beforeAll execution order', function () use ($globalHook) {
+test('global beforeAll execution order', function () use ($globalHook, $offset) {
     expect($globalHook)
         ->toHaveProperty('beforeAll')
         ->and($globalHook->beforeAll)
-        ->toBe(2);
+        ->toBe(2)
+        ->and($globalHook->calls)
+        ->beforeAll
+        ->toBe(3 + $offset);
+});
+
+it('only gets called once per file', function () use ($globalHook, $offset) {
+    expect($globalHook)
+        ->beforeAll
+        ->toBe(2)
+        ->and($globalHook->calls)
+        ->beforeAll
+        ->toBe(3 + $offset);
 });

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -6,7 +6,7 @@ global $globalHook;
 
 // HACK: we have to determine our $globalHook->calls baseline. This is because
 // two other tests are executed before this one due to filename ordering.
-$args = $_SERVER['argv'] ?? [];
+$args   = $_SERVER['argv'] ?? [];
 $single = isset($args[1]) && Str::endsWith(__FILE__, $args[1]);
 $offset = $single ? 0 : 2;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,8 @@
 
 uses()->group('integration')->in('Visual');
 
-$globalHook = (object) []; // NOTE: global test value container to be mutated and checked across files, as needed
+// NOTE: global test value container to be mutated and checked across files, as needed
+$globalHook = (object) ['calls' => (object) ['beforeAll' => 0, 'afterAll' => 0]];
 
 uses()
     ->beforeEach(function () {
@@ -10,11 +11,13 @@ uses()
     })
     ->beforeAll(function () use ($globalHook) {
         $globalHook->beforeAll = 0;
+        $globalHook->calls->beforeAll++;
     })
     ->afterEach(function () {
         $this->ith = 0;
     })
     ->afterAll(function () use ($globalHook) {
         $globalHook->afterAll = 0;
+        $globalHook->calls->afterAll++;
     })
     ->in('Hooks');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #351 

### Issue

The issue is essentially, exactly, as described by @fnzr in the related ticket (great job and good find!).

> Basically, the problem happens because each test, when it's being parsed, registers the global hook on a shared variable (Testable::$beforeAll) as if it were a new hook. The solution would be...well, not do that. [...]

More specifically it is a result of the static nature of these hooks, which is why we do not see this behaviour on the `beforeEach` and `afterEach` variants. This would have been a huge oversight on my part when initially implementing this feature in #282 , and could pose a potential performance issue for some folks, should they be doing any heavy work or network activity within.

### Solution

Funnily enough, it's a one-liner ... 😑 ... 🤣 . Nearly all changes are test related.

#### Source

- ensure that we re-initialize `static ?Closure $beforeAll` and `static ?Closure $afterAll` at constructor-time for each test case, within the `Testable` concern trait;

#### Tests

Due to how these hooks work (e.g., can be defined in multiple files, variable amount of tests using them, etc.), it's a little tricky to ensure they are only run once per file. The solution to this is outlined below.

- add a `calls` property to the `global $globalHook` object;
    - within here we keep a running total of hook calls, starting at 0;
- within each hook (we are testing), assert & increment it's call count;
    - call count is always incremented by 1, except in the tests themselves;
    - when asserting the call count, depending on the test we need to calculate and apply a delta/offset to our expected value;
        - see [`BeforeAllTest.php`](https://github.com/jordanbrauer/pest/blob/fix-static-hooks/tests/Hooks/BeforeAllTest.php#L6-L8) and [`AfterAllTest.php`](https://github.com/jordanbrauer/pest/blob/fix-static-hooks/tests/Hooks/AfterAllTest.php#L4-L8) header comments for full details