### PR TITLE
Add `toBeIn` expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -374,11 +374,11 @@ final class Expectation
     /**
      * Asserts that the value is one of the given values.
      *
-     * @param array<int, int|string> $possibleValues
+     * @param iterable<int|string, mixed> $values
      */
-    public function toBeIn(array $possibleValues): Expectation
+    public function toBeIn(iterable $values): Expectation
     {
-        Assert::assertContains($this->value, $possibleValues);
+        Assert::assertContains($this->value, $values);
 
         return $this;
     }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -372,6 +372,16 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is one of the given values.
+     */
+    public function toBeIn(array $possibleValues): Expectation
+    {
+        Assert::assertContains($this->value, $possibleValues);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is infinite.
      */
     public function toBeInfinite(): Expectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -373,6 +373,8 @@ final class Expectation
 
     /**
      * Asserts that the value is one of the given values.
+     *
+     * @param array<int, int|string> $possibleValues
      */
     public function toBeIn(array $possibleValues): Expectation
     {

--- a/tests/Features/Expect/toBeIn.php
+++ b/tests/Features/Expect/toBeIn.php
@@ -4,8 +4,13 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 test('passes', function () {
     expect('a')->toBeIn(['a', 'b', 'c']);
+    expect('d')->not->toBeIn(['a', 'b', 'c']);
 });
 
 test('failures', function () {
     expect('d')->toBeIn(['a', 'b', 'c']);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect('a')->not->toBeIn(['a', 'b', 'c']);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeIn.php
+++ b/tests/Features/Expect/toBeIn.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes', function () {
+    expect('a')->toBeIn(['a', 'b', 'c']);
+});
+
+test('failures', function () {
+    expect('d')->toBeIn(['a', 'b', 'c']);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds a new `toBeIn` expectation.

```
expect('a')->toBeIn(['a', 'b', 'c',]); // passes
expect('d')->toBeIn(['a', 'b', 'd',]); // doest not pass
```

