### PR TITLE
Datasets can now access the test case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "scripts": {
         "lint": "php-cs-fixer fix -v",
         "test:lint": "php-cs-fixer fix -v --dry-run",
-        "test:types": "phpstan analyse --ansi --memory-limit=0",
+        "test:types": "phpstan analyse --ansi",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration",
         "test:integration": "php bin/pest --colors=always --group=integration",
         "update:snapshots": "REBUILD_SNAPSHOTS=true php bin/pest --colors=always",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "scripts": {
         "lint": "php-cs-fixer fix -v",
         "test:lint": "php-cs-fixer fix -v --dry-run",
-        "test:types": "phpstan analyse --ansi",
+        "test:types": "phpstan analyse --ansi --memory-limit=-1",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration",
         "test:integration": "php bin/pest --colors=always --group=integration",
         "update:snapshots": "REBUILD_SNAPSHOTS=true php bin/pest --colors=always",

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -273,7 +273,19 @@ trait Testable
      */
     public function __test()
     {
-        return $this->__callClosure($this->__test, func_get_args());
+        return $this->__callClosure($this->__test, $this->resolveTestArguments(func_get_args()));
+    }
+
+    /**
+     * Resolve the passed arguments. Any Closures will be bound to the testcase and resolved.
+     *
+     * @throws Throwable
+     */
+    private function resolveTestArguments(array $arguments): array
+    {
+        return array_map(function ($data) {
+            return $data instanceof Closure ? $this->__callClosure($data, []) : $data;
+        }, $arguments);
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -96,6 +96,11 @@
   ✓ more than two datasets with (2) / (4) / (5)
   ✓ more than two datasets with (2) / (4) / (6)
   ✓ more than two datasets did the job right
+  ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
 
    PASS  Tests\Features\Exceptions
   ✓ it gives access the the underlying expectException
@@ -608,5 +613,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 388 passed
+  Tests:  4 incompleted, 9 skipped, 393 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -96,6 +96,11 @@
   ✓ more than two datasets with (2) / (4) / (5)
   ✓ more than two datasets with (2) / (4) / (6)
   ✓ more than two datasets did the job right
+  ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
 
    PASS  Tests\Features\Exceptions
   ✓ it gives access the the underlying expectException
@@ -601,5 +606,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 381 passed
+  Tests:  4 incompleted, 9 skipped, 386 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -96,6 +96,11 @@
   ✓ more than two datasets with (2) / (4) / (5)
   ✓ more than two datasets with (2) / (4) / (6)
   ✓ more than two datasets did the job right
+  ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
 
    PASS  Tests\Features\Exceptions
   ✓ it gives access the the underlying expectException
@@ -614,5 +619,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 390 passed
+  Tests:  4 incompleted, 9 skipped, 395 passed
   

--- a/tests/Datasets/Bound.php
+++ b/tests/Datasets/Bound.php
@@ -1,0 +1,11 @@
+<?php
+
+dataset('bound.closure', function () {
+    yield function () { return 1; };
+    yield function () { return 2; };
+});
+
+dataset('bound.array', [
+    function () { return 1; },
+    function () { return 2; },
+]);

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -5,6 +5,10 @@ use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
 use Pest\Plugin;
 
+beforeEach(function () {
+    $this->foo = 'bar';
+});
+
 it('throws exception if dataset does not exist', function () {
     $this->expectException(DatasetDoesNotExist::class);
     $this->expectExceptionMessage("A dataset with the name `first` does not exist. You can create it using `dataset('first', ['a', 'b']);`.");
@@ -223,3 +227,17 @@ test('more than two datasets', function ($text_a, $text_b, $text_c) use ($state,
 test('more than two datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('121212121212131423241314232411122122111221221112212213142324135136145146235236245246');
 });
+
+it('can resolve a dataset after the test case is available', function ($result) {
+    expect($result)->toBe('bar');
+})->with([
+    function () { return $this->foo; },
+]);
+
+it('can resolve a dataset after the test case is available with shared yield sets', function ($result) {
+    expect($result)->toBeInt()->toBeLessThan(3);
+})->with('bound.closure');
+
+it('can resolve a dataset after the test case is available with shared array sets', function ($result) {
+    expect($result)->toBeInt()->toBeLessThan(3);
+})->with('bound.array');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Howdy!

This PR adds support for bound datasets. These datasets have full access to the test case and are resolved after the `beforeEach` has run.

This allows for some really cool scenarios that were never possible before in datasets. For example, you could provide full blown models via datasets:

```php
it('allows any user to be deleted', function(User $user) {
    $user->delete();
    expect(User::all())->toBeEmpty();
})->with([
    fn() => User::factory()->create(),
    fn() => User::factory()->blocked()->create(),
    fn() => User::factory()->unverified()->create(),
]);
```

This also works with shared datasets:

```php
// Datasets/Users.php
dataset('users', function() {
    yield fn() => User::factory()->create();
    yield fn() => User::factory()->blocked()->create();
    yield fn() => User::factory()->unverified()->create();
});

// Test
it('allows any user to be deleted', function(User $user) {
    $user->delete();
    expect(User::all())->toBeEmpty();
})->with('users');
```

Note that any closure will be resolved, so in order to create a dataset that returns closures, you'd need to return a closure from the closure. I've never ever returned a closure from a dataset before though, so can't see this being a common thing.

Excited to hear your thoughts!

Kind Regards,
Luke