### PR TITLE
implements multiple needles in expect()->toContain()

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -266,14 +266,16 @@ final class Expectation
     /**
      * Asserts that $needle is an element of the value.
      *
-     * @param mixed $needle
+     * @param mixed $needles
      */
-    public function toContain($needle): Expectation
+    public function toContain(...$needles): Expectation
     {
-        if (is_string($this->value)) {
-            Assert::assertStringContainsString($needle, $this->value);
-        } else {
-            Assert::assertContains($needle, $this->value);
+        foreach ($needles as $needle) {
+            if (is_string($this->value)) {
+                Assert::assertStringContainsString($needle, $this->value);
+            } else {
+                Assert::assertContains($needle, $this->value);
+            }
         }
 
         return $this;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -325,9 +325,16 @@
 
    PASS  Tests\Features\Expect\toContain
   ✓ passes strings
+  ✓ passes strings with multiple needles
   ✓ passes arrays
+  ✓ passes arrays with multiple needles
+  ✓ passes with array needles
   ✓ failures
+  ✓ failures with multiple needles (all failing)
+  ✓ failures with multiple needles (some failing)
   ✓ not failures
+  ✓ not failures with multiple needles (all failing)
+  ✓ not failures with multiple needles (some failing)
 
    PASS  Tests\Features\Expect\toEndWith
   ✓ pass
@@ -601,5 +608,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 381 passed
+  Tests:  4 incompleted, 9 skipped, 388 passed
   

--- a/tests/Features/Expect/toContain.php
+++ b/tests/Features/Expect/toContain.php
@@ -3,17 +3,45 @@
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('passes strings', function () {
-    expect([1, 2, 42])->toContain(42);
+    expect('Nuno')->toContain('Nu');
+});
+
+test('passes strings with multiple needles', function () {
+    expect('Nuno')->toContain('Nu', 'no');
 });
 
 test('passes arrays', function () {
-    expect('Nuno')->toContain('Nu');
+    expect([1, 2, 42])->toContain(42);
+});
+
+test('passes arrays with multiple needles', function () {
+    expect([1, 2, 42])->toContain(42, 2);
+});
+
+test('passes with array needles', function () {
+    expect([[1, 2, 3], 2, 42])->toContain(42, [1, 2, 3]);
 });
 
 test('failures', function () {
     expect([1, 2, 42])->toContain(3);
 })->throws(ExpectationFailedException::class);
 
+test('failures with multiple needles (all failing)', function () {
+    expect([1, 2, 42])->toContain(3, 4);
+})->throws(ExpectationFailedException::class);
+
+test('failures with multiple needles (some failing)', function () {
+    expect([1, 2, 42])->toContain(1, 3, 4);
+})->throws(ExpectationFailedException::class);
+
 test('not failures', function () {
     expect([1, 2, 42])->not->toContain(42);
+})->throws(ExpectationFailedException::class);
+
+test('not failures with multiple needles (all failing)', function () {
+    expect([1, 2, 42])->not->toContain(42, 2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures with multiple needles (some failing)', function () {
+    expect([1, 2, 42])->not->toContain(42, 1);
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds the ability to pass multiple needles to `->toContain()` expectation:

```php
 expect('Nuno')->toContain('Nu', 'no');
```

```php
expect([1, 2, 42])->toContain(42, 2);
```

obviously, it still supports arrays as needles:

```php
 expect([[1, 2, 3], 2, 42])->toContain(42, [1, 2, 3]);
```


