### PR TITLE
Add `toBeTruthy` and `ToBeFalsy`

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -206,6 +206,16 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is truthy.
+     */
+    public function toBeTruthy(): Expectation
+    {
+        Assert::assertTrue((bool) $this->value);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is false.
      */
     public function toBeFalse(): Expectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -226,6 +226,16 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is falsy.
+     */
+    public function toBeFalsy(): Expectation
+    {
+        Assert::assertFalse((bool) $this->value);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is greater than $expected.
      *
      * @param int|float $expected

--- a/tests/Features/Expect/ToBeFalsy.php
+++ b/tests/Features/Expect/ToBeFalsy.php
@@ -1,0 +1,26 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes', function () {
+    expect(false)->toBeFalsy();
+    expect('')->toBeFalsy();
+    expect(null)->toBeFalsy();
+    expect([])->toBeFalsy();
+    expect(0)->toBeFalsy();
+    expect('0')->toBeFalsy();
+
+    expect(true)->not->toBeFalsy();
+    expect([1])->not->toBeFalsy();
+    expect('false')->not->toBeFalsy();
+    expect(1)->not->toBeFalsy();
+    expect(-1)->not->toBeFalsy();
+});
+
+test('failures', function () {
+    expect(1)->toBeFalsy();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(null)->not->toBeFalsy();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/ToBeTruthy.php
+++ b/tests/Features/Expect/ToBeTruthy.php
@@ -1,0 +1,26 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes', function () {
+    expect(true)->toBeTruthy();
+    expect([1])->toBeTruthy();
+    expect('false')->toBeTruthy();
+    expect(1)->toBeTruthy();
+    expect(-1)->toBeTruthy();
+
+    expect(false)->not->toBeTruthy();
+    expect('')->not->toBeTruthy();
+    expect(null)->not->toBeTruthy();
+    expect([])->not->toBeTruthy();
+    expect(0)->not->toBeTruthy();
+    expect('0')->not->toBeTruthy();
+});
+
+test('failures', function () {
+    expect(null)->toBeTruthy();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(1)->not->toBeTruthy();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds `toBeTruthy` and `toBeFalsy`.

Useful when you don't care what a value is and you want to ensure a value is true or false in a boolean context.

```php
expect("true")->toBeTruthy(); // passes
expect("0")->toBeTruthy(); // doest not pass

expect("0")->toBeFalsy(); // passes
expect("false")->toBeFalsy(); // doest not pass
```