### PR TITLE
Install php-cs-fixer globally in workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,14 +16,11 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 8.0
-        tools: composer:v2
+        tools: php-cs-fixer:3
         coverage: none
 
-    - name: Install Dependencies
-      run: composer update --no-interaction --no-progress
-
     - name: Run PHP-CS-Fixer
-      run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run
+      run: php-cs-fixer fix -v --allow-risky=yes --dry-run
 
   phpstan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | no <!-- #-prefixed issue number(s), if any -->

PHPCSFixer does not require the dependencies to be installed, installing only the fixer as a global dependency should speed up the workflow and save resources as less has to be downloaded and installed.
<!--
- Replace this comment by a description of what your PR is solving.
-->

