### PR TITLE
Add `throwsIf` exception

### DIFF
--- a/src/PendingObjects/TestCall.php
+++ b/src/PendingObjects/TestCall.php
@@ -79,6 +79,26 @@ final class TestCall
     }
 
     /**
+     * Asserts that the test throws the given `$exceptionClass` when called if the given condition is true.
+     *
+     * @param Closure|bool|int $condition
+     */
+    public function throwsIf($condition, string $exception, string $exceptionMessage = null): TestCall
+    {
+        $condition = is_callable($condition)
+            ? $condition
+            : Closure::fromCallable(function () use ($condition): bool {
+                return (bool) $condition;
+            });
+
+        if ($condition() === true) {
+            return $this->throws($exception, $exceptionMessage);
+        }
+
+        return $this;
+    }
+
+    /**
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -107,6 +107,11 @@
   ✓ it catch exceptions
   ✓ it catch exceptions and messages
   ✓ it can just define the message
+  ✓ it not catch exceptions if given condition is false
+  ✓ it catch exceptions if given condition is true
+  ✓ it catch exceptions and messages if given condition is true
+  ✓ it can just define the message if given condition is true
+  ✓ it can just define the message if given condition is 1
 
    PASS  Tests\Features\Expect\HigherOrder\methods
   ✓ it can access methods
@@ -647,5 +652,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 419 passed
+  Tests:  4 incompleted, 9 skipped, 424 passed
   

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -17,3 +17,23 @@ it('catch exceptions and messages', function () {
 it('can just define the message', function () {
     throw new Exception('Something bad happened');
 })->throws('Something bad happened');
+
+it('not catch exceptions if given condition is false', function () {
+    $this->assertTrue(true);
+})->throwsIf(false, Exception::class);
+
+it('catch exceptions if given condition is true', function () {
+    throw new Exception('Something bad happened');
+})->throwsIf(function () { return true; }, Exception::class);
+
+it('catch exceptions and messages if given condition is true', function () {
+    throw new Exception('Something bad happened');
+})->throwsIf(true, Exception::class, 'Something bad happened');
+
+it('can just define the message if given condition is true', function () {
+    throw new Exception('Something bad happened');
+})->throwsIf(true, 'Something bad happened');
+
+it('can just define the message if given condition is 1', function () {
+    throw new Exception('Something bad happened');
+})->throwsIf(1, 'Something bad happened');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

(snapshots were not updating in this [PR](#362). I forked again.)

I have a test content is about 90 lines. This test content is only compatible with MySQL 8.0+. An exception will be thrown if the MySQL version is less than 8.

I know I can skip this test using Skip. But in this case I will have to create two of the same test. If one is MySQL 8 and above and the other is MySQL 5 it should work.
I can add if-else to test the content.
Or I can create another test with 90 lines.
I chose the fourth alternative, that is, I created a PR :)


```php
function dbVersion() {
    return (int) \DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
}
```

```php
function data() {

    if (dbVersion() < 8) {
        throw new Exception('You need to use MySQL 8+ to make this work');
    } else {
        return [1, 2, 3, 4];
    }
    
}
```

```php
it('example', function () {

    $this->assertEquals([1, 2, 3, 4], data());
    
})->throwsIf(fn() => dbVersion() < 8, 'You need to use MySQL 8+ to make this work');
```

```php
it('example two', function () {

    $this->assertEquals([1, 2, 3, 4], data());
    
})->throwsIf(dbVersion() < 8, Exception::class, 'You need to use MySQL 8+ to make this work');
```

