### PR TITLE
Allows the higher order scope to be reset using `and`

### DIFF
--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -70,10 +70,14 @@ final class HigherOrderExpectation
      *
      * @param TValue $value
      *
-     * @return Expectation<TValue>
+     * @return Expectation<TValue>|Expectation
      */
-    public function and($value): Expectation
+    public function and($value = null): Expectation
     {
+        if ($value === null) {
+            return $this->original;
+        }
+
         return $this->expect($value);
     }
 
@@ -94,11 +98,17 @@ final class HigherOrderExpectation
 
     /**
      * Accesses properties in the value or in the expectation.
+     *
+     * @return self|Expectation
      */
-    public function __get(string $name): self
+    public function __get(string $name)
     {
         if ($name === 'not') {
             return $this->not();
+        }
+
+        if ($name === 'and') {
+            return $this->and();
         }
 
         if (!$this->expectationHasMethod($name)) {

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -6,6 +6,7 @@ namespace Pest\Support;
 
 use Closure;
 use Pest\Expectation;
+use Pest\HigherOrderExpectation;
 use Pest\PendingObjects\TestCall;
 use PHPUnit\Framework\TestCase;
 
@@ -43,12 +44,16 @@ final class HigherOrderCallables
      *
      * Create a new expectation. Callable values will be executed prior to returning the new expectation.
      *
-     * @param callable|TValue $value
+     * @param callable|TValue|null $value
      *
-     * @return Expectation<TValue>
+     * @return Expectation<TValue|null>
      */
-    public function and($value)
+    public function and($value = null)
     {
+        if ($value === null && $this->target instanceof HigherOrderExpectation) {
+            return $this->target->and();
+        }
+
         return $this->expect($value);
     }
 

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -84,8 +84,9 @@ final class HigherOrderMessage
         }
 
         if ($this->hasHigherOrderCallable()) {
+            $arguments = $this->arguments ?? [];
             /* @phpstan-ignore-next-line */
-            return (new HigherOrderCallables($target))->{$this->name}(...$this->arguments);
+            return (new HigherOrderCallables($target))->{$this->name}(...$arguments);
         }
 
         try {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -123,6 +123,7 @@
    PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
   ✓ it can access methods and properties
   ✓ it can handle nested methods and properties
+  ✓ it can reset the scope using the and method
   ✓ it works with higher order tests
   ✓ it can start a new higher order expectation using the and syntax
   ✓ it can start a new higher order expectation using the and syntax in higher order tests
@@ -647,5 +648,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 419 passed
+  Tests:  4 incompleted, 9 skipped, 420 passed
   

--- a/tests/Features/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Features/Expect/HigherOrder/methodsAndProperties.php
@@ -22,9 +22,19 @@ it('can handle nested methods and properties', function () {
         ->newInstance()->books()->toBeArray();
 });
 
+it('can reset the scope using the and method', function () {
+    expect((new HasMethodsAndProperties())->meta)
+        ->toBeArray()
+        ->foo->toBeArray()
+        ->and()->toEqual(['foo' => ['bar' => 'baz']])
+        ->foo->bar->toEqual('baz')
+        ->and->toHaveCount(1);
+});
+
 it('works with higher order tests')
     ->expect(new HasMethodsAndProperties())
     ->meta->foo->bar->toBeString()->toEqual('baz')->not->toBeInt
+    ->and->toBeInstanceOf(HasMethodsAndProperties::class)
     ->newInstance()->meta->foo->toBeArray
     ->newInstance()->multiply(2, 2)->toEqual(4)->not->toEqual(5)
     ->newInstance()->books()->toBeArray();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Hello there!

This PR adds the ability for a user to reset scope whilst using higher order expectations. Allow me to explain the need for this using an example:

```php
expect(['foo' => ['bar' => 'baz']])
    ->foo->bar->toBe('baz')
    ->toHaveCount(1);
```

The above code will fail because `toHaveCount` is still in the context of `->foo->bar`, which is a string. To resolve this issue, I have proposed being able to pass the `and` property or method without any arguments, which causes scope to be reset to the original expectation value:

```php
expect(['foo' => ['bar' => 'baz']])
    ->foo->bar->toBe('baz')
    ->and->toHaveCount(1); // As a property

expect(['foo' => ['bar' => 'baz']])
    ->foo->bar->toBe('baz')
    ->and()->toHaveCount(1); // As a method
```

Another example of a situation solved by this code can be found in this tweet by @Gummibeer: https://twitter.com/devgummibeer/status/1425451138384637956?s=20

Kind Regards,
Luke