### PR TITLE
Adds `len()` Expectation & Tests

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -83,6 +83,38 @@ final class Expectation
     }
 
     /**
+     * Creates a new expectation with the value's length/count.
+     */
+    public function len(): Expectation
+    {
+        if (is_string($this->value)) {
+            $this->value = grapheme_strlen($this->value);
+
+            return $this;
+        }
+
+        if (is_array($this->value)) {
+            $this->value = count($this->value);
+
+            return $this;
+        }
+
+        if (is_object($this->value) && get_class($this->value) == 'Illuminate\Support\Collection') {
+            $this->value = $this->value->count();
+
+            return $this;
+        }
+
+        if (is_object($this->value)) {
+            $this->value = count(get_object_vars($this->value));
+
+            return $this;
+        }
+
+        throw new BadMethodCallException("Expectation value's length is uncountable");
+    }
+
+    /**
      * Dump the expectation value and end the script.
      *
      * @param mixed $arguments

--- a/tests/Features/Expect/len.php
+++ b/tests/Features/Expect/len.php
@@ -1,0 +1,21 @@
+<?php
+
+it('returns uncountable BadMethodCallException', function ($value) {
+    expect($value)->len()->toEqual(1);
+})->with([1, 1.5, true, null])->throws(BadMethodCallException::class, "Expectation value's length is uncountable");
+
+it('properly returns string length', function ($value) {
+    expect($value)->len()->toEqual(9);
+})->with(['Sollefteå', 'Guimarães', 'Ιεράπετρα', 'PT-BR 🇵🇹🇧🇷😎']);
+
+it('properly returns an array length', function () {
+    expect(['pest', 'is', 'the', 'best'])->len()->toEqual(4);
+});
+
+it('properly returns an Eloquent collection length', function () {
+    expect(collect(['pest', 'is', 'the', 'best']))->len()->toEqual(4);
+});
+
+test('properly returns an object length', function () {
+    expect((object) ['pest', 'is', 'the', 'best'])->len()->toEqual(4);
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #

### DESCRIPTION

Adds `len()` Expectation which returns the length of a given string and count of array/object/collection.

### MOTIVATION

I have been a little annoyed to use 'strlen' inside the pretty Pest syntax. For me, it hurts the readability and do not allow me to chain other assertions; hence this only will contain the length.

```php
expect(strlen('pest'))->toEqual(4);
```

vs.

```php
expect('pest')->len()->toEqual(4); 
```

and wouldn't be possible:

```php
expect(strlen('pest'))->toBeString->toEqual(4); //🚫
expect('pest')->toBeString->len()->toEqual(4);  //✅
```

### NAMING

I went for the name 'len' instead of 'length' because PHP's native function is called strlen. Also, spelling 'length' might be a thorn in the side for non-English native speakers.

I have also considered toHaveLength or toHaveLen, but I feel this method is 'extracting' the length, making it available for other assertions, while ToHaveLength would be a direct assertion.

Of course, name suggestions are welcome.

### USE CASE

For instance, the ISBN (international book identifier) can be 10 or 13 characters long.
With this method, I can assert I have received a string, and it has a length of 10 or 13  chars.

```php
test('ISBN must be 10 or 13 characters long', function ($isbn) {
    expect($isbn)->toBeString()
    ->len()
    ->toBeIn([10, 13]);
})
```

Another example, a product reference code always starts with 'A-' and must be between 15-60 characters.

```php
test('Product ref complies with A- and 15-60 chars', function () {
 expect('A-Lgj7Tn35Ddcmn6dw')->toBeString()
    ->toStartWith('A-')
    ->len()
    ->toBeGreaterThanOrEqual(15)
    ->toBeLessThanOrEqual(60);
});
```

There are other ways to perfom these assertions but, to  me, the example above looks cleaner than:

```php
test('Product ref complies with A- and 15-60 chars', function () {

$ref = 'A-Lgj7Tn35Ddcmn6dw';

expect($ref)->toBeString() 
      ->toStartWith('A-');
      
expect(strlen($ref))->toBeGreaterThanOrEqual(15)
      ->toBeLessThanOrEqual(60);
});

test('Product ref complies with A- and 15-60 chars', function () {

    expect('A-Lgj7Tn35Ddcmn6dw')->toBeString()
          ->toStartWith('A-')
          ->and(strlen($ref))->toBeGreaterThanOrEqual(15)
          ->and(strlen($ref))->toBeLessThanOrEqual(60);
});

```

and users are not using `count`, they use `toHaveCount`


```php
test('array has 2 items', function () {
    $countries = ['PT', 'BR','UA'];
    expect($countries)->toBeArray
          ->and(count($countries))->toEqual(3); //👎
})

```

### ARRAYS/COLLECTIONS/OBJECTS

Even though Pest has the method `toHaveCount`, it's quite common to find literature referring 'array count' as 'array length' (for instance, JS has Array.prototype.length).

For this reason, I thought having the possibility of getting the  array count with `len()` would keep the 'friendly' and easy vibe of Pest.

### INTEGER, FLOAT, BOOLEAN

These data types will return a BadMethodCallException with 'Expectation value's length is uncountable.'

### DOC

If the idea is approved, I will update the doc.