### PR TITLE
Adds toHaveLength() Expectation & Tests

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -344,12 +344,14 @@ final class Expectation
 
         if (is_object($this->value)) {
             if (method_exists($this->value, 'toArray')) {
-                $this->value = $this->value->toArray();
+                $array = $this->value->toArray();
             } else {
-                $this->value = (array) $this->value;
+                $array = (array) $this->value;
             }
 
-            return $this->toHaveCount($number);
+            Assert::assertCount($number, $array);
+
+            return $this;
         }
 
         throw new BadMethodCallException('Expectation value length is not countable.');

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -328,6 +328,36 @@ final class Expectation
     }
 
     /**
+     * Asserts that $number matches value's Length.
+     */
+    public function toHaveLength(int $number): Expectation
+    {
+        if (is_string($this->value)) {
+            Assert::assertEquals($number, grapheme_strlen($this->value));
+
+            return $this;
+        }
+
+        if (is_iterable($this->value)) {
+            return $this->toHaveCount($number);
+        }
+
+        if (is_object($this->value)) {
+            if (method_exists($this->value, 'toArray')) {
+                $array = $this->value->toArray();
+            } else {
+                $array = (array) $this->value;
+            }
+
+            Assert::assertCount($number, $array);
+
+            return $this;
+        }
+
+        throw new BadMethodCallException('Expectation value length is not countable.');
+    }
+
+    /**
      * Asserts that $count matches the number of elements of the value.
      */
     public function toHaveCount(int $count): Expectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -344,14 +344,12 @@ final class Expectation
 
         if (is_object($this->value)) {
             if (method_exists($this->value, 'toArray')) {
-                $array = $this->value->toArray();
+                $this->value = $this->value->toArray();
             } else {
-                $array = (array) $this->value;
+                $this->value = (array) $this->value;
             }
 
-            Assert::assertCount($number, $array);
-
-            return $this;
+            return $this->toHaveCount($number);
         }
 
         throw new BadMethodCallException('Expectation value length is not countable.');

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -419,6 +419,21 @@
   ✓ failures
   ✓ not failures
 
+   PASS  Tests\Features\Expect\toHaveLength
+  ✓ it passes with ('Fortaleza')
+  ✓ it passes with ('Sollefteå')
+  ✓ it passes with ('Ιεράπετρα')
+  ✓ it passes with ('PT-BR 🇵🇹🇧🇷😎')
+  ✓ it passes with (stdClass Object (...))
+  ✓ it passes with (Illuminate\Support\Collection Object (...))
+  ✓ it passes with array
+  ✓ it passes with *not*
+  ✓ it properly fails with *not*
+  ✓ it fails with (1)
+  ✓ it fails with (1.5)
+  ✓ it fails with (true)
+  ✓ it fails with (null)
+
    PASS  Tests\Features\Expect\toHaveProperty
   ✓ pass
   ✓ failures
@@ -662,5 +677,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 432 passed
+  Tests:  4 incompleted, 9 skipped, 445 passed
   

--- a/tests/Features/Expect/toHaveLength.php
+++ b/tests/Features/Expect/toHaveLength.php
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('passes', function ($value) {
+    expect($value)->toHaveLength(9);
+})->with([
+    'Fortaleza', 'Sollefteå', 'Ιεράπετρα', 'PT-BR 🇵🇹🇧🇷😎',
+    (object) [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    collect([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+]);
+
+it('passes with array', function () {
+    expect([1, 2, 3])->toHaveLength(3);
+});
+
+it('passes with *not*', function () {
+    expect('')->not->toHaveLength(1);
+});
+
+it('properly fails with *not*', function () {
+    expect('pest')->not->toHaveLength(4);
+})->throws(ExpectationFailedException::class);
+
+it('fails', function ($value) {
+    expect($value)->toHaveLength(1);
+})->with([1, 1.5, true, null])->throws(BadMethodCallException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #

Following @nunomaduro's feedback on [#384](https://github.com/pestphp/pest/pull/384)  
 
Adds the `toHaveLength()` expectation covering strings, arrays, objects and collections.

 ```php
 it('passes', function ($value) {
    expect($value)->toHaveLength(9);
})->with([
    'Fortaleza', 'Sollefteå', 'Ιεράπετρα', 'PT-BR 🇵🇹🇧🇷😎',
    (object) [1, 2, 3, 4, 5, 6, 7, 8, 9],
    collect([1, 2, 3, 4, 5, 6, 7, 8, 9]),
]);

it('passes with array', function () {
    expect([1, 2, 3])->toHaveLength(3);
});

it('passes with not', function () {
    expect([1, 2, 3])->not->toHaveLength(10);
});
 ```