### PR TITLE
Fix case sensitivity when finding test file

### DIFF
--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -25,8 +25,10 @@ final class Backtrace
     {
         $current = null;
 
+        $filerLoaderPath = mb_strtolower((string) realpath('vendor/phpunit/phpunit/src/Util/FileLoader.php'));
+
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
-            if (Str::endsWith($trace[self::FILE], (string) realpath('vendor/phpunit/phpunit/src/Util/FileLoader.php'))) {
+            if (Str::endsWith(mb_strtolower($trace[self::FILE]), $filerLoaderPath)) {
                 break;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

This fixes a really weird issue cause by how debug_backtrace works on case-insensitive file systems.

When using `debug_backtrace` on case insensitive file system it reports the file path as how `pwd` would report it. 
Meaning if I have a folder named `something` and `cd` into it as `SOMEtHing` and run my script, then `debug_backtrace` would report that folder as `SOMEtHing`.
However doing a `realpath` would report it as `something`. 

In pest we have a case where wo look at both file path from `debug_backtrace` and `realpath`, so to make sure we don't hit issues with this, we should lower case both file paths, so this won't happen. 


One potential problem with doing this is one actually case sensitive file system, this could in theory give false positives.


<!--
- Replace this comment by a description of what your PR is solving.
-->

