### PR TITLE
Use mb_strlen instead of grapheme_strlen

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -333,7 +333,7 @@ final class Expectation
     public function toHaveLength(int $number): Expectation
     {
         if (is_string($this->value)) {
-            Assert::assertEquals($number, grapheme_strlen($this->value));
+            Assert::assertEquals($number, mb_strlen($this->value));
 
             return $this;
         }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -423,7 +423,6 @@
   ✓ it passes with ('Fortaleza')
   ✓ it passes with ('Sollefteå')
   ✓ it passes with ('Ιεράπετρα')
-  ✓ it passes with ('PT-BR 🇵🇹🇧🇷😎')
   ✓ it passes with (stdClass Object (...))
   ✓ it passes with (Illuminate\Support\Collection Object (...))
   ✓ it passes with array
@@ -677,5 +676,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 445 passed
+  Tests:  4 incompleted, 9 skipped, 444 passed
   

--- a/tests/Features/Expect/toHaveLength.php
+++ b/tests/Features/Expect/toHaveLength.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 it('passes', function ($value) {
     expect($value)->toHaveLength(9);
 })->with([
-    'Fortaleza', 'Sollefteå', 'Ιεράπετρα', 'PT-BR 🇵🇹🇧🇷😎',
+    'Fortaleza', 'Sollefteå', 'Ιεράπετρα',
     (object) [1, 2, 3, 4, 5, 6, 7, 8, 9],
     collect([1, 2, 3, 4, 5, 6, 7, 8, 9]),
 ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #

Due to inconsistent behave of grapheme_strlen, mb_strlen will be used.

Even though I could get the expected behaviour when counting emoji texts on a local  windows machine, 

![Capture](https://user-images.githubusercontent.com/79267265/131247962-6157e7b1-4473-4880-843a-a570962c2278.PNG)

the tests were failing on [#386](https://github.com/pestphp/pest/pull/386)

<img width="594" alt="test" src="https://user-images.githubusercontent.com/79267265/131247984-a05a48df-b942-4e20-a9c7-e1f33bd88a4e.png">.

Thanks for the feeback @nunomaduro 
