### PR TITLE
Add `toHaveProperties`

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -389,9 +389,9 @@ final class Expectation
     /**
      * Asserts that the value contains the provided properties $names.
      *
-     * @param array<string> $names
+     * @param iterable<array-key, string> $names
      */
-    public function toHaveProperties(array $names): Expectation
+    public function toHaveProperties(iterable $names): Expectation
     {
         foreach ($names as $name) {
             $this->toHaveProperty($name);

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -387,6 +387,20 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value contains the provided properties $names.
+     *
+     * @param array<string> $names
+     */
+    public function toHaveProperties(array $names): Expectation
+    {
+        foreach ($names as $name) {
+            $this->toHaveProperty($name);
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that two variables have the same value.
      *
      * @param mixed $expected

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -433,6 +433,11 @@
   ✓ it fails with (true)
   ✓ it fails with (null)
 
+   PASS  Tests\Features\Expect\toHaveProperties
+  ✓ pass
+  ✓ failures
+  ✓ not failures
+
    PASS  Tests\Features\Expect\toHaveProperty
   ✓ pass
   ✓ failures
@@ -676,5 +681,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 444 passed
+  Tests:  4 incompleted, 9 skipped, 447 passed
   

--- a/tests/Features/Expect/toHaveProperties.php
+++ b/tests/Features/Expect/toHaveProperties.php
@@ -1,0 +1,26 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    $object = new stdClass();
+    $object->name = 'Jhon';
+    $object->age = 21;
+
+    expect($object)->toHaveProperties(['name', 'age']);
+});
+
+test('failures', function () {
+    $object = new stdClass();
+    $object->name = 'Jhon';
+
+    expect($object)->toHaveProperties(['name', 'age']);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    $object = new stdClass();
+    $object->name = 'Jhon';
+    $object->age = 21;
+
+    expect($object)->not->toHaveProperties(['name', 'age']);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds `ToHaveProperties`.

It is like [toHaveKeys](https://pestphp.com/docs/expectations#expect-toHaveKeys) but for object.
Useful when you want to assert the object has the expected properties but you don't care about the values.

```php
$obj->name = "Jhon";
$obj->age = 21;

expect($obj)->toHaveProperties(["name", "age"]); // passes
expect($obj)->toHaveProperties(["name", "age", "gender"]); // doest not pass
```