### PR TITLE
Add TestableValue to datasets.

### DIFF
--- a/src/Contracts/TestableValue.php
+++ b/src/Contracts/TestableValue.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Contracts;
+
+interface TestableValue
+{
+    /**
+     * @return mixed
+     */
+    public function origin();
+
+    /**
+     * @return mixed
+     */
+    public function expected();
+}

--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest;
 
 use Closure;
+use Pest\Contracts\TestableValue;
 use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
 use SebastianBergmann\Exporter\Exporter;
@@ -128,7 +129,11 @@ final class Datasets
             foreach ($datasets[$index] as $key => $values) {
                 $values             = is_array($values) ? $values : [$values];
                 $processedDataset[] = [
-                    'label'  => self::getDataSetDescription($key, $values),
+                    'label'  => self::getDataSetDescription($key, array_map(function ($value) {
+                        return ($value instanceof TestableValue)
+                                ? $value->origin()
+                                : $value;
+                    }, $values)),
                     'values' => $values,
                 ];
             }

--- a/src/Exceptions/MissingExpectedValue.php
+++ b/src/Exceptions/MissingExpectedValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use NunoMaduro\Collision\Contracts\RenderlessEditor;
+use NunoMaduro\Collision\Contracts\RenderlessTrace;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+
+final class MissingExpectedValue extends \InvalidArgumentException implements ExceptionInterface, RenderlessEditor, RenderlessTrace
+{
+}

--- a/src/Exceptions/MissingExpectedValue.php
+++ b/src/Exceptions/MissingExpectedValue.php
@@ -10,4 +10,11 @@ use Symfony\Component\Console\Exception\ExceptionInterface;
 
 final class MissingExpectedValue extends \InvalidArgumentException implements ExceptionInterface, RenderlessEditor, RenderlessTrace
 {
+    /**
+     * Creates a new instance of missing expected value exception.
+     */
+    public function __construct()
+    {
+        parent::__construct('No expected value available.');
+    }
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -11,6 +11,7 @@ use Pest\PendingObjects\UsesCall;
 use Pest\Support\Backtrace;
 use Pest\Support\Extendable;
 use Pest\Support\HigherOrderTapProxy;
+use Pest\Support\TestableValue;
 use Pest\TestSuite;
 use PHPUnit\Framework\TestCase;
 
@@ -28,6 +29,20 @@ function expect($value = null)
     }
 
     return new Expectation($value);
+}
+
+if (!function_exists('origin')) {
+    /**
+     * Creates a new testable value.
+     *
+     * @param mixed $origin the Value
+     *
+     * @return TestableValue
+     */
+    function origin($origin)
+    {
+        return new TestableValue($origin);
+    }
 }
 
 if (!function_exists('beforeAll')) {

--- a/src/Support/TestableValue.php
+++ b/src/Support/TestableValue.php
@@ -39,7 +39,7 @@ final class TestableValue implements TestableValueInterface
             return $this->value['expected'];
         }
 
-        throw new MissingExpectedValue('No expectation set.');
+        throw new MissingExpectedValue();
     }
 
     /**

--- a/src/Support/TestableValue.php
+++ b/src/Support/TestableValue.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+use Pest\Contracts\TestableValue as TestableValueInterface;
+use Pest\Exceptions\MissingExpectedValue;
+
+final class TestableValue implements TestableValueInterface
+{
+    /**
+     * @var array<mixed>
+     */
+    private $value = [];
+
+    /**
+     * @param mixed $origin
+     */
+    public function __construct($origin)
+    {
+        $this->value['origin'] = $origin;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function origin()
+    {
+        return $this->value['origin'];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function expected()
+    {
+        if (array_key_exists('expected', $this->value)) {
+            return $this->value['expected'];
+        }
+
+        throw new MissingExpectedValue('No expectation set.');
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return TestableValue
+     */
+    public function expect($value): TestableValueInterface
+    {
+        $this->value['expected'] = $value;
+
+        return $this;
+    }
+}

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -46,6 +46,10 @@
   ✓ eager wrapped registered datasets with (1)
   ✓ eager wrapped registered datasets with (2)
   ✓ eager registered wrapped datasets did the job right
+  ✓ dataset of single testable value with ('a')
+  ✓ dataset of single testable value with ('b')
+  ✓ dataset of multi testable value with ('a', 'aa')
+  ✓ dataset of multi testable value with ('b', 'bb')
   ✓ named datasets with data set "one"
   ✓ named datasets with data set "two"
   ✓ named datasets did the job right
@@ -619,6 +623,7 @@
    PASS  Tests\Unit\Datasets
   ✓ it show only the names of named datasets in their description
   ✓ it show the actual dataset of non-named datasets in their description
+  ✓ it show the origin value of non-named datasets in their description
   ✓ it show only the names of multiple named datasets in their description
   ✓ it show the actual dataset of multiple non-named datasets in their description
   ✓ it show the correct description for mixed named and not-named datasets
@@ -681,5 +686,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 447 passed
+  Tests:  4 incompleted, 9 skipped, 452 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -50,6 +50,7 @@
   ✓ dataset of single testable value with ('b')
   ✓ dataset of multi testable value with ('a', 'aa')
   ✓ dataset of multi testable value with ('b', 'bb')
+  ✓ testable value without expected value throw exception with ('a')
   ✓ named datasets with data set "one"
   ✓ named datasets with data set "two"
   ✓ named datasets did the job right
@@ -686,5 +687,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 452 passed
+  Tests:  4 incompleted, 9 skipped, 453 passed
   

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -4,6 +4,7 @@ use Pest\Contracts\TestableValue;
 use Pest\Datasets;
 use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
+use Pest\Exceptions\MissingExpectedValue;
 use Pest\Plugin;
 
 beforeEach(function () {
@@ -114,6 +115,12 @@ test('dataset of multi testable value', function (TestableValue $firstString, Te
     [origin('a')->expect('A'), origin('aa')->expect('AA')],
     [origin('b')->expect('B'), origin('bb')->expect('BB')],
 ]);
+
+test('testable value without expected value throw exception', function (TestableValue $string) {
+    $string->expected();
+})->with([
+    origin('a'),
+])->throws(MissingExpectedValue::class);
 
 test('named datasets', function ($text) use ($state, $datasets) {
     $state->text .= $text;

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pest\Contracts\TestableValue;
 use Pest\Datasets;
 use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
@@ -98,6 +99,21 @@ test('eager wrapped registered datasets', function ($text) use ($state, $dataset
 test('eager registered wrapped datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('1212121212');
 });
+
+test('dataset of single testable value', function (TestableValue $string) {
+    expect(strtoupper($string->origin()))->toEqual($string->expected());
+})->with([
+    origin('a')->expect('A'),
+    origin('b')->expect('B'),
+]);
+
+test('dataset of multi testable value', function (TestableValue $firstString, TestableValue $secondString) {
+    expect(strtoupper($firstString->origin()))->toEqual($firstString->expected());
+    expect(strtoupper($secondString->origin()))->toEqual($secondString->expected());
+})->with([
+    [origin('a')->expect('A'), origin('aa')->expect('AA')],
+    [origin('b')->expect('B'), origin('bb')->expect('BB')],
+]);
 
 test('named datasets', function ($text) use ($state, $datasets) {
     $state->text .= $text;

--- a/tests/Unit/Datasets.php
+++ b/tests/Unit/Datasets.php
@@ -26,6 +26,18 @@ it('show the actual dataset of non-named datasets in their description', functio
     expect($descriptions[1])->toBe('test description with (array(2))');
 });
 
+it('show the origin value of non-named datasets in their description', function () {
+    $descriptions = array_keys(Datasets::resolve('test description', [
+        [
+            [origin(1)->expect(10)],
+            [origin(2)],
+        ],
+    ]));
+
+    expect($descriptions[0])->toBe('test description with (1)');
+    expect($descriptions[1])->toBe('test description with (2)');
+});
+
 it('show only the names of multiple named datasets in their description', function () {
     $descriptions = array_keys(Datasets::resolve('test description', [
         [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Hi,

This PR add a new TestableValue class (and an `origine()` helper to create it) that let you create values with origin/expected values that can be used in datasets.
Those TestableValue objects will be nicely display in the tests name.

Example:

```php
test('uppercase', function (TestableValue $string) {
    expect(strtoupper($string->origin()))->toEqual($string->expected());
})->with([
    origin('a')->expect('A'),
    origin('b')->expect('B'),
]);
```

will output:

```
  ✓ uppercase with ('a')
  ✓ uppercase with ('b')
```

