### PR TITLE
Adds new `to()` method

### DIFF
--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -173,6 +173,15 @@
   ✓ it can be passed non-callable values
   ✓ it can be passed a mixture of value types
 
+   PASS  Tests\Features\Expect\to
+  ✓ allows to run on non-iterable data
+  ✓ fails if iterable items are used for the non-iterable value
+  ✓ allows it to be run on iterable data
+  ✓ loops back to the start if it runs out of items
+  ✓ fails if the number of iterable items is greater than the number of values
+  ✓ it can be passed non-callable values
+  ✓ it can be passed a mixture of value types
+
    PASS  Tests\Features\Expect\toBe
   ✓ strict comparisons
   ✓ failures
@@ -681,5 +690,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 447 passed
+  Tests:  4 incompleted, 9 skipped, 454 passed
   

--- a/tests/Features/Expect/to.php
+++ b/tests/Features/Expect/to.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('allows to run on non-iterable data', function () {
+    expect('foo')
+        ->to(
+            function ($value) { return str_replace('foo', 'bar', $value); }
+        )
+        ->toBe('bar');
+
+    expect(static::getCount())->toBe(2);
+});
+
+test('fails if iterable items are used for the non-iterable value', function () {
+    expect('foo')
+        ->to(
+            function ($value) { return $value; },
+            function ($value) { return $value; },
+        );
+})->throws(ExpectationFailedException::class);
+
+test('allows it to be run on iterable data', function () {
+    expect([1, 2, 3])
+        ->to(
+            function ($value) { return $value + 1; },
+            function ($value) { return $value + 1; },
+            function ($value) { return $value + 1; },
+        )
+        ->toMatchArray([2, 3, 4]);
+
+    expect(static::getCount())->toBe(6);
+});
+
+test('loops back to the start if it runs out of items', function () {
+    expect([1, 2, 3, 1, 2, 3, 1, 2])
+        ->to(
+            function ($value) { return $value + 1; },
+            function ($value) { return $value + 1; },
+            function ($value) { return $value + 1; },
+        )
+    ->toMatchArray([2, 3, 4, 2, 3, 4, 2, 3]);
+
+    expect(static::getCount())->toBe(16);
+});
+
+test('fails if the number of iterable items is greater than the number of values', function () {
+    expect([1, 2])
+        ->to(
+            function ($value) { return $value; },
+            function ($value) { return $value; },
+            function ($value) { return $value; },
+        );
+})->throws(ExpectationFailedException::class);
+
+test('it can be passed non-callable values', function () {
+    expect(['foo', 'bar', 'baz'])
+        ->to('pest', 'php', 'com')
+        ->toMatchArray(['pest', 'php', 'com']);
+
+    expect(static::getCount())->toBe(6);
+});
+
+test('it can be passed a mixture of value types', function () {
+    expect(['foo', 'bar', 'baz'])->to(
+        'foo',
+        function ($value) { return str_replace('bar', 'pest', $value); },
+        'baz'
+    )
+    ->toMatchArray(['foo', 'pest', 'baz']);
+
+    expect(static::getCount())->toBe(6);
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

It allows us to change the value/values in `expect()`.

Also useful for Higher Order Tests. Also, there is no need to add temporary variables to pass new values to expectations.

Like this: `->and($data)`

It's like a merge of the `and()` and `sequence()` methods. It has the advantage of being able to change the data for the continuation of expectations.

To use the `and()` method, you must pass a variable. However, with this method, we can do it all in one.

It's as useful as the `toArray()` and `json()` methods, but gives more freedom for the type of value to convert.

```php
test('parse markdown', function () {

    expect('# Foo')
        ->toBeString()
        ->to(
            fn ($value) => Parser::markdown($value)
        )
        ->toBe('<h1>Foo</h1>');
});
```

```php
test('parse currency', function () {

    expect([1, 2, 9999.99])
        ->toBeArray()
        ->toHaveCount(3)
        ->to(
            fn ($value) => Currency::parse($value)
        )
        ->toMatchArray(['1.00 USD', '2.00 USD', '10,000 USD']);
});
```

```php
test('complex', function () {

    expect(['# Foo', 2])
        ->toBeArray()
        ->toHaveCount(2)
        ->to(
            fn ($value) => Parser::markdown($value),
            fn ($value) => Currency::parse($value),
        )
        ->toMatchArray(['<h1>Foo</h1>', '2.00 USD']);
});
```


```php
it('validates the user names')
    ->expect(fn() => Auth::user())
    ->email->toEndWith('bar.com')
    ->to(fn($user) => ValidateUserName::isValid($user->username))
    ->toBeTrue();
```

For more examples, please review the tests.

Thank you.