### PR TITLE
Adds new `match()` method

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -212,7 +212,7 @@ final class Expectation
                 continue;
             }
 
-            (new self($this->value))->toEqual($callback);
+            $this->and($this->value)->toEqual($callback);
 
             break;
         }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -197,7 +197,6 @@ final class Expectation
 
         $subject   = $subject();
         $keys      = array_keys($expressions);
-        $matched   = false;
 
         if (in_array($subject, ['0', '1', false, true], true)) {
             $subject = (int) $subject;
@@ -208,8 +207,6 @@ final class Expectation
                 continue;
             }
 
-            $matched = true;
-
             if (is_callable($callback)) {
                 $callback(new self($this->value));
                 continue;
@@ -218,10 +215,6 @@ final class Expectation
             (new self($this->value))->toEqual($callback);
 
             break;
-        }
-
-        if (!$matched) {
-            test()->addWarning('No item found matching "' . $subject . '".');
         }
 
         return $this;

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -219,7 +219,7 @@ final class Expectation
 
         return $this;
     }
-  
+
     /**
      * It skips the tests in the callback if the condition is not truthy.
      *

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -158,6 +158,18 @@
   ✓ it properly parses json string
   ✓ fails with broken json string
 
+   WARN  Tests\Features\Expect\matchExpectation
+  ✓ it pass
+  ✓ it failures
+  ! it adds a warning if no match is found → No item found matching "bar".
+  ✓ it runs with truthy
+  ✓ it runs with falsy
+  ✓ it runs with truthy closure condition
+  ✓ it runs with falsy closure condition
+  ✓ it can be passed non-callable values
+  ! it passes with empty data → No item found matching "bar".
+  ✓ it can be used in higher order tests
+
    PASS  Tests\Features\Expect\not
   ✓ not property calls
 
@@ -681,5 +693,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 447 passed
+  Tests:  2 warnings, 4 incompleted, 9 skipped, 455 passed
   

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -158,16 +158,15 @@
   ✓ it properly parses json string
   ✓ fails with broken json string
 
-   WARN  Tests\Features\Expect\matchExpectation
+   PASS  Tests\Features\Expect\matchExpectation
   ✓ it pass
   ✓ it failures
-  ! it adds a warning if no match is found → No item found matching "bar".
   ✓ it runs with truthy
   ✓ it runs with falsy
   ✓ it runs with truthy closure condition
   ✓ it runs with falsy closure condition
   ✓ it can be passed non-callable values
-  ! it passes with empty data → No item found matching "bar".
+  ✓ it passes with empty data
   ✓ it can be used in higher order tests
 
    PASS  Tests\Features\Expect\not
@@ -693,5 +692,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  2 warnings, 4 incompleted, 9 skipped, 455 passed
+  Tests:  4 incompleted, 9 skipped, 456 passed
   

--- a/tests/Features/Expect/matchExpectation.php
+++ b/tests/Features/Expect/matchExpectation.php
@@ -39,16 +39,6 @@ it('failures', function () {
         );
 })->throws(ExpectationFailedException::class, 'true is false');
 
-it('adds a warning if no match is found', function () {
-    expect(true)
-        ->match('bar', [
-                'foo' => function ($value) {
-                    return $value->toBeFalse();
-                },
-            ]
-        );
-});
-
 it('runs with truthy', function () {
     expect('foo')
         ->match(1, [

--- a/tests/Features/Expect/matchExpectation.php
+++ b/tests/Features/Expect/matchExpectation.php
@@ -1,0 +1,160 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+beforeEach(function () {
+    $this->matched = null;
+});
+
+it('pass', function () {
+    expect('baz')
+        ->match('foo', [
+                'bar' => function ($value) {
+                    $this->matched = 'bar';
+
+                    return $value->toEqual('bar');
+                },
+                'foo' => function ($value) {
+                    $this->matched = 'baz';
+
+                    return $value->toEqual('baz');
+                },
+            ]
+        )
+        ->toEqual($this->matched);
+
+    expect(static::getCount())->toBe(2);
+});
+
+it('failures', function () {
+    expect(true)
+        ->match('foo', [
+                'bar' => function ($value) {
+                    return $value->toBeTrue();
+                },
+                'foo' => function ($value) {
+                    return $value->toBeFalse();
+                },
+            ]
+        );
+})->throws(ExpectationFailedException::class, 'true is false');
+
+it('adds a warning if no match is found', function () {
+    expect(true)
+        ->match('bar', [
+                'foo' => function ($value) {
+                    return $value->toBeFalse();
+                },
+            ]
+        );
+});
+
+it('runs with truthy', function () {
+    expect('foo')
+        ->match(1, [
+                'bar' => function ($value) {
+                    $this->matched = 'bar';
+
+                    return $value->toEqual('bar');
+                },
+                true => function ($value) {
+                    $this->matched = 'foo';
+
+                    return $value->toEqual('foo');
+                },
+            ]
+        )
+        ->toEqual($this->matched);
+
+    expect(static::getCount())->toBe(2);
+});
+
+it('runs with falsy', function () {
+    expect('foo')
+        ->match(false, [
+                'bar' => function ($value) {
+                    $this->matched = 'bar';
+
+                    return $value->toEqual('bar');
+                },
+                false => function ($value) {
+                    $this->matched = 'foo';
+
+                    return $value->toEqual('foo');
+                },
+            ]
+        )
+        ->toEqual($this->matched);
+
+    expect(static::getCount())->toBe(2);
+});
+
+it('runs with truthy closure condition', function () {
+    expect('foo')
+        ->match(
+            function () { return '1'; }, [
+                'bar' => function ($value) {
+                    $this->matched = 'bar';
+
+                    return $value->toEqual('bar');
+                },
+                true => function ($value) {
+                    $this->matched = 'foo';
+
+                    return $value->toEqual('foo');
+                },
+            ]
+        )
+        ->toEqual($this->matched);
+
+    expect(static::getCount())->toBe(2);
+});
+
+it('runs with falsy closure condition', function () {
+    expect('foo')
+        ->match(
+            function () { return '0'; }, [
+                'bar' => function ($value) {
+                    $this->matched = 'bar';
+
+                    return $value->toEqual('bar');
+                },
+                false => function ($value) {
+                    $this->matched = 'foo';
+
+                    return $value->toEqual('foo');
+                },
+            ]
+        )
+        ->toEqual($this->matched);
+
+    expect(static::getCount())->toBe(2);
+});
+
+it('can be passed non-callable values', function () {
+    expect('foo')
+        ->match('pest', [
+                'bar'  => 'foo',
+                'pest' => 'baz',
+            ]
+        );
+})->throws(ExpectationFailedException::class, 'two strings are equal');
+
+it('passes with empty data', function () {
+    expect('foo')
+        ->match('bar', [])
+        ->toEqual('foo');
+});
+
+it('can be used in higher order tests')
+    ->expect(true)
+    ->match(
+        function () { return true; }, [
+            false => function ($value) {
+                return $value->toBeFalse();
+            },
+            true => function ($value) {
+                return $value->toBeTrue();
+            },
+        ]
+    );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This is an alternative to #406.

```php
it('database test', function () {
    
    expect(new Foo())
        ->foo->toBe('foo')
        ->match(DB::getDriverName(), [
            'mysql'  => fn ($foo) => $foo->mysql->toBeTrue(),
            'sqlite' => fn ($foo) => $foo->sqlite->toBeTrue(),
        ])
        ->bar->toBe('bar');

});
```

```php
it('builder test', function ($driver) {
    
    expect(new Builder())
        ->match($driver, [
            'mysql'   => fn ($b) => $b->where('...')->toBe(...),
            'postgre' => fn ($b) => $b->whereRaw('...')->toBe(...),
        ]);
    
})->with([
    'mysql',
    'postgre',
]);
```

For more examples, please review the tests.

Thank you.
