### PR TITLE
Fix skipping tests with exception asserting

### DIFF
--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Closure;
+use PHPUnit\Framework\SkippedTestError;
 use ReflectionClass;
 use Throwable;
 
@@ -102,6 +103,10 @@ final class HigherOrderMessage
                 /* @phpstan-ignore-next-line */
                 $reflection = $reflection->getParentClass() ?: $reflection;
                 Reflection::setPropertyValue($throwable, 'message', sprintf('Call to undefined method %s::%s()', $reflection->getName(), $this->name));
+            }
+
+            if($throwable instanceof SkippedTestError){
+                return null;
             }
 
             throw $throwable;

--- a/src/Support/HigherOrderMessage.php
+++ b/src/Support/HigherOrderMessage.php
@@ -105,7 +105,7 @@ final class HigherOrderMessage
                 Reflection::setPropertyValue($throwable, 'message', sprintf('Call to undefined method %s::%s()', $reflection->getName(), $this->name));
             }
 
-            if($throwable instanceof SkippedTestError){
+            if ($throwable instanceof SkippedTestError) {
                 return null;
             }
 

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -37,3 +37,7 @@ it('can just define the message if given condition is true', function () {
 it('can just define the message if given condition is 1', function () {
     throw new Exception('Something bad happened');
 })->throwsIf(1, 'Something bad happened');
+
+it('can handle a skipped test if it is trying to catch an exception', function(){
+    expect(1)->toBe(2);
+})->throws(ExpectationFailedException::class)->skip('this test should be skipped');

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\ExpectationFailedException;
+
 it('gives access the the underlying expectException', function () {
     $this->expectException(InvalidArgumentException::class);
 
@@ -40,4 +42,4 @@ it('can just define the message if given condition is 1', function () {
 
 it('can handle a skipped test if it is trying to catch an exception', function(){
     expect(1)->toBe(2);
-})->throws(ExpectationFailedException::class)->skip('this test should be skipped');
+})->throws(ExpectationFailedException::class)->skip('this test should be skipped')->only();

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -40,6 +40,6 @@ it('can just define the message if given condition is 1', function () {
     throw new Exception('Something bad happened');
 })->throwsIf(1, 'Something bad happened');
 
-it('can handle a skipped test if it is trying to catch an exception', function(){
+it('can handle a skipped test if it is trying to catch an exception', function () {
     expect(1)->toBe(2);
-})->throws(ExpectationFailedException::class)->skip('this test should be skipped')->only();
+})->throws(ExpectationFailedException::class)->skip('this test should be skipped');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

This PR will fix skipped text failing if there is a throw expectation (see the test I've added in `tests/Feature/Exceptions.php`)

this test won't be skipped:

```php
it('can handle a skipped test if it is trying to catch an exception', function () {
    expect(1)->toBe(2);
})->throws(ExpectationFailedException::class)->skip('this test should be skipped');
```

but it will trigger an error instead:

```
Failed asserting that exception of type "PHPUnit\Framework\SkippedTestError" matches expected exception "PHPUnit\Framework\ExpectationFailedException". Message was: "this test should be skipped"
```
