### PR TITLE
Fix skipping tests with exception asserting

### DIFF
--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -140,6 +140,10 @@ final class TestCaseFactory
         $proxies     = $this->proxies;
         $factoryTest = $this->test;
 
+        if ($chains->hasMessage('markTestSkipped')) {
+            $proxies->forgetMessage('expectException');
+        }
+
         /**
          * @return mixed
          */

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -140,16 +140,12 @@ final class TestCaseFactory
         $proxies     = $this->proxies;
         $factoryTest = $this->test;
 
-        if ($chains->hasMessage('markTestSkipped')) {
-            $proxies->forgetMessage('expectException');
-        }
-
         /**
          * @return mixed
          */
         $test = function () use ($chains, $proxies, $factoryTest) {
-            $proxies->proxy($this);
             $chains->chain($this);
+            $proxies->proxy($this);
 
             /* @phpstan-ignore-next-line */
             return call_user_func(Closure::bind($factoryTest, $this, get_class($this)), ...func_get_args());

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -69,24 +69,4 @@ final class HigherOrderMessageCollection
             0,
         );
     }
-
-    public function hasMessage(string $name): bool
-    {
-        foreach ($this->messages as $message) {
-            if ($message->name === $name) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public function forgetMessage(string $name): void
-    {
-        foreach ($this->messages as $index => $message) {
-            if ($message->name === $name) {
-                unset($this->messages[$index]);
-            }
-        }
-    }
 }

--- a/src/Support/HigherOrderMessageCollection.php
+++ b/src/Support/HigherOrderMessageCollection.php
@@ -69,4 +69,24 @@ final class HigherOrderMessageCollection
             0,
         );
     }
+
+    public function hasMessage(string $name): bool
+    {
+        foreach ($this->messages as $message) {
+            if ($message->name === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function forgetMessage(string $name): void
+    {
+        foreach ($this->messages as $index => $message) {
+            if ($message->name === $name) {
+                unset($this->messages[$index]);
+            }
+        }
+    }
 }

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -43,7 +43,3 @@ it('can just define the message if given condition is 1', function () {
 it('can handle a skipped test if it is trying to catch an exception', function () {
     expect(1)->toBe(2);
 })->throws(ExpectationFailedException::class)->skip('this test should be skipped')->only();
-
-it('debug', function () {
-    expect(2)->toBe(2);
-})->skip('this test should be skipped')->only();

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\ExpectationFailedException;
+
 it('gives access the the underlying expectException', function () {
     $this->expectException(InvalidArgumentException::class);
 
@@ -37,3 +39,11 @@ it('can just define the message if given condition is true', function () {
 it('can just define the message if given condition is 1', function () {
     throw new Exception('Something bad happened');
 })->throwsIf(1, 'Something bad happened');
+
+it('can handle a skipped test if it is trying to catch an exception', function () {
+    expect(1)->toBe(2);
+})->throws(ExpectationFailedException::class)->skip('this test should be skipped')->only();
+
+it('debug', function () {
+    expect(2)->toBe(2);
+})->skip('this test should be skipped')->only();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

This PR will fix skipped text failing if there is a throw expectation (see the test I've added in `tests/Feature/Exceptions.php`)

this test won't be skipped:

```php
it('can handle a skipped test if it is trying to catch an exception', function () {
    expect(1)->toBe(2);
})->throws(ExpectationFailedException::class)->skip('this test should be skipped');
```

but it will trigger an error instead:

```
Failed asserting that exception of type "PHPUnit\Framework\SkippedTestError" matches expected exception "PHPUnit\Framework\ExpectationFailedException". Message was: "this test should be skipped"
```



**Edit** I've proposed a cleaner solution than this one, see [this comment](https://github.com/pestphp/pest/pull/413#issuecomment-932698555)
~~The fix is made by adding two ne methods to `HigherOrderMessageCollection` (`hasMessage($name)` and `forgetMessage($name)`) and using them in `TestCaseFactory` to detect skipped tests and removing all exception expectation from them:~~

```php
/// TestCaseFactory.php

 if ($chains->hasMessage('markTestSkipped')) {
      $proxies->forgetMessage('expectException');
  }
```