### PR TITLE
feat: add `--memory` usage flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         },
         "pest": {
             "plugins": [
+                "Pest\\Plugins\\Memory",
                 "Pest\\Plugins\\Coverage",
                 "Pest\\Plugins\\Init",
                 "Pest\\Plugins\\Version",

--- a/src/Plugins/Memory.php
+++ b/src/Plugins/Memory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Plugins;
+
+use Pest\Contracts\Plugins\AddsOutput;
+use Pest\Contracts\Plugins\HandlesArguments;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Memory implements AddsOutput, HandlesArguments
+{
+    /** @var OutputInterface */
+    private $output;
+
+    private bool $enabled = false;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function handleArguments(array $arguments): array
+    {
+        foreach ($arguments as $index => $argument) {
+            if ($argument === '--memory') {
+                unset($arguments[$index]);
+
+                $this->enabled = true;
+            }
+        }
+
+        return array_values($arguments);
+    }
+
+    public function addOutput(int $result): int
+    {
+        if ($this->enabled) {
+            $this->output->writeln(sprintf(
+                '  <fg=white;options=bold>Memory: </><fg=default>%s MB</>',
+                round(memory_get_usage(true) / pow(1000, 2), 3)
+            ));
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | ...

This is related to https://github.com/pestphp/pest/issues/375#issuecomment-903183321, and [this message in Discord](https://discord.com/channels/705126275232038944/710642595705126923/905233861615710299).

I've decided to go with outputting `MB`, but I guess we could make it so that it works it out the unit automatically (i.e. B, MB, GB) if that would be better?

Also, I just wanted someone to clarify if `memory_get_usage()` is the correct function to use for this? 🤔