### PR TITLE
[1.x] Fix for sequence

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -170,7 +170,7 @@ final class Expectation
         }
 
         foreach ($values as $key => $item) {
-            if (is_callable($callbacks[$key])) {
+            if ($callbacks[$key] instanceof Closure) {
                 call_user_func($callbacks[$key], new self($item), new self($keys[$key]));
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Previously, any string passed to sequence that was also a function name would cause a failure. This fixes that by specifying a closure.

Will port to master too once merged.
