### PR TITLE
Small Tweaks for Pest v2

### DIFF
--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -73,9 +73,10 @@ final class TestCaseFactory
     {
         $methodsUsingOnly = $this->methodsUsingOnly();
 
-        $methods = array_values(array_filter($this->methods, function ($method) use ($methodsUsingOnly) {
-            return count($methodsUsingOnly) === 0 || in_array($method, $methodsUsingOnly, true);
-        }));
+        $methods = array_values(array_filter(
+            $this->methods,
+            fn ($method) => count($methodsUsingOnly) === 0 || in_array($method, $methodsUsingOnly, true)
+        ));
 
         if (count($methods) > 0) {
             $this->evaluate($this->filename, $methods);

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 final class TestCaseMethodFactory
 {
     use HigherOrderable;
+
     /**
      * Determines if the Test Case will be the "only" being run.
      */
@@ -51,11 +52,9 @@ final class TestCaseMethodFactory
         public ?string $description,
         public ?Closure $closure,
     ) {
-        if ($this->closure === null) {
-            $this->closure = function () {
-                Assert::getCount() > 0 ?: self::markTestIncomplete(); // @phpstan-ignore-line
-            };
-        }
+        $this->closure ??= function () {
+            Assert::getCount() > 0 ?: self::markTestIncomplete(); // @phpstan-ignore-line
+        };
 
         $this->bootHigherOrderable();
     }


### PR DESCRIPTION
Just going through the Pest source code and made a few little tweaks. These are opinions so feel free to disagree.

The main change is moving the responsibility of generating the test *method* string to `TestCaseMethodFactory`. This serves to reduce the complexity of the large `evaluate` function to make it easier to understand. 

