### PR TITLE
[2.x] Adds support for chaining `hasNoExpectations` to the test method.

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -161,9 +161,11 @@ final class TestCall
     }
 
     /**
-     * Informs the test runner that no expectations happen in this test.
+     * Informs the test runner that no expectations happen in this test,
+     * and its purpose is simply to check whether the given code can
+     * be executed without throwing exceptions.
      */
-    public function hasNoExpectations(): TestCall
+    public function throwsNoExceptions(): TestCall
     {
         $this->testCaseMethod->proxies->add(Backtrace::file(), Backtrace::line(), 'expectNotToPerformAssertions', []);
 

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -160,6 +160,9 @@ final class TestCall
         return $this;
     }
 
+    /**
+     * Informs the test runner that no expectations happen in this test.
+     */
     public function hasNoExpectations(): TestCall
     {
         $this->testCaseMethod->proxies->add(Backtrace::file(), Backtrace::line(), 'expectNotToPerformAssertions', []);

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -160,6 +160,13 @@ final class TestCall
         return $this;
     }
 
+    public function hasNoExpectations(): TestCall
+    {
+        $this->testCaseMethod->proxies->add(Backtrace::file(), Backtrace::line(), 'expectNotToPerformAssertions', []);
+
+        return $this;
+    }
+
     /**
      * Saves the property accessors to be used on the target.
      */

--- a/tests/Features/HasNoExpectations.php
+++ b/tests/Features/HasNoExpectations.php
@@ -1,0 +1,11 @@
+<?php
+
+it('allows access to the underlying expectNotToPerformAssertions method', function () {
+    $this->expectNotToPerformAssertions();
+
+    $result = 1 + 1;
+});
+
+it('allows performing no expectations without being risky', function () {
+    $result = 1 + 1;
+})->hasNoExpectations();

--- a/tests/Features/ThrowsNoExceptions.php
+++ b/tests/Features/ThrowsNoExceptions.php
@@ -8,4 +8,4 @@ it('allows access to the underlying expectNotToPerformAssertions method', functi
 
 it('allows performing no expectations without being risky', function () {
     $result = 1 + 1;
-})->hasNoExpectations();
+})->throwsNoExceptions();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

A feature that is often useful in PHPUnit is `expectNotToPerformAssertions`. This is handy when you have a method that is simply testing that a method can be called without throwing any exceptions or causing any errors, without being interested in the end result.

This PR adds a new `hasNoExpectations` method to the `TestCall` class, which allows us to support this functionality in a style more aligned with Pest:

```php
it('does not throw any errors when run', function () {
    SomeComplexService::run();
})->hasNoExpectations();
```

By adding this, we provide 2 main benefits:

1) We allow for visual consistency with other Pest `TestCall` methods, such as `throws`
2) We use the term `expectations` instead of `assertions`, which Pest users are less familiar with

Kind Regards,
Luke