### PR TITLE
Allows prepending '>>>' to a dataset key

### DIFF
--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -157,6 +157,7 @@ final class DatasetsRepository
             }
 
             $filteredDataset = array_filter(
+                // @phpstan-ignore-next-line
                 $datasets[$index],
                 fn ($key) => str_starts_with(strval($key), '>>>'),
                 ARRAY_FILTER_USE_KEY

--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -156,6 +156,14 @@ final class DatasetsRepository
                 $datasets[$index] = iterator_to_array($datasets[$index]);
             }
 
+            $filteredDataset = array_filter(
+                $datasets[$index],
+                fn ($key) => str_starts_with(strval($key), '>>>'),
+                ARRAY_FILTER_USE_KEY
+            );
+
+            $datasets[$index] = count($filteredDataset) > 0 ? $filteredDataset : $datasets[$index];
+
             //@phpstan-ignore-next-line
             foreach ($datasets[$index] as $key => $values) {
                 $values             = is_array($values) ? $values : [$values];

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -288,8 +288,10 @@ it('can correctly resolve a bound dataset that returns an array but wants to be 
 it('can specify a single item in the dataset to run', function (Closure $closure) {
     $closure();
 })->throws('This should run')->with([
-    'this should not run' => fn () => throw new Exception('This should have been skipped'),
-    '>>>this should run' => fn () => throw new Exception('This should run'),
-    'this also should not run' => fn () => throw new Exception('This should have been skipped'),
+    'this should not run'         => fn ()         => throw new Exception('This should have been skipped'),
+    '>>>this should run'          => fn ()          => throw new Exception('This should run'),
+    'this also should not run'    => fn ()    => throw new Exception('This should have been skipped'),
     '>>> but this one should run' => fn () => throw new Exception('This should run'),
+    fn ()                         => throw new Exception('This should have been skipped'),
+    '>>>'                         => fn ()                         => throw new Exception('This should run'),
 ]);

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -288,10 +288,10 @@ it('can correctly resolve a bound dataset that returns an array but wants to be 
 it('can specify a single item in the dataset to run', function (Closure $closure) {
     $closure();
 })->throws('This should run')->with([
-    'this should not run'         => fn ()         => throw new Exception('This should have been skipped'),
-    '>>>this should run'          => fn ()          => throw new Exception('This should run'),
-    'this also should not run'    => fn ()    => throw new Exception('This should have been skipped'),
+    'this should not run'         => fn () => throw new Exception('This should have been skipped'),
+    '>>>this should run'          => fn () => throw new Exception('This should run'),
+    'this also should not run'    => fn () => throw new Exception('This should have been skipped'),
     '>>> but this one should run' => fn () => throw new Exception('This should run'),
     fn ()                         => throw new Exception('This should have been skipped'),
-    '>>>'                         => fn ()                         => throw new Exception('This should run'),
+    '>>>'                         => fn () => throw new Exception('This should run'),
 ]);

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -284,3 +284,12 @@ it('can correctly resolve a bound dataset that returns an array but wants to be 
 })->with([
     function () { return ['foo', 'bar', 'baz']; },
 ]);
+
+it('can specify a single item in the dataset to run', function (Closure $closure) {
+    $closure();
+})->throws('This should run')->with([
+    'this should not run' => fn () => throw new Exception('This should have been skipped'),
+    '>>>this should run' => fn () => throw new Exception('This should run'),
+    'this also should not run' => fn () => throw new Exception('This should have been skipped'),
+    '>>> but this one should run' => fn () => throw new Exception('This should run'),
+]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Hello there!

As discussed internally yesterday, when working with datasets, you often come across a bug in just one of the dataset items. You don't want to run the entire dataset, but it is a real pain to comment out all but one of the items. To allow for devs to quickly specify that Pest run just one item in a dataset, this PR adds the ability to prepend a dataset key with '>>>'.

```php
it('can specify a single item in the dataset to run', function (Closure $closure) {
    $closure();
})->throws('This should run')->with([
    'this should not run' => fn () => throw new Exception('This should have been skipped'),
    '>>>this should run' => fn () => throw new Exception('This should run'),
    'this also should not run' => fn () => throw new Exception('This should have been skipped'),
    '>>> but this one should run' => fn () => throw new Exception('This should run'),
    fn () => throw new Exception('This should have been skipped'),
    '>>>' => fn () => throw new Exception('This should run'),
]);
```

If Pest detects the presence of '>>>' at the start of a dataset item description, it will filter to only dataset items that start with '>>>' for the given test. 

This will allow devs to quickly whitelist a dataset item for debugging, before turning it off again once resolved.

'>>>' was chosen for its uniqueness, but other options are of course up for discussion here too.

Kind Regards,
Luke
