### PR TITLE
Avoid nested expectations with `and()`

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -56,7 +56,7 @@ final class Expectation
      */
     public function and(mixed $value): Expectation
     {
-        return new self($value);
+        return $value instanceof static ? $value : new self($value);
     }
 
     /**

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -44,7 +44,7 @@ final class HigherOrderCallables
      *
      * @param callable|TValue $value
      *
-     * @return Expectation<TValue>
+     * @return Expectation<(callable(): mixed)|TValue>
      */
     public function and(mixed $value)
     {

--- a/tests/Features/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Features/Expect/HigherOrder/methodsAndProperties.php
@@ -48,6 +48,15 @@ it('can start a new higher order expectation using the and syntax in higher orde
     ->toBeArray()
     ->foo->toEqual('bar');
 
+it('can start a new higher order expectation using the and syntax without nesting expectations', function () {
+    expect(new HasMethodsAndProperties())
+        ->toBeInstanceOf(HasMethodsAndProperties::class)
+        ->meta
+        ->sequence(
+            function ($value, $key) { $value->toBeArray()->and($key)->toBe('foo'); },
+        );
+});
+
 class HasMethodsAndProperties
 {
     public $name = 'Has Methods and Properties';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

---

When using `and()` with an expectation, `and()` wraps the expectation into an expectation. That doesn't happen often but it can occur when using something like `sequence()`, where both value and key are already wrapped in an expectation.

```php
it('inspects properties')
    ->expect(['foo' => ['bar' => 'baz']])
    ->sequence(
        fn ($value, $key) => $value->toBeArray()->and($key->value)->toBe('foo'),
    );
```

As the code above shows, we are forced to access the underneath value of the expectation (`$key->value`) to make the test work.

This PR allows `and()` to check if we are passing an expectation - if so, we just return the expectation and don't nest it into a new one. The end result will look like this:

```php
it('inspects properties')
    ->expect(['foo' => ['bar' => 'baz']])
    ->sequence(
        fn ($value, $key) => $value->toBeArray()->and($key)->toBe('foo'),
    );
```