### PR TITLE
Add support for invokable classes in higher order expectations

### DIFF
--- a/src/Contracts/IsHigherOrderCallable.php
+++ b/src/Contracts/IsHigherOrderCallable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Contracts;
+
+/**
+ * Interface used to mark a class callable by higher order expectations.
+ */
+interface IsHigherOrderCallable
+{
+    public function __invoke(): mixed;
+}

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Closure;
+use Pest\Contracts\IsHigherOrderCallable;
 use Pest\Expectation;
 
 /**
@@ -31,6 +32,10 @@ final class HigherOrderCallables
      */
     public function expect(mixed $value): Expectation
     {
+        if ($value instanceof IsHigherOrderCallable) {
+            $value = fn (...$data) => $value(...$data);
+        }
+
         /** @var TValue $value */
         $value = $value instanceof Closure ? Reflection::bindCallableWithData($value) : $value;
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -543,6 +543,11 @@
   ✓ it can forward unexpected calls to any global function
   ✓ it can use helpers from helpers file
 
+   PASS  Tests\Features\HigherOrderCallables
+  ✓ it treats higher order callables as callables
+  ✓ it can pass datasets to higher order callables with (1, 2, 3)
+  ✓ it does not treat all invokable classes as callables
+
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
   ✓ it is capable doing multiple assertions
@@ -573,8 +578,8 @@
 
    PASS  Tests\Features\PendingHigherOrderTests
   ✓ get 'foo'
-  ✓ get 'foo' → get 'bar' → expect true → toBeTrue 
-  ✓ get 'foo' → expect true → toBeTrue 
+  ✓ get 'foo' → get 'bar' → expect true → toBeTrue
+  ✓ get 'foo' → expect true → toBeTrue
 
    WARN  Tests\Features\Skip
   ✓ it do not skips
@@ -740,5 +745,4 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 487 passed
-  
+  Tests:  4 incompleted, 9 skipped, 380 passed

--- a/tests/Features/HigherOrderCallables.php
+++ b/tests/Features/HigherOrderCallables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Pest\Contracts\IsHigherOrderCallable;
+
+class HigherOrderCallable implements IsHigherOrderCallable
+{
+    public function __invoke()
+    {
+        return 'foo';
+    }
+}
+class HigherOrderCallableReturningArguments implements IsHigherOrderCallable
+{
+    public function __invoke(...$args)
+    {
+        return $args;
+    }
+}
+class RandomInvokableClass
+{
+    public function __invoke()
+    {
+        return 'foo';
+    }
+}
+
+beforeEach()->assertTrue(true);
+
+it('treats higher order callables as callables')
+    ->expect(new HigherOrderCallable())
+    ->toBe('foo');
+
+it('can pass datasets to higher order callables')
+    ->with([[1, 2, 3]])
+    ->expect(new HigherOrderCallableReturningArguments())
+    ->toBe([1, 2, 3]);
+
+it('does not treat all invokable classes as callables')
+    ->expect(new RandomInvokableClass())
+    ->toBeInstanceOf(RandomInvokableClass::class);
+
+afterEach()->assertTrue(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | none

## Problem this PR tries to solve
Currently, only closures can be passed to higher order expectations, therefore it is impossible to pass invokable classes into the `test()->expect(...)` method.

## Solution
The naive approach of allowing all callables brings even more problems with it (see #344). This PR tries to allow invokable classes implementing a specific interface provided by pest to get executed by the higher order test expectation call. This way, the callables executed by higher order test expectations are more flexible instead of just accepting plain closures but do not unexpectedly evaluate strings or other callable classes.

## Example
```php
class HigherOrderCallable implements Pest\Contracts\IsHigherOrderCallable
{
    public function __invoke()
    {
        return 'foo';
    }
}

test('higher order callable')
    ->expect(new HigherOrderCallable())
    ->toBe('foo')
```

## Use case
I am currently building a function, that takes care of setting up some complex database situations in a laravel app that should then be tested. Accessing the generated database entries via the Eloquent models is done via a global `situation()` helper function, which returns an object containing all created models. Currently, I am accesing them in higher order expectations like this:

```php
test('has status created')
    ->expect(fn() => situation()->user)
    ->status()->toBe('created')
```

To make this a little bit easier, I wanted the `situation()` helper to return a kind of higher order function builder itself if it was called outside of a running testsuite, in a way that the previous code could be rewritten to: 

```php
test('has status created')
    ->expect(situation()->user) // Note the missing 'fn() => ' in this line
    ->status()->toBe('created')
```

With this approach, `situation()->user` is returning an invokable class, which doesn't get evaluated by pest currently. 

Happy to hear your feedback on this.