### PR TITLE
feature: Pass `each()` keys to closures

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -125,8 +125,8 @@ final class Expectation
         }
 
         if (is_callable($callback)) {
-            foreach ($this->value as $item) {
-                $callback(new self($item));
+            foreach ($this->value as $key => $item) {
+                $callback(new self($item), $key);
             }
         }
 

--- a/tests/Features/Expect/each.php
+++ b/tests/Features/Expect/each.php
@@ -79,13 +79,19 @@ it('can add expectations via "and"', function () {
 });
 
 it('accepts callables', function () {
-    expect([1, 2, 3])->each(function ($number, $key) {
+    expect([1, 2, 3])->each(function ($number) {
         expect($number)->toBeInstanceOf(Expectation::class);
         expect($number->value)->toBeInt();
         $number->toBeInt->not->toBeString;
+    });
 
+    expect(static::getCount())->toBe(12);
+});
+
+it('passes the key of the current item to callables', function () {
+    expect([1, 2, 3])->each(function ($number, $key) {
         expect($key)->toBeInt();
     });
 
-    expect(static::getCount())->toBe(15);
+    expect(static::getCount())->toBe(3);
 });

--- a/tests/Features/Expect/each.php
+++ b/tests/Features/Expect/each.php
@@ -79,11 +79,13 @@ it('can add expectations via "and"', function () {
 });
 
 it('accepts callables', function () {
-    expect([1, 2, 3])->each(function ($number) {
+    expect([1, 2, 3])->each(function ($number, $key) {
         expect($number)->toBeInstanceOf(Expectation::class);
         expect($number->value)->toBeInt();
         $number->toBeInt->not->toBeString;
+
+        expect($key)->toBeInt();
     });
 
-    expect(static::getCount())->toBe(12);
+    expect(static::getCount())->toBe(15);
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds `$key` as a second parameter to `each()` closures.

It is used to retrieve the key of the current item in the array, which is useful when cross-referencing each item to an expected item. For example:

```php
it('can list teams', function () {
    /** @var AuthenticatedTestCase $this */

    $teams = Team::factory()
        ->hasAttached($this->user, [], 'members')
        ->count(5)
        ->create();

    $returnedTeams = getJson(route('api.v2.teams.index'))
        ->assertSuccessful()
        ->json('data');

    expect($returnedTeams)
        ->toBeArray()
        ->each(function (Expectation $returnedTeam, $teamKey) use ($teams) {
            $team = $teams[$teamKey];

            $returnedTeam
                ->toBeArray()
                ->toMatchArray([
                    'name' => $team->name,
                ]);
        });
});
```

We can use `$teamKey` to get the original team from the Eloquent collection and check that the API returns the correct team data for every item.

Without this feature, we'd have to use a normal `foreach` loop which is not fluent:

```php
expect($returnedTeams)
    ->toBeArray();

foreach ($returnedTeams as $teamKey => $returnedTeam) {
    $team = $teams[$teamKey];

    expect($returnedTeam)
        ->toBeArray()
        ->toMatchArray([
            'name' => $team->name,
        ]);
}
```

Maybe this is already possible using other methods from the expectation API? If yes, please let me know :)