### PR TITLE
Fixes `json` in Higher Order Expectations

### DIFF
--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -77,6 +77,11 @@ final class HigherOrderExpectation
         return $this->expect($value);
     }
 
+    public function json(): HigherOrderExpectation
+    {
+        return new self($this->original, $this->expectation->json()->value);
+    }
+
     /**
      * Dynamically calls methods on the class with the given arguments.
      *

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -124,6 +124,7 @@
   ✓ it can compose complex expectations
   ✓ it can handle nested method calls
   ✓ it works with higher order tests
+  ✓ it can call the json method in higher order expectations
 
    PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
   ✓ it can access methods and properties
@@ -720,5 +721,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 478 passed
+  Tests:  4 incompleted, 9 skipped, 479 passed
   

--- a/tests/Features/Expect/HigherOrder/methods.php
+++ b/tests/Features/Expect/HigherOrder/methods.php
@@ -77,14 +77,14 @@ it('works with higher order tests')
 it('can call the json method in higher order expectations', function () {
     expect(new HasMethods())
         ->getJsonContent()->json()->id->toBe(1)->toBeGreaterThan(0)
-        ->getJsonContent()->json()->email->toBe('amenophis@leherpeur.net');
+        ->getJsonContent()->json()->email->toBe('foo@bar.com');
 });
 
 class HasMethods
 {
     public function getJsonContent(): string
     {
-        return '{"id":1,"username":"amenophis","email":"amenophis@leherpeur.net"}';
+        return '{"id":1,"username":"dan","email":"foo@bar.com"}';
     }
 
     public function name()

--- a/tests/Features/Expect/HigherOrder/methods.php
+++ b/tests/Features/Expect/HigherOrder/methods.php
@@ -74,8 +74,19 @@ it('works with higher order tests')
     ->name()->toEqual('Has Methods')
     ->books()->each->toBeArray;
 
+it('can call the json method in higher order expectations', function () {
+    expect(new HasMethods())
+        ->getJsonContent()->json()->id->toBe(1)->toBeGreaterThan(0)
+        ->getJsonContent()->json()->email->toBe('amenophis@leherpeur.net');
+});
+
 class HasMethods
 {
+    public function getJsonContent(): string
+    {
+        return '{"id":1,"username":"amenophis","email":"amenophis@leherpeur.net"}';
+    }
+
     public function name()
     {
         return 'Has Methods';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #452

@dansysanalyst and I have been looking into possible solutions for this issue. We have decided on the following:

```php
it('can call the json method in higher order expectations', function () {
    expect(new HasMethods())
        ->getJsonContent()->json()->id->toBe(1)->toBeGreaterThan(0)
        ->getJsonContent()->json()->email->toBe('amenophis@leherpeur.net');
});
```

Note that at the end of an expectation chain with `json`, the scope will now completely reset, which is in line with how other expectation methods work. Previously, `json` in Higher Order Expectations wasn't working at all.

There was an alternative, which would allow for staying in the JSON object for more expectations on it, but that would have been out of place with how the rest of the expectation API works.
