### PR TITLE
Makes `json` expectation usable in Higher Order Tests

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -62,7 +62,7 @@ final class Expectation
     /**
      * Creates a new expectation with the decoded JSON value.
      *
-     * @return self<mixed>
+     * @return self<array<int|string, mixed>|bool>
      */
     public function json(): Expectation
     {
@@ -70,7 +70,10 @@ final class Expectation
             InvalidExpectationValue::expected('string');
         }
 
-        return $this->toBeJson()->and(json_decode($this->value, true));
+        /** @var array<int|string, mixed>|bool $value */
+        $value = json_decode($this->value, true);
+
+        return $this->toBeJson()->and($value);
     }
 
     /**

--- a/src/Expectations/HigherOrderExpectation.php
+++ b/src/Expectations/HigherOrderExpectation.php
@@ -80,6 +80,16 @@ final class HigherOrderExpectation
     }
 
     /**
+     * Creates a new expectation with the decoded JSON value.
+     *
+     * @return self<TOriginalValue, array<string|int, mixed>|bool>
+     */
+    public function json(): self
+    {
+        return new self($this->original, $this->expectation->json()->value);
+    }
+
+    /**
      * Dynamically calls methods on the class with the given arguments.
      *
      * @param array<int, mixed> $arguments

--- a/tests/Features/Expect/HigherOrder/methods.php
+++ b/tests/Features/Expect/HigherOrder/methods.php
@@ -74,8 +74,20 @@ it('works with higher order tests')
     ->name()->toEqual('Has Methods')
     ->books()->each->toBeArray;
 
+it('works consistently with the json expectation method', function () {
+    expect(new HasMethods())
+        ->jsonString()->json()->id->toBe(1)
+        ->jsonString()->json()->name->toBe('Has Methods')->toBeString()
+        ->jsonString()->json()->quantity->toBe(20)->toBeInt();
+});
+
 class HasMethods
 {
+    public function jsonString(): string
+    {
+        return '{ "id": 1, "name": "Has Methods", "quantity": 20 }';
+    }
+
     public function name()
     {
         return 'Has Methods';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #452 

This fixes an issue with the `json` expectation method when using Higher Order tests. It is technically breaking, hence v2. I've also taken the opportunity to improve type hinting on the `json` method.

