### PR TITLE
Renames `tap` to `defer`.

### DIFF
--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -52,9 +52,9 @@ final class HigherOrderCallables
     }
 
     /**
-     * Tap into the test case to perform an action and return the test case.
+     * Execute the given callable after the test has executed the setup method.
      */
-    public function tap(callable $callable): object
+    public function defer(callable $callable): object
     {
         Reflection::bindCallableWithData($callable);
 

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -21,9 +21,9 @@ it('resolves expect callables correctly')
 test('does not treat method names as callables')
     ->expect('it')->toBeString();
 
-it('can tap into the test')
+it('can defer a method until after test setup')
     ->expect('foo')->toBeString()
-    ->tap(function () { expect($this)->toBeInstanceOf(TestCase::class); })
+    ->defer(function () { expect($this)->toBeInstanceOf(TestCase::class); })
     ->toBe('foo')
     ->and('hello world')->toBeString();
 
@@ -32,15 +32,15 @@ it('can pass datasets into the expect callables')
     ->expect(function (...$numbers) { return $numbers; })->toBe([1, 2, 3])
     ->and(function (...$numbers) { return $numbers; })->toBe([1, 2, 3]);
 
-it('can pass datasets into the tap callable')
+it('can pass datasets into the defer callable')
     ->with([[1, 2, 3]])
-    ->tap(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
+    ->defer(function (...$numbers) { expect($numbers)->toBe([1, 2, 3]); });
 
 it('can pass shared datasets into callables')
     ->with('numbers.closure.wrapped')
     ->expect(function ($value) { return $value; })
     ->and(function ($value) { return $value; })
-    ->tap(function ($value) { expect($value)->toBeInt(); })
+    ->defer(function ($value) { expect($value)->toBeInt(); })
     ->toBeInt();
 
 afterEach()->assertTrue(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

After discussion, we've decided to rename `tap` to `defer` in Higher Order Tests. This PR makes the needed changes for this.