### PR TITLE
Adds support for `scoped` in HigherOrderExpectations

### DIFF
--- a/src/Expectations/HigherOrderExpectation.php
+++ b/src/Expectations/HigherOrderExpectation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Expectations;
 
+use Closure;
 use Pest\Concerns\Retrievable;
 use Pest\Expectation;
 
@@ -77,6 +78,21 @@ final class HigherOrderExpectation
     public function and(mixed $value): Expectation
     {
         return $this->expect($value);
+    }
+
+    /**
+     * Scope an expectation callback to the current value in
+     * the HigherOrderExpectation chain.
+     *
+     * @param Closure(Expectation<TValue>): void $expectation
+     *
+     * @return HigherOrderExpectation<TOriginalValue, TOriginalValue>
+     */
+    public function scoped(Closure $expectation): self
+    {
+        $expectation->__invoke($this->expectation);
+
+        return new self($this->original, $this->original->value);
     }
 
     /**

--- a/tests/Features/Expect/HigherOrder/methods.php
+++ b/tests/Features/Expect/HigherOrder/methods.php
@@ -74,6 +74,23 @@ it('works with higher order tests')
     ->name()->toEqual('Has Methods')
     ->books()->each->toBeArray;
 
+it('can use the scoped method to lock into the given level for expectations', function () {
+    expect(new HasMethods())
+        ->attributes()->scoped(fn ($attributes) => $attributes
+            ->name->toBe('Has Methods')
+            ->quantity->toBe(20)
+        )
+        ->name()->toBeString()->toBe('Has Methods')
+        ->newInstance()->newInstance()->scoped(fn ($instance) => $instance
+            ->name()->toBe('Has Methods')
+            ->quantity()->toBe(20)
+            ->attributes()->scoped(fn ($attributes) => $attributes
+                ->name->toBe('Has Methods')
+                ->quantity->toBe(20)
+            )
+        );
+});
+
 class HasMethods
 {
     public function name()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds a new method to Higher Order Expectations: `scoped`. It is partially inspired by Inertia's assertions and allows for more complex expectation chains without additional boilerplate.

Here's an example.

```php
$user = User::find(1);

// Before
expect($user)
  ->name->toBe('Nuno Maduro')
  ->email->toBe('foo@bar.com')
  ->address()->line1->toBe('1 Pest Street')
  ->address()->city->toBe('Lisbon')
  ->address()->country->toBe('Portugal')

// After
expect($user)
  ->name->toBe('Nuno Maduro')
  ->email->toBe('foo@bar.com')
  ->address()->scoped(fn ($address) => $address
    ->line1->toBe('1 Pest Street')
    ->city->toBe('Lisbon')
    ->country->toBe('Portugal')
  );
```

By using `scoped`, we can by use of a closure lock an expectation in to a given level in the chain. This is very useful for Eloquent models, where you may have a child relation that you also want to check properties on without using repetitive calls. Previously, you would have had to repeat the same accessor chain many times or split out the expectation into two separate expectations. Now, you can use a single `scoped` method instead if preferred.

Kind Regards,
Luke