### PR TITLE
Fix phpstan errors

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -151,6 +151,7 @@ final class Expectation
             throw new BadMethodCallException('Expectation value is not iterable.');
         }
 
+        //@phpstan-ignore-next-line
         $value          = is_array($this->value) ? $this->value : iterator_to_array($this->value);
         $keys           = array_keys($value);
         $values         = array_values($value);

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -88,13 +88,11 @@ final class TestCall
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *
-     * @param array<\Closure|iterable<int|string, mixed>|string> $data
+     * @param Closure|iterable<int|string, mixed>|string $dataset
      */
-    public function with(Closure|iterable|string ...$data): TestCall
+    public function with(Closure|iterable|string $dataset): TestCall
     {
-        foreach ($data as $dataset) {
-            $this->testCaseMethod->datasets[] = $dataset;
-        }
+        $this->testCaseMethod->datasets[] = $dataset;
 
         return $this;
     }

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -26,6 +26,8 @@ final class Backtrace
         $current = null;
 
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
+            assert(array_key_exists(self::FILE, $trace));
+
             if (Str::endsWith($trace[self::FILE], 'overrides/Runner/TestSuiteLoader.php')) {
                 break;
             }
@@ -45,7 +47,11 @@ final class Backtrace
      */
     public static function file(): string
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return $trace[self::FILE];
     }
 
     /**
@@ -53,7 +59,11 @@ final class Backtrace
      */
     public static function dirname(): string
     {
-        return dirname(debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE]);
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return dirname($trace[self::FILE]);
     }
 
     /**
@@ -61,6 +71,10 @@ final class Backtrace
      */
     public static function line(): int
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1]['line'];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists('line', $trace));
+
+        return $trace['line'];
     }
 }

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -151,7 +151,7 @@ test('lazy multiple datasets', function ($text_a, $text_b) use ($state, $dataset
     $state->text .= $text_a . $text_b;
     expect($datasets_a)->toContain([$text_a]);
     expect($datasets_b)->toContain([$text_b]);
-})->with($datasets_a, $datasets_b);
+})->with($datasets_a)->with($datasets_b);
 
 test('lazy multiple datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('12121212121213142324');
@@ -224,7 +224,7 @@ test('more than two datasets', function ($text_a, $text_b, $text_c) use ($state,
     expect($datasets_a)->toContain([$text_a]);
     expect($datasets_b)->toContain([$text_b]);
     expect([5, 6])->toContain($text_c);
-})->with($datasets_a, $datasets_b)->with([5, 6]);
+})->with($datasets_a)->with($datasets_b)->with([5, 6]);
 
 test('more than two datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('121212121212131423241314232411122122111221221112212213142324135136145146235236245246');
@@ -233,8 +233,14 @@ test('more than two datasets did the job right', function () use ($state) {
 it('can resolve a dataset after the test case is available', function ($result) {
     expect($result)->toBe('bar');
 })->with([
-    function () { return $this->foo; },
-    [function () { return $this->foo; }],
+    function () {
+        return $this->foo;
+    },
+    [
+        function () {
+            return $this->foo;
+        },
+    ],
 ]);
 
 it('can resolve a dataset after the test case is available with shared yield sets', function ($result) {
@@ -249,38 +255,58 @@ it('resolves a potential bound dataset logically', function ($foo, $bar) {
     expect($foo)->toBe('foo');
     expect($bar())->toBe('bar');
 })->with([
-    ['foo', function () { return 'bar'; }], // This should be passed as a closure because we've passed multiple arguments
+    [
+        'foo', function () {
+            return 'bar';
+        },
+    ], // This should be passed as a closure because we've passed multiple arguments
 ]);
 
 it('resolves a potential bound dataset logically even when the closure comes first', function ($foo, $bar) {
     expect($foo())->toBe('foo');
     expect($bar)->toBe('bar');
 })->with([
-    [function () { return 'foo'; }, 'bar'], // This should be passed as a closure because we've passed multiple arguments
+    [
+        function () {
+            return 'foo';
+        }, 'bar',
+    ], // This should be passed as a closure because we've passed multiple arguments
 ]);
 
 it('will not resolve a closure if it is type hinted as a closure', function (Closure $data) {
     expect($data())->toBeString();
 })->with([
-    function () { return 'foo'; },
-    function () { return 'bar'; },
+    function () {
+        return 'foo';
+    },
+    function () {
+        return 'bar';
+    },
 ]);
 
 it('will not resolve a closure if it is type hinted as a callable', function (callable $data) {
     expect($data())->toBeString();
 })->with([
-    function () { return 'foo'; },
-    function () { return 'bar'; },
+    function () {
+        return 'foo';
+    },
+    function () {
+        return 'bar';
+    },
 ]);
 
 it('can correctly resolve a bound dataset that returns an array', function (array $data) {
     expect($data)->toBe(['foo', 'bar', 'baz']);
 })->with([
-    function () { return ['foo', 'bar', 'baz']; },
+    function () {
+        return ['foo', 'bar', 'baz'];
+    },
 ]);
 
 it('can correctly resolve a bound dataset that returns an array but wants to be spread', function (string $foo, string $bar, string $baz) {
     expect([$foo, $bar, $baz])->toBe(['foo', 'bar', 'baz']);
 })->with([
-    function () { return ['foo', 'bar', 'baz']; },
+    function () {
+        return ['foo', 'bar', 'baz'];
+    },
 ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

this PR will fix some phpstan errors that cause workflows to fail: (e.g [this one](https://github.com/pestphp/pest/actions/runs/1737348776))


**error in `Expectations.php`** 
can be resumed with this [example](https://phpstan.org/r/ba322af4-75b7-4a5d-bd96-66d70090c4de)

fixed with a @phpstan-ignore, but would like to find a more elegant way

**errors in `Support\Backtrace.php`**

can be resumed with this [example](https://phpstan.org/)

fixed adding some `assert(array_key_exists('key', $array));`

