### PR TITLE
phpstan fix

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -151,6 +151,7 @@ final class Expectation
             throw new BadMethodCallException('Expectation value is not iterable.');
         }
 
+        //@phpstan-ignore-next-line
         $value          = is_array($this->value) ? $this->value : iterator_to_array($this->value);
         $keys           = array_keys($value);
         $values         = array_values($value);

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -26,6 +26,8 @@ final class Backtrace
         $current = null;
 
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
+            assert(array_key_exists(self::FILE, $trace));
+
             if (Str::endsWith($trace[self::FILE], 'overrides/Runner/TestSuiteLoader.php')) {
                 break;
             }
@@ -45,7 +47,11 @@ final class Backtrace
      */
     public static function file(): string
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return $trace[self::FILE];
     }
 
     /**
@@ -53,7 +59,11 @@ final class Backtrace
      */
     public static function dirname(): string
     {
-        return dirname(debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE]);
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return dirname($trace[self::FILE]);
     }
 
     /**
@@ -61,6 +71,10 @@ final class Backtrace
      */
     public static function line(): int
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1]['line'];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists('line', $trace));
+
+        return $trace['line'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

this PR will fix some phpstan errors that cause workflows to fail: (e.g [this one](https://github.com/pestphp/pest/actions/runs/1737348776))


**error in `Expectations.php`** 
can be resumed with this [example](https://phpstan.org/r/ba322af4-75b7-4a5d-bd96-66d70090c4de)

fixed with a @phpstan-ignore, but would like to find a more elegant way

**errors in `Support\Backtrace.php`**

can be resumed with this [example](https://phpstan.org/)

fixed adding some `assert(array_key_exists('key', $array));`

