### PR TITLE
Fix toThrow expectation passing when exception doesn't exist

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest\Mixins;
 
 use BadMethodCallException;
 use Closure;
+use Error;
 use InvalidArgumentException;
 use Pest\Exceptions\InvalidExpectationValue;
 use Pest\Support\Arr;
@@ -824,6 +825,10 @@ final class Expectation
             ($this->value)();
         } catch (Throwable $e) { // @phpstan-ignore-line
             if (!class_exists($exception)) {
+                if ($e instanceof Error && $e->getMessage() === "Class \"$exception\" not found") {
+                    throw $e;
+                }
+
                 Assert::assertStringContainsString($exception, $e->getMessage());
 
                 return $this;

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -823,7 +823,7 @@ final class Expectation
 
         try {
             ($this->value)();
-        } catch (Throwable $e) { // @phpstan-ignore-line
+        } catch (Throwable $e) {
             if (!class_exists($exception)) {
                 if ($e instanceof Error && $e->getMessage() === "Class \"$exception\" not found") {
                     throw $e;

--- a/tests/Features/Expect/toThrow.php
+++ b/tests/Features/Expect/toThrow.php
@@ -58,3 +58,19 @@ test('closure missing parameter', function () {
 test('closure missing type-hint', function () {
     expect(function () {})->toThrow(function ($e) {});
 })->throws(InvalidArgumentException::class, 'The given closure\'s parameter must be type-hinted as the class string.');
+
+it('can handle a non-defined exception', function () {
+    expect(function () {
+        throw new NonExistingException();
+    })->toThrow(NonExistingException::class);
+})->throws(Error::class, 'Class "NonExistingException" not found');
+
+it('can handle a class not found Error', function () {
+    expect(function () {
+        throw new NonExistingException();
+    })->toThrow('Class "NonExistingException" not found');
+
+    expect(function () {
+        throw new NonExistingException();
+    })->toThrow(Error::class, 'Class "NonExistingException" not found');
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Fixed tickets | #483 

This PR will fix tests passing when expecting an exception that does not exist

as pointed out in #483 a test like this will pass without revealing the missing Class error:

```php
it("throws the exception", function() {
    expect(function() { throw new DoesNotExistException; })
        ->toThrow(DoesNotExistException::class);
});
```

this is dued to the `->toThrow` expectation checking if its first parameter is a message and not a class:

```php
//Expectation.php lines from 915
if (!class_exists($exception)) {
    Assert::assertStringContainsString($exception, $e->getMessage());

    return $this;
}
```
in this case:

`$exception` will be `DoesNotExistException`

the class not found error message contained in `$e->getMessage` will be `Class "DoesNotExistException" not found`

and the Assertion will evaluate true

this PR fix will add a check to avoid such a behaviour and rethrow the class not found error:

```php
//Mixin\Expectation.php lines from 828
if (!class_exists($exception)) {
    if ($e instanceof Error && $e->getMessage() === "Class \"$exception\" not found") {
        throw $e;
    }

    Assert::assertStringContainsString($exception, $e->getMessage());

    return $this;
}
```

**note** this should be fixed in v1.x as well, will open a PR for it as soon as we review and merge this