### PR TITLE
Fix throws missing exception

### DIFF
--- a/src/Actions/LoadStructure.php
+++ b/src/Actions/LoadStructure.php
@@ -50,6 +50,7 @@ final class LoadStructure
                 $directory = new RecursiveDirectoryIterator($filename);
                 $iterator  = new RecursiveIteratorIterator($directory);
                 foreach ($iterator as $file) {
+                    /* @phpstan-ignore-next-line */
                     $filename = $file->__toString();
                     if (Str::endsWith($filename, '.php') && file_exists($filename)) {
                         require_once $filename;

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest;
 
 use BadMethodCallException;
 use Closure;
+use Error;
 use InvalidArgumentException;
 use Pest\Concerns\Extendable;
 use Pest\Concerns\RetrievesValues;
@@ -911,8 +912,12 @@ final class Expectation
 
         try {
             ($this->value)();
-        } catch (Throwable $e) { // @phpstan-ignore-line
+        } catch (Throwable $e) {
             if (!class_exists($exception)) {
+                if ($e instanceof Error && (bool) preg_match("/Class [\"']{$exception}[\"'] not found/", $e->getMessage())) {
+                    throw $e;
+                }
+
                 Assert::assertStringContainsString($exception, $e->getMessage());
 
                 return $this;

--- a/src/Logging/JUnit.php
+++ b/src/Logging/JUnit.php
@@ -173,7 +173,6 @@ final class JUnit extends Printer implements TestListener
         $this->doAddSkipped();
     }
 
-    /** @phpstan-ignore-next-line */
     public function startTestSuite(TestSuite $suite): void
     {
         $testSuite = $this->document->createElement('testsuite');
@@ -212,7 +211,6 @@ final class JUnit extends Printer implements TestListener
         $this->testSuiteTimes[$this->testSuiteLevel]      = 0;
     }
 
-    /** @phpstan-ignore-next-line */
     public function endTestSuite(TestSuite $suite): void
     {
         $this->testSuites[$this->testSuiteLevel]->setAttribute(

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -106,7 +106,6 @@ final class TeamCity extends DefaultResultPrinter
             - $result->riskyCount();
     }
 
-    /** @phpstan-ignore-next-line */
     public function startTestSuite(TestSuite $suite): void
     {
         $suiteName = $suite->getName();
@@ -164,7 +163,6 @@ final class TeamCity extends DefaultResultPrinter
         );
     }
 
-    /** @phpstan-ignore-next-line */
     public function endTestSuite(TestSuite $suite): void
     {
         $suiteName = $suite->getName();

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -26,6 +26,7 @@ final class Backtrace
         $current = null;
 
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
+            assert(array_key_exists(self::FILE, $trace));
             if (Str::endsWith($trace[self::FILE], (string) realpath('vendor/phpunit/phpunit/src/Util/FileLoader.php'))) {
                 break;
             }
@@ -45,7 +46,11 @@ final class Backtrace
      */
     public static function file(): string
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return $trace[self::FILE];
     }
 
     /**
@@ -53,7 +58,11 @@ final class Backtrace
      */
     public static function dirname(): string
     {
-        return dirname(debug_backtrace(self::BACKTRACE_OPTIONS)[1][self::FILE]);
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists(self::FILE, $trace));
+
+        return dirname($trace[self::FILE]);
     }
 
     /**
@@ -61,6 +70,10 @@ final class Backtrace
      */
     public static function line(): int
     {
-        return debug_backtrace(self::BACKTRACE_OPTIONS)[1]['line'];
+        $trace = debug_backtrace(self::BACKTRACE_OPTIONS)[1];
+
+        assert(array_key_exists('line', $trace));
+
+        return $trace['line'];
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -496,6 +496,8 @@
   ✓ not failures
   ✓ closure missing parameter
   ✓ closure missing type-hint
+  ✓ it can handle a non-defined exception
+  ✓ it can handle a class not found Error
 
    PASS  Tests\Features\Expect\unless
   ✓ it pass
@@ -720,5 +722,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 478 passed
+  Tests:  4 incompleted, 9 skipped, 480 passed
   

--- a/tests/Features/Expect/toThrow.php
+++ b/tests/Features/Expect/toThrow.php
@@ -58,3 +58,15 @@ test('closure missing parameter', function () {
 test('closure missing type-hint', function () {
     expect(function () {})->toThrow(function ($e) {});
 })->throws(InvalidArgumentException::class, 'The given closure\'s parameter must be type-hinted as the class string.');
+
+it('can handle a non-defined exception', function () {
+    expect(function () {
+        throw new NonExistingException();
+    })->toThrow(NonExistingException::class);
+})->throws(Error::class);
+
+it('can handle a class not found Error', function () {
+    expect(function () {
+        throw new NonExistingException();
+    })->toThrow(Error::class);
+});


### PR DESCRIPTION
fix #483 

basically, it does the same as #484  but had to use a regex to detect the error message, as it is formatted differently in php8 and 7

