### PR TITLE
ci: update to use ANSI output

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,10 +20,10 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --no-interaction --no-progress
+      run: composer update --no-interaction --no-progress --ansi
 
     - name: Run PHP-CS-Fixer
-      run: PHP_CS_FIXER_IGNORE_ENV=true vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run
+      run: PHP_CS_FIXER_IGNORE_ENV=true vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
 
   phpstan:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --prefer-stable --no-interaction --no-progress
+      run: composer update --prefer-stable --no-interaction --no-progress --ansi
 
     - name: Run PHPStan
-      run: vendor/bin/phpstan analyse --no-progress --debug
+      run: vendor/bin/phpstan analyse --no-progress --debug --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
       run: php bin/pest --colors=always --exclude-group=integration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This doesn't really solve anything, it just makes the output of the CI coloured, which is easier to read than the greyscale scheme.