### PR TITLE
[2.x] Add `covers` attribute

### DIFF
--- a/src/Factories/Annotations/CoversNothing.php
+++ b/src/Factories/Annotations/CoversNothing.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Annotations;
+
+use Pest\Factories\Covers\CoversNothing as CoversNothingFactory;
+use Pest\Factories\TestCaseMethodFactory;
+
+/**
+ * @internal
+ */
+final class CoversNothing
+{
+    /**
+     * Adds annotations regarding the "depends" feature.
+     *
+     * @param array<int, string> $annotations
+     *
+     * @return array<int, string>
+     */
+    public function __invoke(TestCaseMethodFactory $method, array $annotations): array
+    {
+        if (($method->covers[0] ?? null) instanceof CoversNothingFactory) {
+            $annotations[] = '@coversNothing';
+        }
+
+        return $annotations;
+    }
+}

--- a/src/Factories/Attributes/Attribute.php
+++ b/src/Factories/Attributes/Attribute.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Attributes;
+
+/**
+ * @internal
+ */
+abstract class Attribute
+{
+    /**
+     * Determine if the attribute should be placed above the classe instead of above the method.
+     *
+     * @var bool
+     */
+    public const ABOVE_CLASS = false;
+}

--- a/src/Factories/Attributes/Attribute.php
+++ b/src/Factories/Attributes/Attribute.php
@@ -10,7 +10,7 @@ namespace Pest\Factories\Attributes;
 abstract class Attribute
 {
     /**
-     * Determine if the attribute should be placed above the classe instead of above the method.
+     * Determine if the attribute should be placed above the class instead of above the method.
      *
      * @var bool
      */

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -39,8 +39,6 @@ final class Covers extends Attribute
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}::class)]";
             } elseif ($covering instanceof CoversFunction) {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}')]";
-            } else {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversNothing]";
             }
         }
 

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -11,8 +11,15 @@ use Pest\Factories\TestCaseMethodFactory;
 /**
  * @internal
  */
-final class Covers
+final class Covers extends Attribute
 {
+    /**
+     * Determine if the attribute should be placed above the classe instead of above the method.
+     *
+     * @var bool
+     */
+    public const ABOVE_CLASS = true;
+
     /**
      * Adds attributes regarding the "covers" feature.
      *

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -32,9 +32,9 @@ final class Covers extends Attribute
     {
         foreach ($method->covers as $covering) {
             if ($covering instanceof CoversClass) {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}]";
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}::class)]";
             } else if ($covering instanceof CoversFunction) {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}']";
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}')]";
             } else {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversNothing]";
             }

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -32,6 +32,11 @@ final class Covers extends Attribute
     {
         foreach ($method->covers as $covering) {
             if ($covering instanceof CoversClass) {
+                // Prepend a backslash for FQN classes
+                if (str_contains($covering->class, '\\')) {
+                    $covering->class = '\\' . $covering->class;
+                }
+
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}::class)]";
             } else if ($covering instanceof CoversFunction) {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}')]";

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -28,10 +28,10 @@ final class Covers
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}]";
 
                 if (!is_null($covering->method)) {
-                    $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering->method}]";
+                    $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->method}']";
                 }
             } else if ($covering instanceof CoversFunction) {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering->function}]";
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}']";
             } else {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversNothing]";
             }

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -26,10 +26,6 @@ final class Covers
         foreach ($method->covers as $covering) {
             if ($covering instanceof CoversClass) {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}]";
-
-                if (!is_null($covering->method)) {
-                    $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->method}']";
-                }
             } else if ($covering instanceof CoversFunction) {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}']";
             } else {

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Attributes;
+
+use Pest\Factories\TestCaseMethodFactory;
+
+/**
+ * @internal
+ */
+final class Covers
+{
+    /**
+     * Adds attributes regarding the "covers" feature.
+     *
+     * @param \Pest\Factories\TestCaseMethodFactory $method
+     * @param array<int, string> $attributes
+     *
+     * @return array<int, string>
+     */
+    public function __invoke(TestCaseMethodFactory $method, array $attributes): array
+    {
+        foreach ($method->covers as $covering) {
+            if (is_array($covering)) {
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering[0]}]";
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering[1]}]";
+            } else {
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass($covering)]";
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -23,7 +23,6 @@ final class Covers extends Attribute
     /**
      * Adds attributes regarding the "covers" feature.
      *
-     * @param \Pest\Factories\TestCaseMethodFactory $method
      * @param array<int, string> $attributes
      *
      * @return array<int, string>
@@ -38,7 +37,7 @@ final class Covers extends Attribute
                 }
 
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}::class)]";
-            } else if ($covering instanceof CoversFunction) {
+            } elseif ($covering instanceof CoversFunction) {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction('{$covering->function}')]";
             } else {
                 $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversNothing]";

--- a/src/Factories/Attributes/Covers.php
+++ b/src/Factories/Attributes/Covers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Factories\Attributes;
 
+use Pest\Factories\Covers\CoversClass;
+use Pest\Factories\Covers\CoversFunction;
 use Pest\Factories\TestCaseMethodFactory;
 
 /**
@@ -22,11 +24,16 @@ final class Covers
     public function __invoke(TestCaseMethodFactory $method, array $attributes): array
     {
         foreach ($method->covers as $covering) {
-            if (is_array($covering)) {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering[0]}]";
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering[1]}]";
+            if ($covering instanceof CoversClass) {
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass({$covering->class}]";
+
+                if (!is_null($covering->method)) {
+                    $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering->method}]";
+                }
+            } else if ($covering instanceof CoversFunction) {
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversFunction({$covering->function}]";
             } else {
-                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversClass($covering)]";
+                $attributes[] = "#[\PHPUnit\Framework\Attributes\CoversNothing]";
             }
         }
 

--- a/src/Factories/Covers/CoversClass.php
+++ b/src/Factories/Covers/CoversClass.php
@@ -9,7 +9,7 @@ namespace Pest\Factories\Covers;
  */
 final class CoversClass
 {
-    public function __construct(public string $class, public ?string $method = null)
+    public function __construct(public string $class)
     {
         //
     }

--- a/src/Factories/Covers/CoversClass.php
+++ b/src/Factories/Covers/CoversClass.php
@@ -11,6 +11,5 @@ final class CoversClass
 {
     public function __construct(public string $class)
     {
-        //
     }
 }

--- a/src/Factories/Covers/CoversClass.php
+++ b/src/Factories/Covers/CoversClass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Covers;
+
+/**
+ * @internal
+ */
+final class CoversClass
+{
+    public function __construct(public string $class, public ?string $method = null)
+    {
+        //
+    }
+}

--- a/src/Factories/Covers/CoversFunction.php
+++ b/src/Factories/Covers/CoversFunction.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Covers;
+
+/**
+ * @internal
+ */
+final class CoversFunction
+{
+    public function __construct(public string $function)
+    {
+        //
+    }
+}

--- a/src/Factories/Covers/CoversFunction.php
+++ b/src/Factories/Covers/CoversFunction.php
@@ -11,6 +11,5 @@ final class CoversFunction
 {
     public function __construct(public string $function)
     {
-        //
     }
 }

--- a/src/Factories/Covers/CoversNothing.php
+++ b/src/Factories/Covers/CoversNothing.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Factories\Covers;
+
+/**
+ * @internal
+ */
+final class CoversNothing
+{
+    //
+}

--- a/src/Factories/Covers/CoversNothing.php
+++ b/src/Factories/Covers/CoversNothing.php
@@ -9,5 +9,4 @@ namespace Pest\Factories\Covers;
  */
 final class CoversNothing
 {
-    //
 }

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -38,7 +38,7 @@ final class TestCaseFactory
     /**
      * The list of annotations.
      *
-     * @var array<int, class-string>
+     * @var array<int, \Pest\Factories\Attributes\Attribute>
      */
     private static array $attributes = [
         Attributes\Covers::class,
@@ -155,6 +155,19 @@ final class TestCaseFactory
             $methods
         ));
 
+        $classAttributes = [];
+
+        foreach (self::$attributes as $attribute) {
+            if ($attribute::ABOVE_CLASS) {
+                /** @phpstan-ignore-next-line */
+                $classAttributes = (new $attribute())->__invoke($this, $classAttributes);
+            }
+        }
+
+        $classAttributes = implode('', array_map(
+            static fn ($attribute) => sprintf("\n                 %s", $attribute), $classAttributes,
+        ));
+
         try {
             eval("
                 namespace $namespace;
@@ -162,6 +175,7 @@ final class TestCaseFactory
                 use Pest\Repositories\DatasetsRepository as __PestDatasets;
                 use Pest\TestSuite as __PestTestSuite;
 
+                $classAttributes
                 final class $className extends $baseClass implements $hasPrintableTestCaseClassFQN {
                     $traitsCode
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -166,7 +166,7 @@ final class TestCaseFactory
         }
 
         $classAttributes = implode('', array_map(
-            static fn ($attribute) => sprintf("\n                 %s", $attribute),
+            static fn (string $attribute) => sprintf("\n                 %s", $attribute),
             array_unique($classAttributes),
         ));
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -36,6 +36,15 @@ final class TestCaseFactory
     ];
 
     /**
+     * The list of annotations.
+     *
+     * @var array<int, class-string>
+     */
+    private static array $attributes = [
+        Attributes\Covers::class,
+    ];
+
+    /**
      * The FQN of the Test Case class.
      *
      * @var class-string
@@ -142,7 +151,7 @@ final class TestCaseFactory
         }
 
         $methodsCode = implode('', array_map(
-            fn (TestCaseMethodFactory $methodFactory) => $methodFactory->buildForEvaluation($classFQN, self::$annotations),
+            fn (TestCaseMethodFactory $methodFactory) => $methodFactory->buildForEvaluation($classFQN, self::$annotations, self::$attributes),
             $methods
         ));
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -151,7 +151,7 @@ final class TestCaseFactory
         }
 
         $methodsCode = implode('', array_map(
-            fn (TestCaseMethodFactory $methodFactory) => $methodFactory->buildForEvaluation($classFQN, self::$annotations, self::$attributes),
+            fn (TestCaseMethodFactory $methodFactory) => $methodFactory->buildForEvaluation($classFQN, self::$annotations),
             $methods
         ));
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -37,7 +37,7 @@ final class TestCaseFactory
     ];
 
     /**
-     * The list of annotations.
+     * The list of attributes.
      *
      * @var array<int, class-string<\Pest\Factories\Attributes\Attribute>>
      */

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -38,7 +38,7 @@ final class TestCaseFactory
     /**
      * The list of annotations.
      *
-     * @var array<int, \Pest\Factories\Attributes\Attribute>
+     * @var array<int, class-string>
      */
     private static array $attributes = [
         Attributes\Covers::class,

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -159,13 +159,15 @@ final class TestCaseFactory
 
         foreach (self::$attributes as $attribute) {
             if ($attribute::ABOVE_CLASS) {
-                /** @phpstan-ignore-next-line */
-                $classAttributes = (new $attribute())->__invoke($this, $classAttributes);
+                foreach ($methods as $methodFactory) {
+                    $classAttributes = (new $attribute())->__invoke($methodFactory, $classAttributes);
+                }
             }
         }
 
         $classAttributes = implode('', array_map(
-            static fn ($attribute) => sprintf("\n                 %s", $attribute), $classAttributes,
+            static fn ($attribute) => sprintf("\n                 %s", $attribute),
+            array_unique($classAttributes),
         ));
 
         try {

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -155,19 +155,20 @@ final class TestCaseFactory
             $methods
         ));
 
-        $classAttributes = [];
+        $classAttributesCode      = [];
+        $classAvailableAttributes = array_filter(self::$attributes, fn (string $attribute) => $attribute::ABOVE_CLASS);
 
-        foreach (self::$attributes as $attribute) {
-            if ($attribute::ABOVE_CLASS) {
-                foreach ($methods as $methodFactory) {
-                    $classAttributes = (new $attribute())->__invoke($methodFactory, $classAttributes);
-                }
-            }
+        foreach ($classAvailableAttributes as $attribute) {
+            $classAttributesCode = array_reduce(
+                $methods,
+                fn (array $carry, TestCaseMethodFactory $methodFactory) => (new $attribute())->__invoke($methodFactory, $carry),
+                $classAttributesCode
+            );
         }
 
-        $classAttributes = implode('', array_map(
+        $classAttributesCode = implode('', array_map(
             static fn (string $attribute) => sprintf("\n                 %s", $attribute),
-            array_unique($classAttributes),
+            array_unique($classAttributesCode),
         ));
 
         try {
@@ -177,7 +178,7 @@ final class TestCaseFactory
                 use Pest\Repositories\DatasetsRepository as __PestDatasets;
                 use Pest\TestSuite as __PestTestSuite;
 
-                $classAttributes
+                $classAttributesCode
                 final class $className extends $baseClass implements $hasPrintableTestCaseClassFQN {
                     $traitsCode
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -38,7 +38,7 @@ final class TestCaseFactory
     /**
      * The list of annotations.
      *
-     * @var array<int, class-string>
+     * @var array<int, class-string<\Pest\Factories\Attributes\Attribute>>
      */
     private static array $attributes = [
         Attributes\Covers::class,

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -48,7 +48,7 @@ final class TestCaseMethodFactory
     public array $groups = [];
 
     /**
-     * The covered classes and methods, if any.
+     * The covered classes and functions, if any.
      *
      * @var array<int, \Pest\Factories\Covers\CoversClass|\Pest\Factories\Covers\CoversFunction|\Pest\Factories\Covers\CoversNothing>
      */
@@ -115,7 +115,7 @@ final class TestCaseMethodFactory
      *
      * @param array<int, class-string> $annotationsToUse
      */
-    public function buildForEvaluation(string $classFQN, array $annotationsToUse, array $attributesToUse): string
+    public function buildForEvaluation(string $classFQN, array $annotationsToUse): string
     {
         if ($this->description === null) {
             throw ShouldNotHappen::fromMessage('The test description may not be empty.');

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -113,7 +113,7 @@ final class TestCaseMethodFactory
     /**
      * Creates a PHPUnit method as a string ready for evaluation.
      *
-     * @param array<int, class-string> $annotationsToUse
+     * @param array<int, class-string>                                       $annotationsToUse
      * @param array<int, class-string<\Pest\Factories\Attributes\Attribute>> $attributesToUse
      */
     public function buildForEvaluation(string $classFQN, array $annotationsToUse, array $attributesToUse): string

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -50,7 +50,7 @@ final class TestCaseMethodFactory
     /**
      * The covered classes and methods, if any.
      *
-     * @var array<int, string>
+     * @var array<int, \Pest\Factories\Covers\CoversClass|\Pest\Factories\Covers\CoversFunction|\Pest\Factories\Covers\CoversNothing>
      */
     public array $covers = [];
 

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -129,16 +129,10 @@ final class TestCaseMethodFactory
 
         $datasetsCode = '';
         $annotations  = ['@test'];
-        $attributes  = [];
 
         foreach ($annotationsToUse as $annotation) {
             /** @phpstan-ignore-next-line */
             $annotations = (new $annotation())->__invoke($this, $annotations);
-        }
-
-        foreach ($attributesToUse as $attribute) {
-            /** @phpstan-ignore-next-line */
-            $attributes = (new $attribute())->__invoke($this, $attributes);
         }
 
         if (count($this->datasets) > 0) {
@@ -151,15 +145,10 @@ final class TestCaseMethodFactory
             static fn ($annotation) => sprintf("\n                 * %s", $annotation), $annotations,
         ));
 
-        $attributes = implode('', array_map(
-            static fn ($attribute) => sprintf("\n                 %s", $attribute), $attributes,
-        ));
-
         return <<<EOF
 
                 /**$annotations
                  */
-                $attributes
                 public function $methodName()
                 {
                     return \$this->__runTest(

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -178,13 +178,11 @@ final class TestCall
     public function covers(string ...$classesOrFunctions): TestCall
     {
         foreach ($classesOrFunctions as $classOrFunction) {
-            $isClass = class_exists($classOrFunction);
+            $isClass  = class_exists($classOrFunction);
             $isMethod = function_exists($classOrFunction);
 
             if (!$isClass && !$isMethod) {
-                throw new InvalidArgumentException(
-                    sprintf('No class or method named "%s" has been found.', $classOrFunction)
-                );
+                throw new InvalidArgumentException(sprintf('No class or method named "%s" has been found.', $classOrFunction));
             }
 
             if ($isClass) {

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -172,25 +172,29 @@ final class TestCall
     }
 
     /**
-     * Sets the covered class and method.
+     * Sets the covered classes.
      *
-     * @param class-string $class
+     * @param class-string..., $classes
      */
-    public function covers(string $class): TestCall
+    public function coversClass(string ...$classes): TestCall
     {
-        $this->testCaseMethod->covers[] = new CoversClass(...func_get_args());
+        foreach ($classes as $class) {
+            $this->testCaseMethod->covers[] = new CoversClass($class);
+        }
 
         return $this;
     }
 
     /**
-     * Sets the covered function.
+     * Sets the covered functions.
      *
-     * @param string $method
+     * @param string..., $functions
      */
-    public function coversFunction(string $method): TestCall
+    public function coversFunction(string ...$functions): TestCall
     {
-        $this->testCaseMethod->covers[] = new CoversFunction(...func_get_args());
+        foreach ($functions as $function) {
+            $this->testCaseMethod->covers[] = new CoversFunction($function);
+        }
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\PendingCalls;
 
 use Closure;
+use InvalidArgumentException;
 use Pest\Factories\TestCaseMethodFactory;
 use Pest\Support\Backtrace;
 use Pest\Support\HigherOrderCallables;
@@ -164,6 +165,25 @@ final class TestCall
         $this->testCaseMethod
             ->chains
             ->addWhen($condition, Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
+
+        return $this;
+    }
+
+    /**
+     * Sets the covered class and method.
+     */
+    public function covers(string|array ...$classes): TestCall
+    {
+        foreach ($classes as $i => $class) {
+            if (is_array($class) && count($class) !== 2) {
+                throw new InvalidArgumentException(sprintf(
+                    'The #%s covered class must be an array with exactly 2 items: class and method name.',
+                    $i
+                ));
+            }
+
+            $this->testCaseMethod->covers[] = $class;
+        }
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Pest\PendingCalls;
 
 use Closure;
-use InvalidArgumentException;
+use Pest\Factories\Covers\CoversClass;
+use Pest\Factories\Covers\CoversFunction;
+use Pest\Factories\Covers\CoversNothing;
 use Pest\Factories\TestCaseMethodFactory;
 use Pest\Support\Backtrace;
 use Pest\Support\HigherOrderCallables;
@@ -171,19 +173,35 @@ final class TestCall
 
     /**
      * Sets the covered class and method.
+     *
+     * @param class-string $class
+     * @param string|null $method
      */
-    public function covers(string|array ...$classes): TestCall
+    public function covers(string $class, ?string $method = null): TestCall
     {
-        foreach ($classes as $i => $class) {
-            if (is_array($class) && count($class) !== 2) {
-                throw new InvalidArgumentException(sprintf(
-                    'The #%s covered class must be an array with exactly 2 items: class and method name.',
-                    $i
-                ));
-            }
+        $this->testCaseMethod->covers[] = new CoversClass(...func_get_args());
 
-            $this->testCaseMethod->covers[] = $class;
-        }
+        return $this;
+    }
+
+    /**
+     * Sets the covered function.
+     *
+     * @param string $method
+     */
+    public function coversFunction(string $method): TestCall
+    {
+        $this->testCaseMethod->covers[] = new CoversFunction(...func_get_args());
+
+        return $this;
+    }
+
+    /**
+     * Sets that the current test covers nothing.
+     */
+    public function coversNothing(): TestCall
+    {
+        $this->testCaseMethod->covers[] = new CoversNothing();
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -175,9 +175,8 @@ final class TestCall
      * Sets the covered class and method.
      *
      * @param class-string $class
-     * @param string|null $method
      */
-    public function covers(string $class, ?string $method = null): TestCall
+    public function covers(string $class): TestCall
     {
         $this->testCaseMethod->covers[] = new CoversClass(...func_get_args());
 

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\PendingCalls;
 
 use Closure;
+use InvalidArgumentException;
 use Pest\Factories\Covers\CoversClass;
 use Pest\Factories\Covers\CoversFunction;
 use Pest\Factories\Covers\CoversNothing;
@@ -167,6 +168,31 @@ final class TestCall
         $this->testCaseMethod
             ->chains
             ->addWhen($condition, Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
+
+        return $this;
+    }
+
+    /**
+     * Sets the covered classes or methods.
+     */
+    public function covers(string ...$classesOrFunctions): TestCall
+    {
+        foreach ($classesOrFunctions as $classOrFunction) {
+            $isClass = class_exists($classOrFunction);
+            $isMethod = function_exists($classOrFunction);
+
+            if (!$isClass && !$isMethod) {
+                throw new InvalidArgumentException(
+                    sprintf('No class or method named "%s" has been found.', $classOrFunction)
+                );
+            }
+
+            if ($isClass) {
+                $this->coversClass($classOrFunction);
+            } else {
+                $this->coversFunction($classOrFunction);
+            }
+        }
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -224,7 +224,7 @@ final class TestCall
      */
     public function coversNothing(): TestCall
     {
-        $this->testCaseMethod->covers[] = new CoversNothing();
+        $this->testCaseMethod->covers = [new CoversNothing()];
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -173,8 +173,6 @@ final class TestCall
 
     /**
      * Sets the covered classes.
-     *
-     * @param class-string..., $classes
      */
     public function coversClass(string ...$classes): TestCall
     {
@@ -187,8 +185,6 @@ final class TestCall
 
     /**
      * Sets the covered functions.
-     *
-     * @param string..., $functions
      */
     public function coversFunction(string ...$functions): TestCall
     {

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -17,7 +17,9 @@ class TestCoversClass3
 {
 }
 
-function testCoversFunction() { }
+function testCoversFunction()
+{
+}
 
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -1,0 +1,46 @@
+<?php
+
+use Pest\Factories\Attributes\Covers;
+
+$runCounter = 0;
+
+class TestCoversClass1 {}
+class TestCoversClass2 {}
+
+it('uses the correct PHPUnit attribute for class', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[0]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[0]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass1');
+})->coversClass(TestCoversClass1::class);
+
+it('uses the correct PHPUnit attribute for function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[1]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[1]->getArguments()[0])->toBe('foo');
+})->coversFunction('foo');
+
+it('uses the correct PHPUnit attribute for nothing', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[2]->getName())->toBe('PHPUnit\Framework\Attributes\CoversNothing');
+})->coversNothing();
+
+it('removes duplicated attributes', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes)->toHaveCount(7); // 3 classes, 3 functions, 1 nothing
+
+    expect($attributes[3]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[3]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass2');
+    expect($attributes[4]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[4]->getArguments()[0])->toBe('Pest\Factories\Attributes\Covers');
+    expect($attributes[5]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[5]->getArguments()[0])->toBe('bar');
+    expect($attributes[6]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[6]->getArguments()[0])->toBe('baz');
+})
+    ->coversClass(TestCoversClass2::class, TestCoversClass1::class, Covers::class)
+    ->coversNothing()
+    ->coversFunction('bar', 'foo', 'baz');

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -4,8 +4,14 @@ use Pest\Factories\Attributes\Covers;
 
 $runCounter = 0;
 
-class TestCoversClass1 {}
-class TestCoversClass2 {}
+class TestCoversClass1
+{
+
+}
+class TestCoversClass2
+{
+
+}
 
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -35,36 +35,41 @@ it('uses the correct PHPUnit attribute for function', function () {
     expect($attributes[1]->getArguments()[0])->toBe('foo');
 })->coversFunction('foo');
 
-it('uses the correct PHPUnit attribute for nothing', function () {
-    $attributes = (new ReflectionClass($this))->getAttributes();
-
-    expect($attributes[2]->getName())->toBe('PHPUnit\Framework\Attributes\CoversNothing');
-})->coversNothing();
-
 it('removes duplicated attributes', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
+    expect($attributes[2]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[2]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass2');
     expect($attributes[3]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[3]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass2');
-    expect($attributes[4]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[4]->getArguments()[0])->toBe('Pest\Factories\Attributes\Covers');
+    expect($attributes[3]->getArguments()[0])->toBe('Pest\Factories\Attributes\Covers');
+    expect($attributes[4]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[4]->getArguments()[0])->toBe('bar');
     expect($attributes[5]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
-    expect($attributes[5]->getArguments()[0])->toBe('bar');
-    expect($attributes[6]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
-    expect($attributes[6]->getArguments()[0])->toBe('baz');
+    expect($attributes[5]->getArguments()[0])->toBe('baz');
 })
     ->coversClass(TestCoversClass2::class, TestCoversClass1::class, Covers::class)
-    ->coversNothing()
     ->coversFunction('bar', 'foo', 'baz');
 
 it('guesses if the given argument is a class or function', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes[7]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[7]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass3');
-    expect($attributes[8]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
-    expect($attributes[8]->getArguments()[0])->toBe('testCoversFunction');
+    expect($attributes[6]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[6]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass3');
+    expect($attributes[7]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[7]->getArguments()[0])->toBe('testCoversFunction');
 })->covers(TestCoversClass3::class, 'testCoversFunction');
+
+it('appends CoversNothing to method attributes', function () {
+    $phpDoc = (new ReflectionClass($this))->getMethod($this->getName());
+
+    expect(str_contains($phpDoc->getDocComment(), '* @coversNothing'))->toBeTrue();
+})->coversNothing();
+
+it('does not append CoversNothing to other methods', function () {
+    $phpDoc = (new ReflectionClass($this))->getMethod($this->getName());
+
+    expect(str_contains($phpDoc->getDocComment(), '* @coversNothing'))->toBeFalse();
+});
 
 it('throws exception if no class nor method has been found', function () {
     $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'description', fn () => 'closure');

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -1,17 +1,23 @@
 <?php
 
 use Pest\Factories\Attributes\Covers;
+use Pest\PendingCalls\TestCall;
+use Pest\TestSuite;
 
 $runCounter = 0;
 
 class TestCoversClass1
 {
-
 }
 class TestCoversClass2
 {
-
 }
+
+class TestCoversClass3
+{
+}
+
+function testCoversFunction() { }
 
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
@@ -36,8 +42,6 @@ it('uses the correct PHPUnit attribute for nothing', function () {
 it('removes duplicated attributes', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes)->toHaveCount(7); // 3 classes, 3 functions, 1 nothing
-
     expect($attributes[3]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
     expect($attributes[3]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass2');
     expect($attributes[4]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
@@ -50,3 +54,18 @@ it('removes duplicated attributes', function () {
     ->coversClass(TestCoversClass2::class, TestCoversClass1::class, Covers::class)
     ->coversNothing()
     ->coversFunction('bar', 'foo', 'baz');
+
+it('guesses if the given argument is a class or function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[7]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[7]->getArguments()[0])->toBe('P\Tests\Features\TestCoversClass3');
+    expect($attributes[8]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
+    expect($attributes[8]->getArguments()[0])->toBe('testCoversFunction');
+})->covers(TestCoversClass3::class, 'testCoversFunction');
+
+it('throws exception if no class nor method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'description', fn () => 'closure');
+
+    $testCall->covers('fakeName');
+})->throws(InvalidArgumentException::class, 'No class or method named "fakeName" has been found.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #32 

This PR _tries_ to implement the `@covers` annotation. Actually, following the issue https://github.com/sebastianbergmann/phpunit/issues/4502 , I decided to implement it as a PHP Attribute since the annotations will be deprecated in PHPUnit 11.

I haven't tested this yet because I started working on it on Windows and 90% of the commands do not work, will come back on this in the next few days.

Because of the logic of Pest (where final user does not have a class), I think it's not possible to implement the `@coversDefaultClass`, but that's not a big deal since the other methods works just fine without it.

**Usage**

```php
test('covers class')
    ->expect(true)->toBeTrue()
    ->coversClass(Foo::class, Bar::class); // Same as `@covers MyClass`

test('covers global function')
    ->expect(true)->toBeTrue()
    ->coversFunction('globalFunction', 'anotherFunction'); // Same as `@covers ::functionName`

test('covers nothing')
    ->expect(true)->toBeTrue()
    ->coversNothing(); // Same as `@coversNothing`
```

**Todo**

- [x] Move attributes above class and not method (`only allowed on classes; @covers was allowed on methods but it does not make sense to mix different coverage targets in a test case class`)
- [x] Check FQN when passing a class name string (when it's passed to the Attribute)
- [x] Lint
- [x] Add tests
- [x] Add smart "covers()" that accepts both classes and functions and checks if they exists (?)