### PR TITLE
[1.x] Add `dump` helper to Expectation class

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -77,6 +77,22 @@ final class Expectation
     }
 
     /**
+     * Dump the expectation value.
+     *
+     * @return self<TValue>
+     */
+    public function dump(mixed ...$arguments): self
+    {
+        if (function_exists('dump')) {
+            dump($this->value, ...$arguments);
+        } else {
+            var_dump($this->value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Dump the expectation value and end the script.
      *
      * @return never


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Adds a `->dump()` helper to Expectation class.

**Usage**
```php
expect(someComplicatedFetchingOrSo())
->dump()
->toBe(...);
```

**Before**
```php
$data = someComplicatedFetchingOrSo();
dump($data);

expect($data)->toBe(...);
```