### PR TITLE
Fix phpstan static errors

### DIFF
--- a/src/Factories/Attributes/Attribute.php
+++ b/src/Factories/Attributes/Attribute.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Factories\Attributes;
 
+use Pest\Factories\TestCaseMethodFactory;
+
 /**
  * @internal
  */
@@ -15,4 +17,14 @@ abstract class Attribute
      * @var bool
      */
     public const ABOVE_CLASS = false;
+
+    /**
+     * @param array<int, string> $attributes
+     *
+     * @return array<int, string>
+     */
+    public function __invoke(TestCaseMethodFactory $method, array $attributes): array // @phpstan-ignore-line
+    {
+        return $attributes;
+    }
 }

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -138,7 +138,6 @@ final class TestCaseMethodFactory
         }
 
         foreach ($attributesToUse as $attribute) {
-            /** @phpstan-ignore-next-line */
             $attributes = (new $attribute())->__invoke($this, $attributes);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kinda?
| New feature?  | no
| Fixed tickets | n/a (comment https://github.com/pestphp/pest/pull/492#issuecomment-1062780491)

@nunomaduro this fixes the static types check, sorry!

I had to phpstan-ignore the `__invoke` method because it was complaining about a "missing" final statement on the abstract class method, not 100% sure why.