### PR TITLE
[2.x] Read tests folder from PHPUnit.xml file

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -29,9 +29,10 @@ use Symfony\Component\Console\Output\OutputInterface;
     $rootPath = dirname($autoloadPath, 2);
     $argv = new ArgvInput();
 
-    $phpunitConfig = new ConfigLoader($rootPath);
-
-    $testSuite = TestSuite::getInstance($rootPath, $argv->getParameterOption('--test-directory', $phpunitConfig->getTestsDirectory()));
+    $testSuite = TestSuite::getInstance(
+        $rootPath,
+        $argv->getParameterOption('--test-directory', (new ConfigLoader($rootPath))->getTestsDirectory())
+    );
 
     $isDecorated = $argv->getParameterOption('--colors', 'always') !== 'never';
     $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);

--- a/bin/pest
+++ b/bin/pest
@@ -2,6 +2,7 @@
 <?php declare(strict_types=1);
 
 use Pest\Actions\ValidatesEnvironment;
+use Pest\ConfigLoader;
 use Pest\Support\Container;
 use Pest\Kernel;
 use Pest\TestSuite;
@@ -28,7 +29,9 @@ use Symfony\Component\Console\Output\OutputInterface;
     $rootPath = dirname($autoloadPath, 2);
     $argv = new ArgvInput();
 
-    $testSuite = TestSuite::getInstance($rootPath, $argv->getParameterOption('--test-directory', 'tests'));
+    $phpunitConfig = new ConfigLoader($rootPath);
+
+    $testSuite = TestSuite::getInstance($rootPath, $argv->getParameterOption('--test-directory', $phpunitConfig->getTestsDirectory()));
 
     $isDecorated = $argv->getParameterOption('--colors', 'always') !== 'never';
     $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -13,14 +13,17 @@ use Throwable;
  */
 final class ConfigLoader
 {
-    private ?SimpleXMLElement $config = null;
-
     /**
      * Default path if config loading went wrong.
      *
      * @var string
      */
-    private const DEFAULT_TESTS_PATH = 'tests';
+    public const DEFAULT_TESTS_PATH = 'tests';
+
+    /**
+     * XML tree of the PHPUnit configuration file.
+     */
+    private ?SimpleXMLElement $config = null;
 
     /**
      * Creates a new instance of the config loader.
@@ -63,6 +66,26 @@ final class ConfigLoader
     }
 
     /**
+     * Get the configuration file path.
+     */
+    public function getConfigurationFilePath(): string|false
+    {
+        $candidates = [
+            $this->rootPath . '/phpunit.xml',
+            $this->rootPath . '/phpunit.dist.xml',
+            $this->rootPath . '/phpunit.xml.dist',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return realpath($candidate);
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Load the configuration file.
      */
     private function loadConfiguration(): void
@@ -86,25 +109,5 @@ final class ConfigLoader
 
         // Restore the correct error reporting
         error_reporting($oldReportingLevel);
-    }
-
-    /**
-     * Get the configuration file path.
-     */
-    private function getConfigurationFilePath(): string|false
-    {
-        $candidates = [
-            $this->rootPath . '/phpunit.xml',
-            $this->rootPath . '/phpunit.dist.xml',
-            $this->rootPath . '/phpunit.xml.dist',
-        ];
-
-        foreach ($candidates as $candidate) {
-            if (is_file($candidate)) {
-                return realpath($candidate);
-            }
-        }
-
-        return false;
     }
 }

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest;
+
+use Pest\Support\Str;
+use SimpleXMLElement;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class ConfigLoader
+{
+    private ?SimpleXMLElement $config = null;
+
+    /**
+     * Default path if config loading went wrong.
+     *
+     * @var string
+     */
+    private const DEFAULT_TESTS_PATH = 'tests';
+
+    /**
+     * Creates a new instance of the config loader.
+     */
+    public function __construct(private string $rootPath)
+    {
+        $this->loadConfiguration();
+    }
+
+    /**
+     * Get the tests directory or fallback to default path.
+     */
+    public function getTestsDirectory(): string
+    {
+        if (is_null($this->config)) {
+            return self::DEFAULT_TESTS_PATH;
+        }
+
+        $suiteDirectory = $this->config->xpath('/phpunit/testsuites/testsuite/directory');
+
+        // @phpstan-ignore-next-line
+        if (!$suiteDirectory || count($suiteDirectory) === 0) {
+            return self::DEFAULT_TESTS_PATH;
+        }
+
+        $directory = (string) ($suiteDirectory[0] ?? '');
+
+        if ($directory === '') {
+            return self::DEFAULT_TESTS_PATH;
+        }
+
+        // Return the whole directory if only a separator found (e.g. `./tests`)
+        if (substr_count($directory, DIRECTORY_SEPARATOR) === 1) {
+            return is_dir($directory) ? $directory : self::DEFAULT_TESTS_PATH;
+        }
+
+        $basePath = Str::beforeLast($directory, DIRECTORY_SEPARATOR);
+
+        return is_dir($basePath) ? $basePath : self::DEFAULT_TESTS_PATH;
+    }
+
+    /**
+     * Load the configuration file.
+     */
+    private function loadConfiguration(): void
+    {
+        $configPath = $this->getConfigurationFilePath();
+
+        if ($configPath === false) {
+            return;
+        }
+
+        $oldReportingLevel = error_reporting(0);
+        $content           = file_get_contents($configPath);
+
+        if ($content !== false) {
+            try {
+                $this->config = new SimpleXMLElement($content);
+            } catch (Throwable) { // @phpstan-ignore-line
+                // @ignoreException
+            }
+        }
+
+        // Restore the correct error reporting
+        error_reporting($oldReportingLevel);
+    }
+
+    /**
+     * Get the configuration file path.
+     */
+    private function getConfigurationFilePath(): string|false
+    {
+        $candidates = [
+            $this->rootPath . '/phpunit.xml',
+            $this->rootPath . '/phpunit.dist.xml',
+            $this->rootPath . '/phpunit.xml.dist',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return realpath($candidate);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -58,4 +58,22 @@ final class Str
 
         return (string) preg_replace('/[^A-Z_a-z0-9\\\\]/', '', $code);
     }
+
+    /**
+     * Get the portion of a string before the last occurrence of a given value.
+     */
+    public static function beforeLast(string $subject, string $search): string
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $pos = mb_strrpos($subject, $search);
+
+        if ($pos === false) {
+            return $subject;
+        }
+
+        return substr($subject, 0, $pos);
+    }
 }

--- a/tests/Unit/ConfigLoader.php
+++ b/tests/Unit/ConfigLoader.php
@@ -1,0 +1,19 @@
+<?php
+
+use Pest\ConfigLoader;
+use Pest\Support\Reflection;
+
+it('fallbacks to default path if no phpunit file is found', function () {
+    $instance = new ConfigLoader('fake-path');
+
+    expect(Reflection::getPropertyValue($instance, 'config'))->toBeNull();
+    expect($instance->getConfigurationFilePath())->toBeFalse();
+    expect($instance->getTestsDirectory())->toBe(ConfigLoader::DEFAULT_TESTS_PATH);
+});
+
+it('fallbacks to default path if phpunit is not a valid XML')->skip();
+it('fallbacks to default path if failing to read phpunit content')->skip();
+it('fallbacks to default path if there is no test suites directory')->skip();
+it('fallbacks to default path if test suite directory has no value')->skip();
+it('fallbacks to default path if test suite directory does not exist')->skip();
+it('returns the parent folder of first test suite directory')->skip();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #494 

With this PR the tests folder will be read by default from the `phpunit.xml` file and, of course, can still be overwritten by the `--test-directory` arg. 
In the beginning I wanted to use the [TextUI Loader](https://github.com/sebastianbergmann/phpunit/blob/master/src/TextUI/Configuration/Xml/Loader.php) by PHPUnit but it's an internal class and could break at any time and does too much stuff for what was actually needed and, at the end, it was simpler to just use the native PHP XML library.

The code is mainly ispired to [PHPUnit XML Loader](https://github.com/sebastianbergmann/phpunit/blob/b1422ac347707e4039048bdc477ef64f12a05199/src/Util/Xml/Loader.php).