### PR TITLE
Drop support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # (macos-latest, windows-latest) 2.x-dev is under development
-        php: ['8.0', '8.1']
+        php: ['8.1']
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "nunomaduro/collision": "^5.11.0|^6.0.0",
         "pestphp/pest-plugin": "^1.0.0",
         "phpunit/phpunit": "10.0.x-dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe?
| New feature?  | no
| Fixed tickets | N/A

Since [PHPUnit 10 [dropped support for PHP 8.0](https://github.com/sebastianbergmann/phpunit/commit/95b61586c5d9b90bcaa516ddca0af00efc408940), we have to drop it as well for Pest.

