### PR TITLE
[1.x] remove constraining typehint

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: src/Factories/TestCaseFactory.php
 
 		-
-			message: "#^Function it\\(\\) should return Pest\\\\PendingObjects\\\\TestCall but returns mixed\\.$#"
-			count: 1
-			path: src/Functions.php
-
-		-
 			message: "#^Parameter \\#2 \\$classAndTraits of class Pest\\\\PendingObjects\\\\UsesCall constructor expects array\\<int, string\\>, array\\<int\\|string, string\\> given\\.$#"
 			count: 1
 			path: src/Functions.php

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -107,7 +107,7 @@ if (!function_exists('it')) {
      *
      * @return TestCall|TestCase|mixed
      */
-    function it(string $description, Closure $closure = null): TestCall
+    function it(string $description, Closure $closure = null)
     {
         $description = sprintf('it %s', $description);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

The `it` helper method has a typehint of `Testcall` which is incorrect as it can also have other return types as specified in the docblock, this PR removes this typehint to fix this and satisfy static analysis tools when using higher order tests with `it`.
<!--
- Replace this comment by a description of what your PR is solving.
-->

