### PR TITLE
Fix issues after PHPUnit refactoring

### DIFF
--- a/src/Logging/JUnit.php
+++ b/src/Logging/JUnit.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Pest\Logging;
 
-use PHPUnit\Util\Printer;
+use Pest\Support\Printer;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit

--- a/src/Support/Printer.php
+++ b/src/Support/Printer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+use PHPUnit\Util\Exception;
+use PHPUnit\Util\Filesystem;
+
+abstract class Printer implements \PHPUnit\Util\Printer
+{
+    /** @var resource|false */
+    private $stream;
+
+    private bool $isPhpStream;
+    private bool $isOpen;
+
+    private function __construct(string $out)
+    {
+        if (str_starts_with($out, 'socket://')) {
+            $tmp = explode(':', str_replace('socket://', '', $out));
+
+            if (count($tmp) !== 2) {
+                throw new Exception(sprintf('"%s" does not match "socket://hostname:port" format', $out));
+            }
+
+            $this->stream = fsockopen($tmp[0], (int) $tmp[1]);
+            $this->isOpen = true;
+
+            return;
+        }
+
+        $this->isPhpStream = str_starts_with($out, 'php://');
+
+        if (!$this->isPhpStream && !Filesystem::createDirectory(dirname($out))) {
+            throw new Exception(sprintf('Directory "%s" was not created', dirname($out)));
+        }
+
+        $this->stream = fopen($out, 'wb');
+        $this->isOpen = true;
+    }
+
+    final public function print(string $buffer): void
+    {
+        assert($this->isOpen);
+        assert($this->stream !== false);
+
+        fwrite($this->stream, $buffer);
+    }
+
+    final public function flush(): void
+    {
+        if ($this->isOpen && $this->isPhpStream && $this->stream !== false) {
+            fclose($this->stream);
+
+            $this->isOpen = false;
+        }
+    }
+}

--- a/src/TestCases/IgnorableTestCase.php
+++ b/src/TestCases/IgnorableTestCase.php
@@ -8,8 +8,15 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ * @phpstan-ignore-next-line
  */
-abstract class IgnorableTestCase extends TestCase
+class IgnorableTestCase extends TestCase
 {
-    // ..
+    /**
+     * @test
+     */
+    public function fake(): void
+    {
+        self::markTestIncomplete();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

This will fix two issue coming from changes in PhpUnit core:

1. `\PHPUnit\Util\Printer` was changed to abstract and its implementation moved to `\PHPUnit\Util\DefaultPrinter` , which is final. I implemented our own Printer that behaves like the old PhpUnit Printer
2. Our `TestSuiteLoader` loaded an **abstract** `IgnorableTestCase` for detected files that shouldn't be loaded. With PhpUnit recent changes, abstract classes now will throw and exception instead to be ignored ([ref](https://github.com/sebastianbergmann/phpunit/commit/32d838252ce3826df7796c1ce557b2c7d56422e7#diff-ce07bbf9be7fe14e3102ab699c8a2d6c2a995bc23f8f93871fb4f3dde098dfaa)), so the trick doesn't work anymore. I changed `IgnorableTestCase` to defined an incomplete test in order to skip it. This will allow our core tests to run without failing because of this change (**note** ignored files will result in an incomplete tests warning instead of be skipped, this should be addressed when we will work on v2 output)


