### PR TITLE
[2.x] Skipping tests based on group parameter

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -178,7 +178,7 @@ final class TestCall
      */
     public function skipUnlessGroup(string $group, string $message = ''): TestCall
     {
-        $has = (new ArgvInput())->hasParameterOption("--group={$group}");
+        $has = ((new ArgvInput())->getParameterOption('--group') === $group);
 
         return $this->skip(!$has, $message)
             ->group($group);

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -15,6 +15,7 @@ use Pest\Support\HigherOrderCallables;
 use Pest\Support\NullClosure;
 use Pest\TestSuite;
 use SebastianBergmann\Exporter\Exporter;
+use Symfony\Component\Console\Input\ArgvInput;
 
 /**
  * @internal
@@ -170,6 +171,17 @@ final class TestCall
             ->addWhen($condition, Backtrace::file(), Backtrace::line(), 'markTestSkipped', [$message]);
 
         return $this;
+    }
+
+    /**
+     * Skips the current test when no set group.
+     */
+    public function skipUnlessGroup(string $group, string $message = ''): TestCall
+    {
+        $has = (new ArgvInput())->hasParameterOption("--group={$group}");
+
+        return $this->skip(!$has, $message)
+            ->group($group);
     }
 
     /**

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -44,3 +44,7 @@ it('can user higher order callables and skip')
     ->skip(function () { return $this->shouldSkip; })
     ->expect(function () { return $this->shouldSkip; })
     ->toBeFalse();
+
+it('skip unless group integration')
+    ->skipUnlessGroup('integration')
+    ->assertTrue(true);


### PR DESCRIPTION
This PR brings the possibility to skip or run tests based on stipulated groups via the command line using using the `--groups=` parameter.

### Motivation

I would like my tests to reach the API and endpoints during ONLY deployment.  This could be achieved with phpunit.xml or with aliases or  makefile, but this would need external configuration by my other team members.
Also, I would like to avoid passing commands every time I run tests.

### Usage

The test below will be **skipped** unless the group is explicitly called using the `--groups=` parameter.

Runs the test: `./vendor/bin/pest --group=group1`
Skips the test: `./vendor/bin/pest`

```php
it('runs this test when group is called', function () {
    expect(true)->toBeTrue();
})
    ->group('group1') // it is not necessary
    ->skipUnlessGroup('group1');
```
