### PR TITLE
[1.x] Clean up test output for PhpStorm.

### DIFF
--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -4,49 +4,83 @@ declare(strict_types=1);
 
 namespace Pest\Logging;
 
-use function getmypid;
-
+use Illuminate\Console\BufferedConsoleOutput;
+use NunoMaduro\Collision\Adapters\Phpunit\State;
+use NunoMaduro\Collision\Adapters\Phpunit\Style;
+use NunoMaduro\Collision\Adapters\Phpunit\TestResult as CollisionTestResult;
+use NunoMaduro\Collision\Adapters\Phpunit\Timer;
 use Pest\Concerns\Logging\WritesToConsole;
 use Pest\Concerns\Testable;
-use Pest\Support\ExceptionTrace;
-
-use function Pest\version;
-
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\TextUI\DefaultResultPrinter;
+use ReflectionClass;
+use ReflectionException;
 
+use SebastianBergmann\Comparator\ComparisonFailure;
 use function round;
 use function str_replace;
-use function strlen;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
+use const PHP_EOL;
 
 final class TeamCity extends DefaultResultPrinter
 {
     use WritesToConsole;
-    private const PROTOCOL            = 'pest_qn://';
-    private const NAME                = 'name';
-    private const LOCATION_HINT       = 'locationHint';
-    private const DURATION            = 'duration';
-    private const TEST_SUITE_STARTED  = 'testSuiteStarted';
+
+    private const PROTOCOL = 'pest_qn://';
+    private const NAME = 'name';
+    private const LOCATION_HINT = 'locationHint';
+    private const DURATION = 'duration';
+    private const TEST_SUITE_STARTED = 'testSuiteStarted';
     private const TEST_SUITE_FINISHED = 'testSuiteFinished';
-    private const TEST_COUNT          = 'testCount';
-    private const TEST_STARTED        = 'testStarted';
-    private const TEST_FINISHED       = 'testFinished';
+    private const TEST_COUNT = 'testCount';
+    private const TEST_STARTED = 'testStarted';
+    private const TEST_FINISHED = 'testFinished';
 
     /** @var int */
     private $flowId;
 
-    /** @var bool */
-    private $isSummaryTestCountPrinted = false;
-
     /** @var \PHPUnit\Util\Log\TeamCity */
     private $phpunitTeamCity;
+
+    /** @var Style */
+    private $style;
+
+    /** @var Style */
+    private $bufferedStyle;
+
+    /** @var BufferedConsoleOutput */
+    private $bufferedOutput;
+
+    /** @var State */
+    private $state;
+
+    /**
+     * If the test suite has failed.
+     *
+     * @var bool
+     */
+    private $failed = false;
+
+    /**
+     * We store here all the run tests, so we handle them later together.
+     *
+     * @var array
+     */
+    private $storedTests = [];
+
+    /**
+     * @var TestSuite
+     */
+    private $testSuite;
 
     /**
      * @param resource|string|null $out
@@ -54,109 +88,250 @@ final class TeamCity extends DefaultResultPrinter
     public function __construct($out, bool $verbose, string $colors)
     {
         parent::__construct($out, $verbose, $colors);
+
+        $this->createNewStyleWriter();
+
+        $this->createNewBufferedStyleWriter();
+
         $this->phpunitTeamCity = new \PHPUnit\Util\Log\TeamCity($out, $verbose, $colors);
 
-        $this->logo();
-    }
-
-    private function logo(): void
-    {
-        $this->writeNewLine();
-        $this->write('Pest ' . version());
-        $this->writeNewLine();
-    }
-
-    public function printResult(TestResult $result): void
-    {
-        $this->write('Tests:  ');
-
-        $results = [
-            'failed'     => ['count' => $result->errorCount() + $result->failureCount(), 'color' => 'fg-red'],
-            'skipped'    => ['count' => $result->skippedCount(), 'color' => 'fg-yellow'],
-            'warned'     => ['count' => $result->warningCount(), 'color' => 'fg-yellow'],
-            'risked'     => ['count' => $result->riskyCount(), 'color' => 'fg-yellow'],
-            'incomplete' => ['count' => $result->notImplementedCount(), 'color' => 'fg-yellow'],
-            'passed'     => ['count' => $this->successfulTestCount($result), 'color' => 'fg-green'],
-        ];
-
-        $filteredResults = array_filter($results, function ($item): bool {
-            return $item['count'] > 0;
-        });
-
-        foreach ($filteredResults as $key => $info) {
-            $this->writeWithColor($info['color'], $info['count'] . " $key", false);
-
-            if ($key !== array_reverse(array_keys($filteredResults))[0]) {
-                $this->write(', ');
-            }
-        }
-
-        $this->writeNewLine();
-        $this->write("Assertions:  $this->numAssertions");
-
-        $this->writeNewLine();
-        $this->write("Time:  {$result->time()}s");
-
-        $this->writeNewLine();
-    }
-
-    private function successfulTestCount(TestResult $result): int
-    {
-        return $result->count()
-            - $result->failureCount()
-            - $result->errorCount()
-            - $result->skippedCount()
-            - $result->warningCount()
-            - $result->notImplementedCount()
-            - $result->riskyCount();
+        $this->state = $this->createNewEmptyState();
     }
 
     public function startTestSuite(TestSuite $suite): void
     {
-        $suiteName = $suite->getName();
+        $this->testSuite = $suite;
+        $this->state->testCaseName = $this->testSuite->getName();
 
-        if (static::isCompoundTestSuite($suite)) {
-            $this->writeWithColor('bold', '  ' . $suiteName);
-        } elseif (static::isPestTestSuite($suite)) {
-            $this->writeWithColor('fg-white, bold', '  ' . substr_replace($suiteName, '', 0, 2) . ' ');
-        } else {
-            $this->writeWithColor('fg-white, bold', '  ' . $suiteName);
+        if ($this->state->suiteTotalTests === null) {
+            $this->state->suiteTotalTests = $suite->count();
         }
+    }
 
-        $this->writeNewLine();
-
-        $this->flowId = (int) getmypid();
-
-        if (!$this->isSummaryTestCountPrinted) {
-            $this->printEvent(self::TEST_COUNT, [
-                'count' => $suite->count(),
-            ]);
-            $this->isSummaryTestCountPrinted = true;
-        }
-
-        $this->printEvent(self::TEST_SUITE_STARTED, [
-            self::NAME          => static::isCompoundTestSuite($suite) ? $suiteName : substr($suiteName, 2),
-            self::LOCATION_HINT => self::PROTOCOL . (static::isCompoundTestSuite($suite) ? $suiteName : $suiteName::__getFileName()),
-        ]);
+    /*
+     * Leave empty because we deal with tests in printResult.
+     * @param TestSuite $suite
+     * @return void
+     */
+    public function endTestSuite(TestSuite $suite): void
+    {
     }
 
     /**
+     * Leave empty because we deal with tests in printResult.
+     * @param Test $test
+     * @return void
+     */
+    public function startTest(Test $test): void
+    {
+    }
+
+    /**
+     * Leave almost empty because we deal with tests in printResult.
+     * We just check if the test wasn't handled yet, which means it is a passing test.
+     * @param Test $test
+     * @param float $time
+     * @return void
+     */
+    public function endTest(Test $test, float $time): void
+    {
+        if (! $this->state->existsInTestCase($test)) {
+            $this->storedTests[] = ['test' => $test, 'status' => '', 'time' => $time];
+            $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::PASS));
+        }
+    }
+
+    /**
+     * Print TeamCity event
      * @param array<string, string|int> $params
      */
     private function printEvent(string $eventName, array $params = []): void
     {
-        $this->write("##teamcity[{$eventName}");
+        $this->style->write("##teamcity[{$eventName}");
 
         if ($this->flowId !== 0) {
             $params['flowId'] = $this->flowId;
         }
 
         foreach ($params as $key => $value) {
-            $escapedValue = self::escapeValue((string) $value);
-            $this->write(" {$key}='{$escapedValue}'");
+            $escapedValue = self::escapeValue((string)$value);
+            $this->style->write(" {$key}='{$escapedValue}'");
         }
 
-        $this->write("]\n");
+        $this->style->write("]\n");
+    }
+
+    /**
+     * Leave empty so we can better override the output.
+     * @param string $buffer
+     * @return void
+     */
+    public function write(string $buffer): void
+    {
+    }
+
+    /**
+     * Here we deal with all the tests and write the output.
+     *
+     * @param TestResult $result
+     * @return void
+     * @throws ReflectionException
+     */
+    public function printResult(TestResult $result): void
+    {
+        // Write a list showing the status of all tests (passed, failed, skipped, etc.).
+        $this->style->writeCurrentTestCaseSummary($this->state);
+
+        if ($this->state->suiteTotalTests === null) {
+            $this->state->suiteTotalTests = $this->testSuite->count();
+        }
+
+        $this->printTestSuiteStartedEvent();
+
+        if ($result->count() === 0) {
+            $this->style->writeWarning('No tests executed!');
+        }
+
+        // Loop through all tests, start them, write output, and end them
+        $totalTime = $this->handleStoredTestsAndWriteOutput();
+
+        // Show how many tests passed, failed, etc. and the time
+        $this->style->writeRecap($this->state, $this->createTimerWithTotalTime($totalTime));
+
+        $this->printTestSuiteFinishedEvent();
+    }
+
+    /**
+     * Failure listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param AssertionFailedError $error
+     * @param float $time
+     * @return void
+     */
+    public function addFailure(Test $test, AssertionFailedError $error, float $time): void
+    {
+        $this->failed = true;
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::FAIL,
+            'error' => $error,
+            'time' => $time,
+            'state' => CollisionTestResult::fromTestCase($test, CollisionTestResult::FAIL, $error)
+        ];
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::FAIL, $error));
+    }
+
+    /**
+     * Skipped listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     * @return void
+     */
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::SKIPPED,
+            'throwable' => $t,
+            'time' => $time,
+        ];
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::SKIPPED, $t));
+    }
+
+    /**
+     * Error listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     * @return void
+     */
+    public function addError(Test $test, Throwable $t, float $time): void
+    {
+        $this->failed = true;
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::FAIL,
+            'throwable' => $t,
+            'time' => $time,
+            'state' => CollisionTestResult::fromTestCase($test, CollisionTestResult::FAIL, $t)
+        ];
+
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::FAIL, $t));
+
+    }
+
+    /**
+     * Warning listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param Warning $e
+     * @param float $time
+     * @return void
+     */
+    public function addWarning(Test $test, Warning $e, float $time): void
+    {
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::WARN,
+            'warning' => $e,
+            'time' => $time,
+        ];
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::WARN, $e));
+
+    }
+
+    /**
+     * Risky listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     * @return void
+     */
+    public function addRiskyTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::RISKY,
+            'throwable' => $t,
+            'time' => $time,
+        ];
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::RISKY, $t));
+    }
+
+    /**
+     * Incomplete listener we use to store the run test and add it to the state.
+     *
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     * @return void
+     */
+    public function addIncompleteTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->storedTests[] = [
+            'test' => $test,
+            'status' => CollisionTestResult::INCOMPLETE,
+            'throwable' => $t,
+            'time' => $time,
+        ];
+
+        $this->state->add(CollisionTestResult::fromTestCase($test, CollisionTestResult::INCOMPLETE, $t));
+    }
+
+    /**
+     * Determine if the test suite is made up of multiple smaller test suites.
+     *
+     * @param TestSuite<Test> $suite
+     * @return bool
+     */
+    private static function isCompoundTestSuite(TestSuite $suite): bool
+    {
+        return file_exists($suite->getName()) || ! method_exists($suite->getName(), '__getFileName');
     }
 
     private static function escapeValue(string $text): string
@@ -168,55 +343,180 @@ final class TeamCity extends DefaultResultPrinter
         );
     }
 
-    public function endTestSuite(TestSuite $suite): void
+    private static function toMilliseconds(float $time): int
     {
-        $suiteName = $suite->getName();
-
-        $this->writeNewLine();
-        $this->writeNewLine();
-
-        $this->printEvent(self::TEST_SUITE_FINISHED, [
-            self::NAME          => static::isCompoundTestSuite($suite) ? $suiteName : substr($suiteName, 2),
-            self::LOCATION_HINT => self::PROTOCOL . (static::isCompoundTestSuite($suite) ? $suiteName : $suiteName::__getFileName()),
-        ]);
+        return (int)round($time * 1000);
     }
 
     /**
-     * @param Test|Testable $test
+     * Create timer for a specific time back in time.
+     *
+     * @param float $totalTime
+     * @return object
+     * @throws ReflectionException
      */
-    public function startTest(Test $test): void
+    private function createTimerWithTotalTime(float $totalTime): object
     {
-        if (!TeamCity::isPestTest($test)) {
-            $this->phpunitTeamCity->startTest($test);
+        $testInMicroTime = microtime(true) - $totalTime;
 
-            return;
+        $class = new ReflectionClass(Timer::class);
+
+        $method = $class->getConstructor();
+        $method->setAccessible(true);
+        $timer = $class->newInstanceWithoutConstructor();
+        $method->invoke($timer, $testInMicroTime);
+
+        return $timer;
+    }
+
+    protected function createNewStyleWriter(): void
+    {
+        $output = new ConsoleOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $this->style = new Style($output);
+    }
+
+    protected function createNewBufferedStyleWriter(): void
+    {
+        $this->bufferedOutput = new class extends BufferedConsoleOutput {
+            protected function doWrite(string $message, bool $newline)
+            {
+                $this->buffer .= $message;
+
+                if ($newline) {
+                    $this->buffer .= PHP_EOL;
+                }
+            }
+        };
+
+        $this->bufferedStyle = new Style($this->bufferedOutput);
+    }
+
+    protected function createNewEmptyState(): State
+    {
+        $dummyTest = new class() extends TestCase {
+        };
+
+        return State::from($dummyTest);
+    }
+
+    protected function printTestSuiteStartedEvent()
+    {
+        $suiteName = $this->testSuite->getName();
+        $this->printEvent(self::TEST_SUITE_STARTED, [
+            self::NAME => TeamCity::isCompoundTestSuite($this->testSuite) ? $suiteName : substr($suiteName, 2),
+            self::LOCATION_HINT => self::PROTOCOL . (TeamCity::isCompoundTestSuite($this->testSuite) ? $suiteName : $suiteName::__getFileName()),
+        ]);
+    }
+
+    protected function printTestStartedEvent($test1): void
+    {
+        $this->printEvent(self::TEST_STARTED, [
+            self::NAME => $test1->getName(),
+            // @phpstan-ignore-next-line
+            self::LOCATION_HINT => self::PROTOCOL . $test1->toString(),
+        ]);
+    }
+
+    protected function handleStoredTestsAndWriteOutput()
+    {
+        $totalTime = 0;
+
+        foreach ($this->storedTests as $testData) {
+            $totalTime += $testData['time'];
+
+            // Let's check first if the testCase is over.
+            if ($this->state->testCaseHasChanged($testData['test'])) {
+                $this->state->moveTo($testData['test']);
+            }
+
+            $this->printTestStartedEvent($testData['test']);
+
+            // Write output depending on which type of test it is.
+            if ($testData['status'] === CollisionTestResult::FAIL) {
+
+                // Create message and details for TeamCity event.
+                $this->bufferedStyle->writeError($testData['error'] ?? $testData['throwable']);
+                $output = $this->bufferedOutput->fetch();
+                [$message, $details] = explode("\n", $output, 2);
+
+                $currentState = $this->createNewEmptyState();
+                $currentState->add($testData['state']);
+
+                // Write error headline for test
+                $this->style->writeErrorsSummary($currentState, false);
+
+                // Add comparison info
+                // Taken from vendor/phpunit/phpunit/src/Util/Log/TeamCity.php:104:126
+                // Added to handle comparisonFailure type events.
+                $parameters = [];
+                if (isset($testData['error']) && $testData['error'] instanceof ExpectationFailedException) {
+                    $comparisonFailure = $testData['error']->getComparisonFailure();
+
+                    if ($comparisonFailure instanceof ComparisonFailure) {
+                        $expectedString = $comparisonFailure->getExpectedAsString();
+
+                        if ($expectedString === null || empty($expectedString)) {
+                            $expectedString = self::getPrimitiveValueAsString($comparisonFailure->getExpected());
+                        }
+
+                        $actualString = $comparisonFailure->getActualAsString();
+
+                        if ($actualString === null || empty($actualString)) {
+                            $actualString = self::getPrimitiveValueAsString($comparisonFailure->getActual());
+                        }
+
+                        if ($actualString !== null && $expectedString !== null) {
+                            $parameters['type'] = 'comparisonFailure';
+                            $parameters['actual'] = $actualString;
+                            $parameters['expected'] = $expectedString;
+                        }
+                    }
+                }
+
+                $this->printEventTestFailed($testData, $message, $parameters);
+            } elseif (in_array($testData['status'], [CollisionTestResult::SKIPPED, CollisionTestResult::INCOMPLETE])) {
+                // Write PHPUnit output for skipped and incomplete tests.
+                $this->phpunitTeamCity->printIgnoredTest($testData['test']->getName(), $testData['throwable'], $testData['time']);
+            } elseif ($testData['status'] === CollisionTestResult::WARN) {
+                // Write PHPUnit output for test with warning.
+                $this->phpunitTeamCity->addWarning($testData['test'], $testData['warning'], $testData['time']);
+            }
+
+            $this->printEventTestEnded($testData);
         }
 
-        $this->printEvent(self::TEST_STARTED, [
-            self::NAME => $test->getName(),
-            // @phpstan-ignore-next-line
-            self::LOCATION_HINT => self::PROTOCOL . $test->toString(),
+        return $totalTime;
+    }
+
+    protected function printTestSuiteFinishedEvent(): void
+    {
+        $suiteName = $this->testSuite->getName();
+
+        $this->printEvent(self::TEST_SUITE_FINISHED, [
+            self::NAME => TeamCity::isCompoundTestSuite($this->testSuite) ? $suiteName : substr($suiteName, 2),
+            self::LOCATION_HINT => self::PROTOCOL . (TeamCity::isCompoundTestSuite($this->testSuite) ? $suiteName : $suiteName::__getFileName()),
         ]);
     }
 
-    /**
-     * Verify that the given test suite is a valid Pest suite.
-     *
-     * @param TestSuite<Test> $suite
-     */
-    private static function isPestTestSuite(TestSuite $suite): bool
+    protected function printEventTestFailed($testData, $message, array $parameters): void
     {
-        return strncmp($suite->getName(), 'P\\', strlen('P\\')) === 0;
+        $this->printEvent('testFailed', array_merge([
+            'name' => $testData['test']->getName(),
+            'message' => trim($message),
+            // to do add time
+            'duration' => self::toMilliseconds($testData['time']),
+            'details' => '',
+        ], $parameters));
     }
 
-    /**
-     * Determine if the test suite is made up of multiple smaller test suites.
-     *
-     * @param TestSuite<Test> $suite
-     */
-    private static function isCompoundTestSuite(TestSuite $suite): bool
+    protected function printEventTestEnded($testData): void
     {
-        return file_exists($suite->getName()) || !method_exists($suite->getName(), '__getFileName');
+        $this->printEvent(self::TEST_FINISHED, [
+            self::NAME => $testData['test']->getName(),
+            // Todo: add time
+
+            self::DURATION => self::toMilliseconds($testData['time'] ?? 0),
+        ]);
     }
 
     public static function isPestTest(Test $test): bool
@@ -225,76 +525,5 @@ final class TeamCity extends DefaultResultPrinter
         $uses = class_uses($test);
 
         return in_array(Testable::class, $uses, true);
-    }
-
-    /**
-     * @param Test|Testable $test
-     */
-    public function endTest(Test $test, float $time): void
-    {
-        $this->printEvent(self::TEST_FINISHED, [
-            self::NAME     => $test->getName(),
-            self::DURATION => self::toMilliseconds($time),
-        ]);
-
-        if (!$this->lastTestFailed) {
-            $this->writeSuccess($test->getName());
-        }
-
-        $this->numAssertions += $test instanceof TestCase ? $test->getNumAssertions() : 1;
-        $this->lastTestFailed = false;
-    }
-
-    private static function toMilliseconds(float $time): int
-    {
-        return (int) round($time * 1000);
-    }
-
-    public function addError(Test $test, Throwable $t, float $time): void
-    {
-        $this->markAsFailure($t);
-        $this->writeError($test->getName());
-        $this->phpunitTeamCity->addError($test, $t, $time);
-    }
-
-    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
-    {
-        $this->markAsFailure($e);
-        $this->writeError($test->getName());
-        $this->phpunitTeamCity->addFailure($test, $e, $time);
-    }
-
-    public function addWarning(Test $test, Warning $e, float $time): void
-    {
-        $this->markAsFailure($e);
-        $this->writeWarning($test->getName());
-        $this->phpunitTeamCity->addWarning($test, $e, $time);
-    }
-
-    public function addIncompleteTest(Test $test, Throwable $t, float $time): void
-    {
-        $this->markAsFailure($t);
-        $this->writeWarning($test->getName());
-        $this->phpunitTeamCity->addIncompleteTest($test, $t, $time);
-    }
-
-    public function addRiskyTest(Test $test, Throwable $t, float $time): void
-    {
-        $this->markAsFailure($t);
-        $this->writeWarning($test->getName());
-        $this->phpunitTeamCity->addRiskyTest($test, $t, $time);
-    }
-
-    public function addSkippedTest(Test $test, Throwable $t, float $time): void
-    {
-        $this->markAsFailure($t);
-        $this->writeWarning($test->getName());
-        $this->phpunitTeamCity->printIgnoredTest($test->getName(), $t, $time);
-    }
-
-    private function markAsFailure(Throwable $t): void
-    {
-        $this->lastTestFailed = true;
-        ExceptionTrace::removePestReferences($t);
     }
 }

--- a/src/Logging/TeamCity.php
+++ b/src/Logging/TeamCity.php
@@ -403,7 +403,6 @@ final class TeamCity extends DefaultResultPrinter
     /**
      * Print test suite started event for TeamCity.
      *
-     * @param TestSuite $testSuite
      * @return void
      */
     protected function printTestSuiteStartedEvent(TestSuite $testSuite)
@@ -416,9 +415,6 @@ final class TeamCity extends DefaultResultPrinter
 
     /**
      * Print test suite finished event for TeamCity.
-     *
-     * @param TestSuite $testSuite
-     * @return void
      */
     protected function printTestSuiteFinishedEvent(TestSuite $testSuite): void
     {
@@ -432,7 +428,6 @@ final class TeamCity extends DefaultResultPrinter
      * Print a test started event for TeamCity.
      *
      * @param $test
-     * @return void
      */
     protected function printTestStartedEvent($test): void
     {
@@ -447,21 +442,17 @@ final class TeamCity extends DefaultResultPrinter
      * Print a test ended event for TeamCity.
      *
      * @param $testData
-     * @return void
      */
     protected function printTestEndedEvent($testData): void
     {
         $this->printEvent(self::TEST_FINISHED, [
-            self::NAME => $testData['test']->getName(),
+            self::NAME     => $testData['test']->getName(),
             self::DURATION => self::toMilliseconds($testData['time']),
         ]);
     }
 
     /**
      * For every test we write the corresponding start and end events and the error output.
-     *
-     * @param array $testSuiteWithTests
-     * @return void
      */
     protected function handleStoredTestsAndWriteOutput(array $testSuiteWithTests): void
     {
@@ -504,8 +495,8 @@ final class TeamCity extends DefaultResultPrinter
     protected function printEventTestFailed($testData, $message, array $parameters): void
     {
         $this->printEvent('testFailed', array_merge([
-            'name'    => $testData['test']->getName(),
-            'message' => trim($message),
+            'name'     => $testData['test']->getName(),
+            'message'  => trim($message),
             'duration' => self::toMilliseconds($testData['time']),
             'details'  => '',
         ], $parameters));

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -705,8 +705,8 @@
    WARN  Tests\Visual\Success
   - visual snapshot of test suite on success
 
-   PASS  Tests\Visual\TeamCity
-  ✓ it is can successfully call all public methods
+   FAIL  Tests\Visual\TeamCity
+  ⨯ teamcity snapshot test
 
    PASS  Tests\Features\Depends
   ✓ first
@@ -722,5 +722,30 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 480 passed
+  ---
+
+  • Tests\Visual\TeamCity > teamcity snapshot test
+   Whoops\Exception\ErrorException 
+
+  Undefined property: P\Tests\Visual\TeamCity::$snapshot
+
+  at tests/Visual/TeamCity.php:27
+     23▕ 
+     24▕     $this->output = $process->getOutput();
+     25▕     $this->output = sanitizeOutput($this->output);
+     26▕ 
+  ➜  27▕     expect($this->output)->toEqual($this->snapshot);
+     28▕ });
+     29▕ 
+     30▕ function sanitizeOutput(string $output): string
+     31▕ {
+
+  1   tests/Visual/TeamCity.php:27
+      Whoops\Run::handleError("Undefined property: P\Tests\Visual\TeamCity::$snapshot", "/Users/christophrumpel/Sites/Forks/pest/tests/Visual/TeamCity.php")
+
+  2   src/Factories/TestCaseFactory.php:151
+      P\Tests\Visual\TeamCity::{closure}()
+
+
+  Tests:  1 failed, 4 incompleted, 9 skipped, 479 passed
   

--- a/tests/.snapshots/teamcity.txt
+++ b/tests/.snapshots/teamcity.txt
@@ -1,0 +1,23 @@
+
+  [30;42;1m PASS [39;49;22m[39m Tests\Unit\Datasets[39m
+  [32;1m✓[39;22m[39m [2mit show only the names of named datasets in their description[22m[39m
+  [32;1m✓[39;22m[39m [2mit show the actual dataset of non-named datasets in their description[22m[39m
+  [32;1m✓[39;22m[39m [2mit show only the names of multiple named datasets in their description[22m[39m
+  [32;1m✓[39;22m[39m [2mit show the actual dataset of multiple non-named datasets in their description[22m[39m
+  [32;1m✓[39;22m[39m [2mit show the correct description for mixed named and not-named datasets[22m[39m
+##teamcity[testSuiteStarted name='Tests\Unit\Datasets' locationHint='pest_qn:///tests/Unit/Datasets.php' flowId='']
+##teamcity[testStarted name='it show only the names of named datasets in their description' locationHint='pest_qn:///tests/Unit/Datasets.php::it show only the names of named datasets in their description' flowId='']
+##teamcity[testFinished name='it show only the names of named datasets in their description' duration='10' flowId='']
+##teamcity[testStarted name='it show the actual dataset of non-named datasets in their description' locationHint='pest_qn:///tests/Unit/Datasets.php::it show the actual dataset of non-named datasets in their description' flowId='']
+##teamcity[testFinished name='it show the actual dataset of non-named datasets in their description' duration='10' flowId='']
+##teamcity[testStarted name='it show only the names of multiple named datasets in their description' locationHint='pest_qn:///tests/Unit/Datasets.php::it show only the names of multiple named datasets in their description' flowId='']
+##teamcity[testFinished name='it show only the names of multiple named datasets in their description' duration='10' flowId='']
+##teamcity[testStarted name='it show the actual dataset of multiple non-named datasets in their description' locationHint='pest_qn:///tests/Unit/Datasets.php::it show the actual dataset of multiple non-named datasets in their description' flowId='']
+##teamcity[testFinished name='it show the actual dataset of multiple non-named datasets in their description' duration='10' flowId='']
+##teamcity[testStarted name='it show the correct description for mixed named and not-named datasets' locationHint='pest_qn:///tests/Unit/Datasets.php::it show the correct description for mixed named and not-named datasets' flowId='']
+##teamcity[testFinished name='it show the correct description for mixed named and not-named datasets' duration='10' flowId='']
+##teamcity[testSuiteFinished name='Tests\Unit\Datasets' locationHint='pest_qn:///tests/Unit/Datasets.php' flowId='']
+
+  [37;1mTests:  [39;22m[32;1m5 passed[39;22m
+  [37;1mTime:   [39;22m[39m10.10s[39m
+

--- a/tests/Visual/TeamCity.php
+++ b/tests/Visual/TeamCity.php
@@ -2,12 +2,12 @@
 
 beforeEach(function () {
     $this->snapshotPath = __DIR__ . '/../.snapshots/teamcity.txt';
-    $this->snapshot = file_get_contents($this->snapshotPath);
+    $this->snapshot     = file_get_contents($this->snapshotPath);
 });
 
 afterEach(function () {
     if (getenv('REBUILD_SNAPSHOTS')) {
-        echo "Rebuilding snapshots...";
+        echo 'Rebuilding snapshots...';
         file_put_contents($this->snapshotPath, $this->output);
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | no ticket

This PR is a WIP to improve the PhpStorm output when running PEST through PhpStorm (not console).

**What needs to be improved:**
Here is what the current output looks like, which is very PHPUnit-like but not PEST-like.

![CleanShot 2022-08-24 at 11 48 36@2x](https://user-images.githubusercontent.com/1394539/186389500-8d320aad-f2cf-4c8e-9b85-63b33601e0be.png)

Let's also compare it with the current PEST output in the console:

![CleanShot 2022-08-24 at 11 58 26@2x](https://user-images.githubusercontent.com/1394539/186390032-e242406a-9c2a-4089-ac8c-d130a0283168.png)

As you can see the PEST output is much cleaner and we also need this for PhpStorm output.

**What is included in this PR:**

By adapting the `Logging\TeamCity` class, I was able to reduce of the noise. Here is what the output looks like with my changes:

![CleanShot 2022-08-24 at 11 46 44@2x](https://user-images.githubusercontent.com/1394539/186391270-744d3180-4705-44c8-879b-56abadec7161.png)


**Two issues still remain:**

1. The changes you can do in the `Logging\TeamCity` class are limited. This is also why @nunomaduro created the whole PEST output himself through PHPUnit events. (so it seems) Maybe it is better to try to use the same approach for this output? Is that possible?
2. Different to the console, PhpStorm stops at the first line of the output. That's why you always need to scroll to see the result, which you should see immediately.

![CleanShot 2022-08-24 at 11 47 22@2x](https://user-images.githubusercontent.com/1394539/186392017-8de82b35-a53e-491e-be75-013f4a590372.png)

Of course, it is even worse with the current output.

![CleanShot 2022-08-24 at 11 48 51@2x](https://user-images.githubusercontent.com/1394539/186392103-3de458e4-7e7b-4956-ad55-396130446143.png)

I think we have two option here: Try to see if we can scroll with PhpStorm plugin to the end of the output, or change the output to see the result first. We definitely want to see something green immediately to know the tests pass.

Thanks for the help so far @olivernybroe and I would appreciate some feedback and help here.




