### PR TITLE
[1.x] Add new command make:pest as an alias for pest:test

### DIFF
--- a/src/Laravel/Commands/MakePestCommand.php
+++ b/src/Laravel/Commands/MakePestCommand.php
@@ -6,12 +6,7 @@ namespace Pest\Laravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use Pest\Exceptions\InvalidConsoleArgument;
-use Pest\Support\Str;
 
-use function Pest\testDirectory;
-
-use Pest\TestSuite;
 
 /**
  * @internal

--- a/src/Laravel/Commands/MakePestCommand.php
+++ b/src/Laravel/Commands/MakePestCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Pest\Exceptions\InvalidConsoleArgument;
+use Pest\Support\Str;
+
+use function Pest\testDirectory;
+
+use Pest\TestSuite;
+
+/**
+ * @internal
+ */
+final class MakePestCommand extends PestTestCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'make:pest {name : The name of the file} {--unit : Create a unit test} {--dusk : Create a Dusk test} {--test-directory=tests : The name of the tests directory} {--force : Overwrite the existing test file with the same name}';
+
+
+}

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -16,7 +16,7 @@ use Pest\TestSuite;
 /**
  * @internal
  */
-final class PestTestCommand extends Command
+class PestTestCommand extends Command
 {
     /**
      * The console command name.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  no
| New feature?  | yes
| Fixed tickets | none

I would really like to be able to do

> php artisan make:pest

rather than

> php artisan pest:test

This PR adds a new command `make:pest`  that extends PestTestCommand but with simply a new command name.  This is inspired by @calebporzio who has lots of aliases for many of his livewire commands.

I could hide the command but it seems that it would be nice for it not to be hidden.

I didnt add tests as I couldnt find tests for pest:test, but it is possible I am being blind.

Let me know if you need me to make changes.

ps. thanks for a great tool, first time in 20 years I've started to really use tests in php.