### PR TITLE
2.x dynamic properties fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # (macos-latest, windows-latest) 2.x-dev is under development
-        php: ['8.1']
+        php: ['8.1', '8.2']
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']
-        exclude:
-          - php: 8.1
-            os: macos-latest
-          - php: 8.1
-            os: windows-latest
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
 

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -186,7 +186,7 @@ final class TestCaseFactory
                 use Pest\TestSuite as __PestTestSuite;
 
                 $classAttributesCode
-                #[AllowDynamicProperties]
+                #[\AllowDynamicProperties]
                 final class $className extends $baseClass implements $hasPrintableTestCaseClassFQN {
                     $traitsCode
 

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -710,16 +710,20 @@ final class Expectation
     /**
      * Asserts that the value array matches the given array subset.
      *
-     * @param iterable<int|string, mixed> $array
+     * @param iterable<int|string, mixed>|object $array
      *
      * @return Expectation<TValue>
      */
-    public function toMatchArray(iterable|object $array): Expectation
+    public function toMatchArray(array|object $array): Expectation
     {
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $valueAsArray = $this->value->toArray();
         } else {
             $valueAsArray = (array) $this->value;
+        }
+
+        if (is_object($array) && method_exists($array, 'toArray')) {
+            $array = $array->toArray();
         }
 
         foreach ($array as $key => $value) {
@@ -743,11 +747,11 @@ final class Expectation
      * Asserts that the value object matches a subset
      * of the properties of an given object.
      *
-     * @param iterable<string, mixed>|object $object
+     * @param object|array<string, mixed> $object
      *
      * @return Expectation<TValue>
      */
-    public function toMatchObject(iterable|object $object): Expectation
+    public function toMatchObject(object|array $object): Expectation
     {
         foreach ((array) $object as $property => $value) {
             if (!is_object($this->value) && !is_string($this->value)) {

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -722,10 +722,6 @@ final class Expectation
             $valueAsArray = (array) $this->value;
         }
 
-        if (is_object($array) && method_exists($array, 'toArray')) {
-            $array = $array->toArray();
-        }
-
         foreach ($array as $key => $value) {
             Assert::assertArrayHasKey($key, $valueAsArray);
 

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -710,11 +710,11 @@ final class Expectation
     /**
      * Asserts that the value array matches the given array subset.
      *
-     * @param iterable<int|string, mixed>|object $array
+     * @param iterable<int|string, mixed> $array
      *
      * @return Expectation<TValue>
      */
-    public function toMatchArray(array|object $array): Expectation
+    public function toMatchArray(iterable $array): Expectation
     {
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $valueAsArray = $this->value->toArray();
@@ -747,11 +747,11 @@ final class Expectation
      * Asserts that the value object matches a subset
      * of the properties of an given object.
      *
-     * @param object|array<string, mixed> $object
+     * @param iterable<string, mixed> $object
      *
      * @return Expectation<TValue>
      */
-    public function toMatchObject(object|array $object): Expectation
+    public function toMatchObject(iterable $object): Expectation
     {
         foreach ((array) $object as $property => $value) {
             if (!is_object($this->value) && !is_string($this->value)) {

--- a/tests/Features/Expect/toMatchObject.php
+++ b/tests/Features/Expect/toMatchObject.php
@@ -17,6 +17,16 @@ test('pass', function () {
     ]);
 });
 
+test('pass with class', function () {
+    expect(new class() {
+        public $name  = 'Nuno';
+        public $email = 'enunomaduro@gmail.com';
+    })->toMatchObject([
+        'name'  => 'Nuno',
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+});
+
 test('failures', function () {
     expect($this->user)->toMatchObject([
         'name'  => 'Not the same name',


### PR DESCRIPTION
- Fix missing `\` in #[\AllowDynamicProperties]  attribute
- Add PHP8.2 test workflow
- Fix tests failing with PHP8.2
