### PR TITLE
[2.x] failed expectation messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "bin/pest"
     ],
     "scripts": {
-        "lint": "pint --test",
+        "lint": "pint",
         "test:lint": "pint --test",
         "test:types": "phpstan analyse --ansi --memory-limit=-1 --debug",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration --compact",

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -280,7 +280,7 @@ final class Expectation
     {
         if (! self::hasMethod($method)) {
             /* @phpstan-ignore-next-line */
-            return new HigherOrderExpectation($this, $this->value->$method(...$parameters));
+            return new HigherOrderExpectation($this, call_user_func_array($this->value->$method(...), $parameters));
         }
 
         ExpectationPipeline::for($this->getExpectationClosure($method))

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use Pest\Exceptions\InvalidExpectationValue;
 use Pest\Support\Arr;
 use Pest\Support\NullClosure;
+use Pest\Support\NullValue;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -51,9 +52,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBe(mixed $expected): self
+    public function toBe(mixed $expected, string $message = ''): self
     {
-        Assert::assertSame($expected, $this->value);
+        Assert::assertSame($expected, $this->value, $message);
 
         return $this;
     }
@@ -63,9 +64,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeEmpty(): self
+    public function toBeEmpty(string $message = ''): self
     {
-        Assert::assertEmpty($this->value);
+        Assert::assertEmpty($this->value, $message);
 
         return $this;
     }
@@ -75,9 +76,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeTrue(): self
+    public function toBeTrue(string $message = ''): self
     {
-        Assert::assertTrue($this->value);
+        Assert::assertTrue($this->value, $message);
 
         return $this;
     }
@@ -87,9 +88,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeTruthy(): self
+    public function toBeTruthy(string $message = ''): self
     {
-        Assert::assertTrue((bool) $this->value);
+        Assert::assertTrue((bool) $this->value, $message);
 
         return $this;
     }
@@ -99,9 +100,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeFalse(): self
+    public function toBeFalse(string $message = ''): self
     {
-        Assert::assertFalse($this->value);
+        Assert::assertFalse($this->value, $message);
 
         return $this;
     }
@@ -111,9 +112,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeFalsy(): self
+    public function toBeFalsy(string $message = ''): self
     {
-        Assert::assertFalse((bool) $this->value);
+        Assert::assertFalse((bool) $this->value, $message);
 
         return $this;
     }
@@ -123,9 +124,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThan(int|float $expected): self
+    public function toBeGreaterThan(int|float $expected, string $message = ''): self
     {
-        Assert::assertGreaterThan($expected, $this->value);
+        Assert::assertGreaterThan($expected, $this->value, $message);
 
         return $this;
     }
@@ -135,9 +136,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThanOrEqual(int|float $expected): self
+    public function toBeGreaterThanOrEqual(int|float $expected, string $message = ''): self
     {
-        Assert::assertGreaterThanOrEqual($expected, $this->value);
+        Assert::assertGreaterThanOrEqual($expected, $this->value, $message);
 
         return $this;
     }
@@ -147,9 +148,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThan(int|float $expected): self
+    public function toBeLessThan(int|float $expected, string $message = ''): self
     {
-        Assert::assertLessThan($expected, $this->value);
+        Assert::assertLessThan($expected, $this->value, $message);
 
         return $this;
     }
@@ -159,9 +160,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThanOrEqual(int|float $expected): self
+    public function toBeLessThanOrEqual(int|float $expected, string $message = ''): self
     {
-        Assert::assertLessThanOrEqual($expected, $this->value);
+        Assert::assertLessThanOrEqual($expected, $this->value, $message);
 
         return $this;
     }
@@ -192,15 +193,15 @@ final class Expectation
      * Asserts that the value starts with $expected.
      *
      * @param  non-empty-string  $expected
-     *@return self<TValue>
+     * @return self<TValue>
      */
-    public function toStartWith(string $expected): self
+    public function toStartWith(string $expected, string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertStringStartsWith($expected, $this->value);
+        Assert::assertStringStartsWith($expected, $this->value, $message);
 
         return $this;
     }
@@ -209,15 +210,15 @@ final class Expectation
      * Asserts that the value ends with $expected.
      *
      * @param  non-empty-string  $expected
-     *@return self<TValue>
+     * @return self<TValue>
      */
-    public function toEndWith(string $expected): self
+    public function toEndWith(string $expected, string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertStringEndsWith($expected, $this->value);
+        Assert::assertStringEndsWith($expected, $this->value, $message);
 
         return $this;
     }
@@ -227,22 +228,22 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toHaveLength(int $number): self
+    public function toHaveLength(int $number, string $message = ''): self
     {
         if (is_string($this->value)) {
-            Assert::assertEquals($number, mb_strlen($this->value));
+            Assert::assertEquals($number, mb_strlen($this->value), $message);
 
             return $this;
         }
 
         if (is_iterable($this->value)) {
-            return $this->toHaveCount($number);
+            return $this->toHaveCount($number, $message);
         }
 
         if (is_object($this->value)) {
             $array = method_exists($this->value, 'toArray') ? $this->value->toArray() : (array) $this->value;
 
-            Assert::assertCount($number, $array);
+            Assert::assertCount($number, $array, $message);
 
             return $this;
         }
@@ -255,13 +256,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toHaveCount(int $count): self
+    public function toHaveCount(int $count, string $message = ''): self
     {
         if (! is_countable($this->value) && ! is_iterable($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertCount($count, $this->value);
+        Assert::assertCount($count, $this->value, $message);
 
         return $this;
     }
@@ -271,16 +272,16 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toHaveProperty(string $name, mixed $value = null): self
+    public function toHaveProperty(string $name, mixed $value = new NullValue(), string $message = ''): self
     {
         $this->toBeObject();
 
         // @phpstan-ignore-next-line
-        Assert::assertTrue(property_exists($this->value, $name));
+        Assert::assertTrue(property_exists($this->value, $name), $message);
 
-        if (func_num_args() > 1) {
+        if (! $value instanceof NullValue) {
             /* @phpstan-ignore-next-line */
-            Assert::assertEquals($value, $this->value->{$name});
+            Assert::assertEquals($value, $this->value->{$name}, $message);
         }
 
         return $this;
@@ -290,12 +291,12 @@ final class Expectation
      * Asserts that the value contains the provided properties $names.
      *
      * @param  iterable<array-key, string>  $names
-     *@return self<TValue>
+     * @return self<TValue>
      */
-    public function toHaveProperties(iterable $names): self
+    public function toHaveProperties(iterable $names, string $message = ''): self
     {
         foreach ($names as $name) {
-            $this->toHaveProperty($name);
+            $this->toHaveProperty($name, message: $message);
         }
 
         return $this;
@@ -306,9 +307,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toEqual(mixed $expected): self
+    public function toEqual(mixed $expected, string $message = ''): self
     {
-        Assert::assertEquals($expected, $this->value);
+        Assert::assertEquals($expected, $this->value, $message);
 
         return $this;
     }
@@ -324,9 +325,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toEqualCanonicalizing(mixed $expected): self
+    public function toEqualCanonicalizing(mixed $expected, string $message = ''): self
     {
-        Assert::assertEqualsCanonicalizing($expected, $this->value);
+        Assert::assertEqualsCanonicalizing($expected, $this->value, $message);
 
         return $this;
     }
@@ -337,9 +338,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toEqualWithDelta(mixed $expected, float $delta): self
+    public function toEqualWithDelta(mixed $expected, float $delta, string $message = ''): self
     {
-        Assert::assertEqualsWithDelta($expected, $this->value, $delta);
+        Assert::assertEqualsWithDelta($expected, $this->value, $delta, $message);
 
         return $this;
     }
@@ -350,9 +351,9 @@ final class Expectation
      * @param  iterable<int|string, mixed>  $values
      * @return self<TValue>
      */
-    public function toBeIn(iterable $values): self
+    public function toBeIn(iterable $values, string $message = ''): self
     {
-        Assert::assertContains($this->value, $values);
+        Assert::assertContains($this->value, $values, $message);
 
         return $this;
     }
@@ -362,9 +363,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeInfinite(): self
+    public function toBeInfinite(string $message = ''): self
     {
-        Assert::assertInfinite($this->value);
+        Assert::assertInfinite($this->value, $message);
 
         return $this;
     }
@@ -375,9 +376,9 @@ final class Expectation
      * @param  class-string  $class
      * @return self<TValue>
      */
-    public function toBeInstanceOf(string $class): self
+    public function toBeInstanceOf(string $class, string $message = ''): self
     {
-        Assert::assertInstanceOf($class, $this->value);
+        Assert::assertInstanceOf($class, $this->value, $message);
 
         return $this;
     }
@@ -387,9 +388,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeArray(): self
+    public function toBeArray(string $message = ''): self
     {
-        Assert::assertIsArray($this->value);
+        Assert::assertIsArray($this->value, $message);
 
         return $this;
     }
@@ -399,9 +400,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeBool(): self
+    public function toBeBool(string $message = ''): self
     {
-        Assert::assertIsBool($this->value);
+        Assert::assertIsBool($this->value, $message);
 
         return $this;
     }
@@ -411,9 +412,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeCallable(): self
+    public function toBeCallable(string $message = ''): self
     {
-        Assert::assertIsCallable($this->value);
+        Assert::assertIsCallable($this->value, $message);
 
         return $this;
     }
@@ -423,9 +424,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeFloat(): self
+    public function toBeFloat(string $message = ''): self
     {
-        Assert::assertIsFloat($this->value);
+        Assert::assertIsFloat($this->value, $message);
 
         return $this;
     }
@@ -435,9 +436,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeInt(): self
+    public function toBeInt(string $message = ''): self
     {
-        Assert::assertIsInt($this->value);
+        Assert::assertIsInt($this->value, $message);
 
         return $this;
     }
@@ -447,9 +448,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeIterable(): self
+    public function toBeIterable(string $message = ''): self
     {
-        Assert::assertIsIterable($this->value);
+        Assert::assertIsIterable($this->value, $message);
 
         return $this;
     }
@@ -459,9 +460,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeNumeric(): self
+    public function toBeNumeric(string $message = ''): self
     {
-        Assert::assertIsNumeric($this->value);
+        Assert::assertIsNumeric($this->value, $message);
 
         return $this;
     }
@@ -471,9 +472,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeObject(): self
+    public function toBeObject(string $message = ''): self
     {
-        Assert::assertIsObject($this->value);
+        Assert::assertIsObject($this->value, $message);
 
         return $this;
     }
@@ -483,9 +484,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeResource(): self
+    public function toBeResource(string $message = ''): self
     {
-        Assert::assertIsResource($this->value);
+        Assert::assertIsResource($this->value, $message);
 
         return $this;
     }
@@ -495,9 +496,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeScalar(): self
+    public function toBeScalar(string $message = ''): self
     {
-        Assert::assertIsScalar($this->value);
+        Assert::assertIsScalar($this->value, $message);
 
         return $this;
     }
@@ -507,9 +508,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeString(): self
+    public function toBeString(string $message = ''): self
     {
-        Assert::assertIsString($this->value);
+        Assert::assertIsString($this->value, $message);
 
         return $this;
     }
@@ -519,12 +520,12 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeJson(): self
+    public function toBeJson(string $message = ''): self
     {
-        Assert::assertIsString($this->value);
+        Assert::assertIsString($this->value, $message);
 
         // @phpstan-ignore-next-line
-        Assert::assertJson($this->value);
+        Assert::assertJson($this->value, $message);
 
         return $this;
     }
@@ -534,9 +535,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeNan(): self
+    public function toBeNan(string $message = ''): self
     {
-        Assert::assertNan($this->value);
+        Assert::assertNan($this->value, $message);
 
         return $this;
     }
@@ -546,9 +547,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeNull(): self
+    public function toBeNull(string $message = ''): self
     {
-        Assert::assertNull($this->value);
+        Assert::assertNull($this->value, $message);
 
         return $this;
     }
@@ -558,7 +559,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toHaveKey(string|int $key, mixed $value = null): self
+    public function toHaveKey(string|int $key, mixed $value = new NullValue(), string $message = ''): self
     {
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $array = $this->value->toArray();
@@ -571,11 +572,15 @@ final class Expectation
 
             /* @phpstan-ignore-next-line */
         } catch (ExpectationFailedException $exception) {
-            throw new ExpectationFailedException("Failed asserting that an array has the key '$key'", $exception->getComparisonFailure());
+            if ($message === '') {
+                $message = "Failed asserting that an array has the key '$key'";
+            }
+
+            throw new ExpectationFailedException($message, $exception->getComparisonFailure());
         }
 
-        if (func_num_args() > 1) {
-            Assert::assertEquals($value, Arr::get($array, $key));
+        if (! $value instanceof NullValue) {
+            Assert::assertEquals($value, Arr::get($array, $key), $message);
         }
 
         return $this;
@@ -584,16 +589,16 @@ final class Expectation
     /**
      * Asserts that the value array has the provided $keys.
      *
-     * @param  array<int, int|string|array<int-string, mixed>>  $keys
+     * @param  array<int, int|string|array<array-key, mixed>>  $keys
      * @return self<TValue>
      */
-    public function toHaveKeys(array $keys): self
+    public function toHaveKeys(array $keys, string $message = ''): self
     {
         foreach ($keys as $k => $key) {
             if (is_array($key)) {
-                $this->toHaveKeys(array_keys(Arr::dot($key, $k.'.')));
+                $this->toHaveKeys(array_keys(Arr::dot($key, $k.'.')), $message);
             } else {
-                $this->toHaveKey($key);
+                $this->toHaveKey($key, message: $message);
             }
         }
 
@@ -605,13 +610,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeDirectory(): self
+    public function toBeDirectory(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertDirectoryExists($this->value);
+        Assert::assertDirectoryExists($this->value, $message);
 
         return $this;
     }
@@ -621,13 +626,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeReadableDirectory(): self
+    public function toBeReadableDirectory(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertDirectoryIsReadable($this->value);
+        Assert::assertDirectoryIsReadable($this->value, $message);
 
         return $this;
     }
@@ -637,13 +642,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeWritableDirectory(): self
+    public function toBeWritableDirectory(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertDirectoryIsWritable($this->value);
+        Assert::assertDirectoryIsWritable($this->value, $message);
 
         return $this;
     }
@@ -653,13 +658,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeFile(): self
+    public function toBeFile(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertFileExists($this->value);
+        Assert::assertFileExists($this->value, $message);
 
         return $this;
     }
@@ -669,13 +674,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeReadableFile(): self
+    public function toBeReadableFile(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
 
-        Assert::assertFileIsReadable($this->value);
+        Assert::assertFileIsReadable($this->value, $message);
 
         return $this;
     }
@@ -685,12 +690,12 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeWritableFile(): self
+    public function toBeWritableFile(string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
-        Assert::assertFileIsWritable($this->value);
+        Assert::assertFileIsWritable($this->value, $message);
 
         return $this;
     }
@@ -701,7 +706,7 @@ final class Expectation
      * @param  iterable<int|string, mixed>  $array
      * @return self<TValue>
      */
-    public function toMatchArray(iterable $array): self
+    public function toMatchArray(iterable $array, string $message = ''): self
     {
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $valueAsArray = $this->value->toArray();
@@ -710,17 +715,17 @@ final class Expectation
         }
 
         foreach ($array as $key => $value) {
-            Assert::assertArrayHasKey($key, $valueAsArray);
+            Assert::assertArrayHasKey($key, $valueAsArray, $message);
 
-            Assert::assertEquals(
-                $value,
-                $valueAsArray[$key],
-                sprintf(
+            if ($message === '') {
+                $message = sprintf(
                     'Failed asserting that an array has a key %s with the value %s.',
                     $this->export($key),
                     $this->export($valueAsArray[$key]),
-                ),
-            );
+                );
+            }
+
+            Assert::assertEquals($value, $valueAsArray[$key], $message);
         }
 
         return $this;
@@ -733,26 +738,27 @@ final class Expectation
      * @param  iterable<string, mixed>  $object
      * @return self<TValue>
      */
-    public function toMatchObject(iterable $object): self
+    public function toMatchObject(iterable $object, string $message = ''): self
     {
         foreach ((array) $object as $property => $value) {
             if (! is_object($this->value) && ! is_string($this->value)) {
                 InvalidExpectationValue::expected('object|string');
             }
 
-            Assert::assertTrue(property_exists($this->value, $property));
+            Assert::assertTrue(property_exists($this->value, $property), $message);
 
             /* @phpstan-ignore-next-line */
             $propertyValue = $this->value->{$property};
-            Assert::assertEquals(
-                $value,
-                $propertyValue,
-                sprintf(
+
+            if ($message === '') {
+                $message = sprintf(
                     'Failed asserting that an object has a property %s with the value %s.',
                     $this->export($property),
                     $this->export($propertyValue),
-                ),
-            );
+                );
+            }
+
+            Assert::assertEquals($value, $propertyValue, $message);
         }
 
         return $this;
@@ -763,12 +769,12 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toMatch(string $expression): self
+    public function toMatch(string $expression, string $message = ''): self
     {
         if (! is_string($this->value)) {
             InvalidExpectationValue::expected('string');
         }
-        Assert::assertMatchesRegularExpression($expression, $this->value);
+        Assert::assertMatchesRegularExpression($expression, $this->value, $message);
 
         return $this;
     }
@@ -778,9 +784,9 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toMatchConstraint(Constraint $constraint): self
+    public function toMatchConstraint(Constraint $constraint, string $message = ''): self
     {
-        Assert::assertThat($this->value, $constraint);
+        Assert::assertThat($this->value, $constraint, $message);
 
         return $this;
     }
@@ -789,13 +795,13 @@ final class Expectation
      * @param  class-string  $class
      * @return self<TValue>
      */
-    public function toContainOnlyInstancesOf(string $class): self
+    public function toContainOnlyInstancesOf(string $class, string $message = ''): self
     {
         if (! is_iterable($this->value)) {
             InvalidExpectationValue::expected('iterable');
         }
 
-        Assert::assertContainsOnlyInstancesOf($class, $this->value);
+        Assert::assertContainsOnlyInstancesOf($class, $this->value, $message);
 
         return $this;
     }
@@ -806,7 +812,7 @@ final class Expectation
      * @param (Closure(Throwable): mixed)|string $exception
      * @return self<TValue>
      */
-    public function toThrow(callable|string $exception, string $exceptionMessage = null): self
+    public function toThrow(callable|string $exception, string $exceptionMessage = null, string $message = ''): self
     {
         $callback = NullClosure::create();
 
@@ -833,16 +839,16 @@ final class Expectation
                     throw $e;
                 }
 
-                Assert::assertStringContainsString($exception, $e->getMessage());
+                Assert::assertStringContainsString($exception, $e->getMessage(), $message);
 
                 return $this;
             }
 
             if ($exceptionMessage !== null) {
-                Assert::assertStringContainsString($exceptionMessage, $e->getMessage());
+                Assert::assertStringContainsString($exceptionMessage, $e->getMessage(), $message);
             }
 
-            Assert::assertInstanceOf($exception, $e);
+            Assert::assertInstanceOf($exception, $e, $message);
             $callback($e);
 
             return $this;

--- a/src/Support/ExpectationPipeline.php
+++ b/src/Support/ExpectationPipeline.php
@@ -21,7 +21,7 @@ final class ExpectationPipeline
     /**
      * The list of passables.
      *
-     * @var array<int, mixed>
+     * @var array<array-key, mixed>
      */
     private array $passables;
 
@@ -46,7 +46,7 @@ final class ExpectationPipeline
      */
     public function send(mixed ...$passables): self
     {
-        $this->passables = array_values($passables);
+        $this->passables = $passables;
 
         return $this;
     }
@@ -72,7 +72,7 @@ final class ExpectationPipeline
             array_reverse($this->pipes),
             $this->carry(),
             function (): void {
-                ($this->closure)(...$this->passables);
+                call_user_func_array($this->closure, $this->passables);
             }
         );
 

--- a/src/Support/NullValue.php
+++ b/src/Support/NullValue.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+final class NullValue
+{
+}

--- a/tests/.snapshots/help-command.txt
+++ b/tests/.snapshots/help-command.txt
@@ -1,103 +1,119 @@
+PHPUnit 10.0-dev by Sebastian Bergmann and contributors.
 
-  Pest Testing Framework 2.x-dev.  
+Usage:
+  phpunit [options] UnitTest.php
+  phpunit [options] <directory>
 
-  USAGE: pest <file> [options]  
+Configuration:
 
-  CONFIGURATION OPTIONS:
-  --init ............................ Initialise a standard Pest configuration  
-  -c|--configuration <file> ....................... Read configuration from XML file  
-  --no-configuration ......... Ignore default configuration file (phpunit.xml)  
-  --no-extensions ............................. Do not load PHPUnit extensions  
-  --include-path <path(s)> ..... Prepend PHP's include_path with given path(s)  
-  -d <key[=value]> ...................................... Sets a php.ini value  
-  --cache-directory <dir> ................................. Specify cache directory  
-  --generate-configuration  Generate configuration file with suggested settings  
-  --migrate-configuration ....... Migrate configuration file to current format  
+  --bootstrap <file>               A PHP script that is included before the tests run
+  -c|--configuration <file>        Read configuration from XML file
+  --no-configuration               Ignore default configuration file (phpunit.xml)
+  --no-extensions                  Do not load PHPUnit extensions
+  --include-path <path(s)>         Prepend PHP's include_path with given path(s)
+  -d <key[=value]>                 Sets a php.ini value
+  --cache-directory <dir>          Specify cache directory
+  --generate-configuration         Generate configuration file with suggested settings
+  --migrate-configuration          Migrate configuration file to current format
 
-  SELECTION OPTIONS:
-  --list-suites ................................... List available test suites  
-  --testsuite <name> ............... Only run tests from the specified test suite(s)  
-  --exclude-testsuite <name> ........ Exclude tests from the specified test suite(s)  
-  --list-groups ................................... List available test groups  
-  --group <name> ........................ Only run tests from the specified group(s)  
-  --exclude-group <name> ................. Exclude tests from the specified group(s)  
-  --covers <name> ......................... Only run tests annotated with "@covers <name>"  
-  --uses <name> ............................. Only run tests annotated with "@uses <name>"  
-  --list-tests .......................................... List available tests  
-  --list-tests-xml <file> ....................... List available tests in XML format  
-  --filter <pattern> ........................................ Filter which tests to run  
-  --test-suffix <suffixes>  Only search for test in files with specified suffix(es). Default: Test.php,.phpt  
+Selection:
 
-  EXECUTION OPTIONS:
-  --process-isolation ................ Run each test in a separate PHP process  
-  --globals-backup ................. Backup and restore $GLOBALS for each test  
-  --static-backup ......... Backup and restore static properties for each test  
-  --strict-coverage . Be strict about code coverage attributes and annotations  
-  --strict-global-state .............. Be strict about changes to global state  
-  --disallow-test-output ................. Be strict about output during tests  
-  --enforce-time-limit ................. Enforce time limit based on test size  
-  --default-time-limit <sec>  Timeout in seconds for tests that have no declared size  
-  --dont-report-useless-tests .. Do not report tests that do not test anything  
-  --stop-on-defect ................. Stop execution upon first not-passed test  
-  --stop-on-error ............................ Stop execution upon first error  
-  --stop-on-failure ............... Stop execution upon first error or failure  
-  --stop-on-warning ........................ Stop execution upon first warning  
-  --stop-on-risky ....................... Stop execution upon first risky test  
-  --stop-on-skipped ................... Stop execution upon first skipped test  
-  --stop-on-incomplete ............. Stop execution upon first incomplete test  
-  --fail-on-incomplete .................... Treat incomplete tests as failures  
-  --fail-on-risky .............................. Treat risky tests as failures  
-  --fail-on-skipped .......................... Treat skipped tests as failures  
-  --fail-on-warning .................... Treat tests with warnings as failures  
-  --repeat <times> ...................................... Runs the test(s) repeatedly  
-  --cache-result ............................ Write test results to cache file  
-  --do-not-cache-result .............. Do not write test results to cache file  
-  --order-by <order>  Run tests in order: default|defects|duration|no-depends|random|reverse|size  
-  --random-order-seed <N> .......... Use a specific random seed <N> for random order  
+  --list-suites                    List available test suites
+  --testsuite <name>               Only run tests from the specified test suite(s)
+  --exclude-testsuite <name>       Exclude tests from the specified test suite(s)
+  --list-groups                    List available test groups
+  --group <name>                   Only run tests from the specified group(s)
+  --exclude-group <name>           Exclude tests from the specified group(s)
+  --covers <name>                  Only run tests annotated with "@covers <name>"
+  --uses <name>                    Only run tests annotated with "@uses <name>"
+  --list-tests                     List available tests
+  --list-tests-xml <file>          List available tests in XML format
+  --filter <pattern>               Filter which tests to run
+  --test-suffix <suffixes>         Only search for test in files with specified suffix(es). Default: Test.php,.phpt
 
-  REPORTING OPTIONS:
-  --colors <flag> ............... Use colors in output ("never", "auto" or "always")  
-  --columns <n> .................... Number of columns to use for progress output  
-  --columns max ............ Use maximum number of columns for progress output  
-  --stderr ................................. Write to STDERR instead of STDOUT  
-  --display-incomplete .................. Display details for incomplete tests  
-  --display-skipped ........................ Display details for skipped tests  
-  --display-deprecations . Display details for deprecations triggered by tests  
-  --display-errors ............. Display details for errors triggered by tests  
-  --display-notices ........... Display details for notices triggered by tests  
-  --display-warnings ......... Display details for warnings triggered by tests  
-  --reverse-list .............................. Print defects in reverse order  
-  --teamcity ............... Report test execution progress in TeamCity format  
-  --testdox ................. Report test execution progress in TestDox format  
-  --no-interaction ........................ Disable TestDox progress animation  
+Execution:
 
-  LOGGING OPTIONS:
-  --log-junit <file> ................ Log test execution in JUnit XML format to file  
-  --log-teamcity <file> .............. Log test execution in TeamCity format to file  
-  --testdox-html <file> ........... Write agile documentation in HTML format to file  
-  --testdox-text <file> ........... Write agile documentation in Text format to file  
-  --testdox-xml <file> ............. Write agile documentation in XML format to file  
-  --log-events-text <file> ..................... Stream events as plain text to file  
-  --log-events-verbose-text <file>  Stream events as plain text to file (with telemetry information)  
-  --no-logging .................................. Ignore logging configuration  
+  --process-isolation              Run each test in a separate PHP process
+  --globals-backup                 Backup and restore $GLOBALS for each test
+  --static-backup                  Backup and restore static properties for each test
 
-  CODE COVERAGE OPTIONS:
-  --coverage ..... Generate code coverage report and output to standard output  
-  --coverage --min  Set the minimum required coverage percentage, and fail if not met  
-  --coverage-crap4j <file> ...... Generate code coverage report in Crap4J XML format  
-  --coverage-html <dir> .............. Generate code coverage report in HTML format  
-  --coverage-php <file> ..................... Export PHP_CodeCoverage object to file  
-  --coverage-text=<file>  Generate code coverage report in text format [default: standard output]  
-  --coverage-xml <dir> ........ Generate code coverage report in PHPUnit XML format  
-  --warm-coverage-cache ........................... Warm static analysis cache  
-  --coverage-filter <dir> ...................... Include <dir> in code coverage analysis  
-  --path-coverage ............................. Perform path coverage analysis  
-  --disable-coverage-ignore  Disable attributes and annotations for ignoring code coverage  
-  --no-coverage ........................... Ignore code coverage configuration  
+  --strict-coverage                Be strict about code coverage attributes and annotations
+  --strict-global-state            Be strict about changes to global state
+  --disallow-test-output           Be strict about output during tests
+  --enforce-time-limit             Enforce time limit based on test size
+  --default-time-limit <sec>       Timeout in seconds for tests that have no declared size
+  --dont-report-useless-tests      Do not report tests that do not test anything
 
-  MISCELLANEOUS OPTIONS:
-  -h|--help .................................... Prints this usage information  
-  --version ..................................... Prints the version and exits  
-  --atleast-version <min> ....... Checks that version is greater than min and exits  
-  --check-version ................ Check whether PHPUnit is the latest version  
+  --stop-on-defect                 Stop execution upon first not-passed test
+  --stop-on-error                  Stop execution upon first error
+  --stop-on-failure                Stop execution upon first error or failure
+  --stop-on-warning                Stop execution upon first warning
+  --stop-on-risky                  Stop execution upon first risky test
+  --stop-on-skipped                Stop execution upon first skipped test
+  --stop-on-incomplete             Stop execution upon first incomplete test
+
+  --fail-on-incomplete             Treat incomplete tests as failures
+  --fail-on-risky                  Treat risky tests as failures
+  --fail-on-skipped                Treat skipped tests as failures
+  --fail-on-warning                Treat tests with warnings as failures
+
+  --repeat <times>                 Runs the test(s) repeatedly
+
+  --cache-result                   Write test results to cache file
+  --do-not-cache-result            Do not write test results to cache file
+
+  --order-by <order>               Run tests in order: default|defects|duration|no-depends|random|reverse|size
+  --random-order-seed <N>          Use a specific random seed <N> for random order
+
+Reporting:
+
+  --colors <flag>                  Use colors in output ("never", "auto" or "always")
+  --columns <n>                    Number of columns to use for progress output
+  --columns max                    Use maximum number of columns for progress output
+  --stderr                         Write to STDERR instead of STDOUT
+
+  --display-incomplete             Display details for incomplete tests
+  --display-skipped                Display details for skipped tests
+  --display-deprecations           Display details for deprecations triggered by tests
+  --display-errors                 Display details for errors triggered by tests
+  --display-notices                Display details for notices triggered by tests
+  --display-warnings               Display details for warnings triggered by tests
+  --reverse-list                   Print defects in reverse order
+
+  --teamcity                       Report test execution progress in TeamCity format
+  --testdox                        Report test execution progress in TestDox format
+  --no-interaction                 Disable TestDox progress animation
+
+Logging:
+
+  --log-junit <file>               Log test execution in JUnit XML format to file
+  --log-teamcity <file>            Log test execution in TeamCity format to file
+  --testdox-html <file>            Write agile documentation in HTML format to file
+  --testdox-text <file>            Write agile documentation in Text format to file
+  --testdox-xml <file>             Write agile documentation in XML format to file
+  --log-events-text <file>         Stream events as plain text to file
+  --log-events-verbose-text <file> Stream events as plain text to file (with telemetry information)
+  --no-logging                     Ignore logging configuration
+
+Code Coverage:
+
+  --coverage-clover <file>         Generate code coverage report in Clover XML format
+  --coverage-cobertura <file>      Generate code coverage report in Cobertura XML format
+  --coverage-crap4j <file>         Generate code coverage report in Crap4J XML format
+  --coverage-html <dir>            Generate code coverage report in HTML format
+  --coverage-php <file>            Export PHP_CodeCoverage object to file
+  --coverage-text=<file>           Generate code coverage report in text format [default: standard output]
+  --coverage-xml <dir>             Generate code coverage report in PHPUnit XML format
+  --warm-coverage-cache            Warm static analysis cache
+  --coverage-filter <dir>          Include <dir> in code coverage analysis
+  --path-coverage                  Perform path coverage analysis
+  --disable-coverage-ignore        Disable attributes and annotations for ignoring code coverage
+  --no-coverage                    Ignore code coverage configuration
+
+Miscellaneous:
+
+  -h|--help                        Prints this usage information
+  --version                        Prints the version and exits
+  --atleast-version <min>          Checks that version is greater than min and exits
+  --check-version                  Check whether PHPUnit is the latest version
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1,775 +1,651 @@
-
-   PASS  Tests\Features\AfterAll
-  ✓ deletes file after all
-
-   PASS  Tests\Features\AfterEach
-  ✓ it does not get executed before the test
-  ✓ it gets executed after the test
-
-   PASS  Tests\Features\BeforeAll
-  ✓ it gets executed before tests
-  ✓ it do not get executed before each test
-
-   PASS  Tests\Features\BeforeEach
-  ✓ it gets executed before each test
-  ✓ it gets executed before each test once again
-
-   WARN  Tests\Features\Coverage
-  ✓ it has plugin
-  - it adds coverage if --coverage exist → Coverage is not available
-  ✓ it adds coverage if --min exist
-  ✓ it generates coverage based on file input
-
-   PASS  Tests\Features\Covers
-  ✓ it uses the correct PHPUnit attribute for class
-  ✓ it uses the correct PHPUnit attribute for function
-  ✓ it removes duplicated attributes
-  ✓ it guesses if the given argument is a class or function
-  ✓ it appends CoversNothing to method attributes
-  ✓ it does not append CoversNothing to other methods
-  ✓ it throws exception if no class nor method has been found
-
-   PASS  Tests\Features\Datasets
-  ✓ it throws exception if dataset does not exist
-  ✓ it throws exception if dataset already exist
-  ✓ it sets closures
-  ✓ it sets arrays
-  ✓ it gets bound to test case object with ('a')
-  ✓ it gets bound to test case object with ('b')
-  ✓ it truncates the description with ('FoooFoooFoooFoooFoooFoooFoooF...ooFooo')
-  ✓ lazy datasets with (1)
-  ✓ lazy datasets with (2)
-  ✓ lazy datasets did the job right
-  ✓ eager datasets with (1)
-  ✓ eager datasets with (2)
-  ✓ eager datasets did the job right
-  ✓ lazy registered datasets with (1)
-  ✓ lazy registered datasets with (2)
-  ✓ lazy registered datasets did the job right
-  ✓ eager registered datasets with (1)
-  ✓ eager registered datasets with (2)
-  ✓ eager registered datasets did the job right
-  ✓ eager wrapped registered datasets with (1)
-  ✓ eager wrapped registered datasets with (2)
-  ✓ eager registered wrapped datasets did the job right
-  ✓ named datasets with data set "one"
-  ✓ named datasets with data set "two"
-  ✓ named datasets did the job right
-  ✓ lazy named datasets with (Bar Object (...))
-  ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
-  ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #2
-  ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), false)
-  ✓ it creates unique test case names with ('Name 2', Pest\Plugin Object (), false)
-  ✓ it creates unique test case names with ('Name 2', Pest\Plugin Object (), true)
-  ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #3
-  ✓ it creates unique test case names - count
-  ✓ lazy multiple datasets with (1) / (3)
-  ✓ lazy multiple datasets with (1) / (4)
-  ✓ lazy multiple datasets with (2) / (3)
-  ✓ lazy multiple datasets with (2) / (4)
-  ✓ lazy multiple datasets did the job right
-  ✓ eager multiple datasets with (1) / (3)
-  ✓ eager multiple datasets with (1) / (4)
-  ✓ eager multiple datasets with (2) / (3)
-  ✓ eager multiple datasets with (2) / (4)
-  ✓ eager multiple datasets did the job right
-  ✓ lazy registered multiple datasets with (1) / (1)
-  ✓ lazy registered multiple datasets with (1) / (2)
-  ✓ lazy registered multiple datasets with (2) / (1)
-  ✓ lazy registered multiple datasets with (2) / (2)
-  ✓ lazy registered multiple datasets did the job right
-  ✓ eager registered multiple datasets with (1) / (1)
-  ✓ eager registered multiple datasets with (1) / (2)
-  ✓ eager registered multiple datasets with (2) / (1)
-  ✓ eager registered multiple datasets with (2) / (2)
-  ✓ eager registered multiple datasets did the job right
-  ✓ eager wrapped registered multiple datasets with (1) / (1)
-  ✓ eager wrapped registered multiple datasets with (1) / (2)
-  ✓ eager wrapped registered multiple datasets with (2) / (1)
-  ✓ eager wrapped registered multiple datasets with (2) / (2)
-  ✓ eager wrapped registered multiple datasets did the job right
-  ✓ named multiple datasets with data set "one" / data set "three"
-  ✓ named multiple datasets with data set "one" / data set "four"
-  ✓ named multiple datasets with data set "two" / data set "three"
-  ✓ named multiple datasets with data set "two" / data set "four"
-  ✓ named multiple datasets did the job right
-  ✓ more than two datasets with (1) / (3) / (5)
-  ✓ more than two datasets with (1) / (3) / (6)
-  ✓ more than two datasets with (1) / (4) / (5)
-  ✓ more than two datasets with (1) / (4) / (6)
-  ✓ more than two datasets with (2) / (3) / (5)
-  ✓ more than two datasets with (2) / (3) / (6)
-  ✓ more than two datasets with (2) / (4) / (5)
-  ✓ more than two datasets with (2) / (4) / (6)
-  ✓ more than two datasets did the job right
-  ✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #1
-  ✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #2
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
-  ✓ it resolves a potential bound dataset logically with ('foo', Closure Object (...))
-  ✓ it resolves a potential bound dataset logically even when the closure comes first with (Closure Object (...), 'bar')
-  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (...)) #1
-  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (...)) #2
-  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (...)) #1
-  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (...)) #2
-  ✓ it can correctly resolve a bound dataset that returns an array with (Closure Object (...))
-  ✓ it can correctly resolve a bound dataset that returns an array but wants to be spread with (Closure Object (...))
-
-   PASS  Tests\Features\Depends
-  ✓ first
-  ✓ second
-  ✓ depends
-  ✓ depends with ...params
-  ✓ depends with defined arguments
-  ✓ depends run test only once
-  ✓ it asserts true is true
-  ✓ depends works with the correct test name
-
-   PASS  Tests\Features\DependsInheritance
-  ✓ it is a test
-  ✓ it uses correct parent class
-
-   PASS  Tests\Features\Exceptions
-  ✓ it gives access the the underlying expectException
-  ✓ it catch exceptions
-  ✓ it catch exceptions and messages
-  ✓ it catch exceptions, messages and code
-  ✓ it can just define the message
-  ✓ it can just define the code
-  ✓ it not catch exceptions if given condition is false
-  ✓ it catch exceptions if given condition is true
-  ✓ it catch exceptions and messages if given condition is true
-  ✓ it catch exceptions, messages and code if given condition is true
-  ✓ it can just define the message if given condition is true
-  ✓ it can just define the code if given condition is true
-  ✓ it can just define the message if given condition is 1
-  ✓ it can just define the code if given condition is 1
-
-   PASS  Tests\Features\Expect\HigherOrder\methods
-  ✓ it can access methods
-  ✓ it can access multiple methods
-  ✓ it works with not
-  ✓ it can accept arguments
-  ✓ it works with each
-  ✓ it works inside of each
-  ✓ it works with sequence
-  ✓ it can compose complex expectations
-  ✓ it can handle nested method calls
-  ✓ it works with higher order tests
-  ✓ it can use the scoped method to lock into the given level for expectations
-  ✓ it works consistently with the json expectation method
-
-   PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
-  ✓ it can access methods and properties
-  ✓ it can handle nested methods and properties
-  ✓ it works with higher order tests
-  ✓ it can start a new higher order expectation using the and syntax
-  ✓ it can start a new higher order expectation using the and syntax in higher order tests
-  ✓ it can start a new higher order expectation using the and syntax without nesting expectations
-
-   PASS  Tests\Features\Expect\HigherOrder\properties
-  ✓ it allows properties to be accessed from the value
-  ✓ it can access multiple properties from the value
-  ✓ it works with not
-  ✓ it works with each
-  ✓ it works inside of each
-  ✓ it works with sequence
-  ✓ it can compose complex expectations
-  ✓ it works with objects
-  ✓ it works with nested properties
-  ✓ it works with higher order tests
-
-   PASS  Tests\Features\Expect\each
-  ✓ an exception is thrown if the the type is not iterable
-  ✓ it expects on each item
-  ✓ it chains expectations on each item
-  ✓ opposite expectations on each item
-  ✓ chained opposite and non-opposite expectations
-  ✓ it can add expectations via "and"
-  ✓ it accepts callables
-  ✓ it passes the key of the current item to callables
-
-   PASS  Tests\Features\Expect\extend
-  ✓ it macros true is true
-  ✓ it macros false is not true
-  ✓ it macros true is true with argument
-  ✓ it macros false is not true with argument
-
-   PASS  Tests\Features\Expect\json
-  ✓ it properly parses json string
-  ✓ fails with broken json string
-
-   PASS  Tests\Features\Expect\matchExpectation
-  ✓ it pass
-  ✓ it failures
-  ✓ it runs with truthy
-  ✓ it runs with falsy
-  ✓ it runs with truthy closure condition
-  ✓ it runs with falsy closure condition
-  ✓ it can be passed non-callable values
-  ✓ it fails with unhandled match
-  ✓ it can be used in higher order tests
-
-   PASS  Tests\Features\Expect\not
-  ✓ not property calls
-
-   PASS  Tests\Features\Expect\pipes
-  ✓ pipe is applied and can stop pipeline
-  ✓ pipe is run and can let the pipeline keep going
-  ✓ pipe works with negated expectation
-  ✓ interceptor is applied
-  ✓ interceptor stops the pipeline
-  ✓ interceptor is called only when filter is met
-  ✓ interceptor can be filtered with a closure
-  ✓ interceptor can be filter the expected parameter as well
-  ✓ interceptor works with negated expectation
-  ✓ intercept can add new parameters to the expectation
-
-   PASS  Tests\Features\Expect\ray
-  ✓ ray calls do not fail when ray is not installed
-
-   PASS  Tests\Features\Expect\sequence
-  ✓ an exception is thrown if the the type is not iterable
-  ✓ allows for sequences of checks to be run on iterable data
-  ✓ loops back to the start if it runs out of sequence items
-  ✓ fails if the number of iterable items is greater than the number of expectations
-  ✓ it works with associative arrays
-  ✓ it can be passed non-callable values
-  ✓ it can be passed a mixture of value types
-
-   PASS  Tests\Features\Expect\toBe
-  ✓ strict comparisons
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeArray
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeBool
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeCallable
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeDirectory
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeEmpty
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeFalse
-  ✓ strict comparisons
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeFalsy
-  ✓ passes as falsy with (false)
-  ✓ passes as falsy with ('')
-  ✓ passes as falsy with (null)
-  ✓ passes as falsy with (0)
-  ✓ passes as falsy with ('0')
-  ✓ passes as not falsy with (true)
-  ✓ passes as not falsy with (1) #1
-  ✓ passes as not falsy with ('false')
-  ✓ passes as not falsy with (1) #2
-  ✓ passes as not falsy with (-1)
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeFile
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeFloat
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeGreatherThan
-  ✓ passes
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeGreatherThanOrEqual
-  ✓ passes
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeIn
-  ✓ passes
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeInfinite
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeInstanceOf
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeInt
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeIterable
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeJson
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeLessThan
-  ✓ passes
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeLessThanOrEqual
-  ✓ passes
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeNAN
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeNull
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeNumeric
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeObject
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeReadableDirectory
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeReadableFile
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeResource
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeScalar
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeString
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeTrue
-  ✓ strict comparisons
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeTruthy
-  ✓ passes as truthy with (true)
-  ✓ passes as truthy with (1) #1
-  ✓ passes as truthy with ('false')
-  ✓ passes as truthy with (1) #2
-  ✓ passes as truthy with (-1)
-  ✓ passes as not truthy with (false)
-  ✓ passes as not truthy with ('')
-  ✓ passes as not truthy with (null)
-  ✓ passes as not truthy with (0)
-  ✓ passes as not truthy with ('0')
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeWritableDirectory
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toBeWritableFile
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toContain
-  ✓ passes strings
-  ✓ passes strings with multiple needles
-  ✓ passes arrays
-  ✓ passes arrays with multiple needles
-  ✓ passes with array needles
-  ✓ failures
-  ✓ failures with multiple needles (all failing)
-  ✓ failures with multiple needles (some failing)
-  ✓ not failures
-  ✓ not failures with multiple needles (all failing)
-  ✓ not failures with multiple needles (some failing)
-
-   PASS  Tests\Features\Expect\toContainOnlyInstancesOf
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toEndWith
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toEqual
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toEqualCanonicalizing
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toEqualWithDelta
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toHaveCount
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toHaveKey
-  ✓ pass
-  ✓ pass with nested key
-  ✓ pass with plain key with dots
-  ✓ pass with value check
-  ✓ pass with value check and nested key
-  ✓ pass with value check and plain key with dots
-  ✓ failures
-  ✓ failures with nested key
-  ✓ failures with plain key with dots
-  ✓ fails with wrong value
-  ✓ fails with wrong value and nested key
-  ✓ fails with wrong value and plain key with dots
-  ✓ not failures
-  ✓ not failures with nested key
-  ✓ not failures with plain key with dots
-  ✓ not failures with correct value
-  ✓ not failures with correct value and with nested key
-  ✓ not failures with correct value and with plain key with dots
-
-   PASS  Tests\Features\Expect\toHaveKeys
-  ✓ pass
-  ✓ pass with multi-dimensional arrays
-  ✓ failures
-  ✓ failures with multi-dimensional arrays
-  ✓ not failures
-  ✓ not failures with multi-dimensional arrays
-
-   PASS  Tests\Features\Expect\toHaveLength
-  ✓ it passes with ('Fortaleza')
-  ✓ it passes with ('Sollefteå')
-  ✓ it passes with ('Ιεράπετρα')
-  ✓ it passes with (stdClass Object (...))
-  ✓ it passes with (Illuminate\Support\Collection Object (...))
-  ✓ it passes with array
-  ✓ it passes with *not*
-  ✓ it properly fails with *not*
-  ✓ it fails with (1)
-  ✓ it fails with (1.5)
-  ✓ it fails with (true)
-  ✓ it fails with (null)
-
-   PASS  Tests\Features\Expect\toHaveProperties
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toHaveProperty
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toMatch
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toMatchArray
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toMatchConstraint
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toMatchObject
-  ✓ pass
-  ✓ pass with class
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toStartWith
-  ✓ pass
-  ✓ failures
-  ✓ not failures
-
-   PASS  Tests\Features\Expect\toThrow
-  ✓ passes
-  ✓ failures 1
-  ✓ failures 2
-  ✓ failures 3
-  ✓ failures 4
-  ✓ failures 5
-  ✓ failures 6
-  ✓ failures 7
-  ✓ not failures
-  ✓ closure missing parameter
-  ✓ closure missing type-hint
-  ✓ it can handle a non-defined exception
-  ✓ it can handle a class not found Error
-
-   PASS  Tests\Features\Expect\unless
-  ✓ it pass
-  ✓ it failures
-  ✓ it runs with truthy
-  ✓ it skips with falsy
-  ✓ it runs with truthy closure condition
-  ✓ it skips with falsy closure condition
-  ✓ it can be used in higher order tests
-
-   PASS  Tests\Features\Expect\when
-  ✓ it pass
-  ✓ it failures
-  ✓ it runs with truthy
-  ✓ it skips with falsy
-  ✓ it runs with truthy closure condition
-  ✓ it skips with falsy closure condition
-  ✓ it can be used in higher order tests
-
-   PASS  Tests\Features\Helpers
-  ✓ it can set/get properties on $this
-  ✓ it throws error if property do not exist
-  ✓ it allows to call underlying protected/private methods
-  ✓ it throws error if method do not exist
-  ✓ it can forward unexpected calls to any global function
-  ✓ it can use helpers from helpers file
-
-   PASS  Tests\Features\HigherOrderTests
-  ✓ it proxies calls to object
-  ✓ it is capable doing multiple assertions
-  ✓ it resolves expect callables correctly
-  ✓ does not treat method names as callables
-  ✓ it can defer a method until after test setup
-  ✓ it can pass datasets into the expect callables with (1, 2, 3)
-  ✓ it can pass datasets into the defer callable with (1, 2, 3)
-  ✓ it can pass shared datasets into callables with (1)
-  ✓ it can pass shared datasets into callables with (2)
-
-   WARN  Tests\Features\Incompleted
-  … incompleted
-  … it is incompleted
-  … it is incompleted even with method calls like skip
-  … it is incompleted even with method calls like group
-  ✓ it is not incompleted because of expect
-  ✓ it is not incompleted because of assert
-  ✓ it is not incompleted because of test with assertions
-
-   PASS  Tests\Features\It
-  ✓ it is a test
-  ✓ it is a higher order message test
-
-   PASS  Tests\Features\Macro
-  ✓ it can call chained macro method
-  ✓ it will throw exception from call if no macro exists
-
-   PASS  Tests\Features\PendingHigherOrderTests
-  ✓ get 'foo'
-  ✓ get 'foo' → get 'bar' → expect true → toBeTrue
-  ✓ get 'foo' → expect true → toBeTrue
-
-   WARN  Tests\Features\Skip
-  ✓ it do not skips
-  - it skips with truthy → 1
-  - it skips with truthy condition by default
-  - it skips with message → skipped because bar
-  - it skips with truthy closure condition
-  ✓ it do not skips with falsy closure condition
-  - it skips with condition and message → skipped because foo
-  - it skips when skip after assertion
-  - it can use something in the test case as a condition → This test was skipped
-  - it can user higher order callables and skip
-
-   PASS  Tests\Features\Test
-  ✓ a test
-  ✓ higher order message test
-
-   PASS  Tests\Features\ThrowsNoExceptions
-  ✓ it allows access to the underlying expectNotToPerformAssertions method
-  ✓ it allows performing no expectations without being risky
-
-   PASS  Tests\Features\Todo
-  ↓ something todo later
-  ✓ it does something within a file with a todo
-
-   PASS  Tests\Fixtures\DirectoryWithTests\ExampleTest
-  ✓ it example 1
-
-   PASS  Tests\Fixtures\ExampleTest
-  ✓ it example 2
-
-   PASS  Tests\Hooks\AfterAllTest
-  ✓ global afterAll execution order
-  ✓ it only gets called once per file
-
-   PASS  Tests\Hooks\AfterEachTest
-  ✓ global afterEach execution order
-
-   PASS  Tests\Hooks\BeforeAllTest
-  ✓ global beforeAll execution order
-  ✓ it only gets called once per file
-
-   PASS  Tests\Hooks\BeforeEachTest
-  ✓ global beforeEach execution order
-
-   PASS  Tests\PHPUnit\CustomAffixes\InvalidTestName
-  ✓ it runs file names like `@#$%^&()-_=+.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\ATestWithSpaces
-  ✓ it runs file names like `A Test With Spaces.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\AdditionalFileExtension
-  ✓ it runs file names like `AdditionalFileExtension.spec.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\FolderWithAn\ExampleTest
-  ✓ custom traits can be used
-  ✓ trait applied in this file
-
-   PASS  Tests\PHPUnit\CustomAffixes\ManyExtensions
-  ✓ it runs file names like `ManyExtensions.class.test.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\TestCaseWithQuotes
-  ✓ it runs file names like `Test 'Case' With Quotes.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\kebabcasespec
-  ✓ it runs file names like `kebab-case-spec.php`
-
-   PASS  Tests\PHPUnit\CustomAffixes\snakecasespec
-  ✓ it runs file names like `snake_case_spec.php`
-
-   PASS  Tests\PHPUnit\CustomTestCase\UsesPerDirectory
-  ✓ closure was bound to CustomTestCase
-
-   PASS  Tests\PHPUnit\CustomTestCaseInSubFolders\SubFolder\SubFolder\UsesPerSubDirectory
-  ✓ closure was bound to CustomTestCase
-
-   PASS  Tests\PHPUnit\CustomTestCaseInSubFolders\SubFolder2\UsesPerFile
-  ✓ custom traits can be used
-  ✓ trait applied in this file
-
-   PASS  Tests\Playground
-  ✓ basic
-
-   PASS  Tests\Plugins\Traits
-  ✓ it allows global uses
-  ✓ it allows multiple global uses registered in the same path
-
-   WARN  Tests\Unit\ConfigLoader
-  ✓ it fallbacks to default path if no phpunit file is found
-  - it fallbacks to default path if phpunit is not a valid XML
-  - it fallbacks to default path if failing to read phpunit content
-  - it fallbacks to default path if there is no test suites directory
-  - it fallbacks to default path if test suite directory has no value
-  - it fallbacks to default path if test suite directory does not exist
-  - it returns the parent folder of first test suite directory
-
-   PASS  Tests\Unit\Console\Help
-  ✓ it outputs the help information when --help is used
-
-   PASS  Tests\Unit\Datasets
-  ✓ it show only the names of named datasets in their description
-  ✓ it show the actual dataset of non-named datasets in their description
-  ✓ it show only the names of multiple named datasets in their description
-  ✓ it show the actual dataset of multiple non-named datasets in their description
-  ✓ it show the correct description for mixed named and not-named datasets
-
-   PASS  Tests\Unit\Plugins\Environment
-  ✓ environment is set to CI when --ci option is used
-  ✓ environment is set to Local when --ci option is not used
-
-   PASS  Tests\Unit\Plugins\Retry
-  ✓ it retries if --retry argument is used
-
-   PASS  Tests\Unit\Support\Backtrace
-  ✓ it gets file name from called file
-
-   PASS  Tests\Unit\Support\Container
-  ✓ it exists
-  ✓ it gets an instance
-  ✓ autowire
-  ✓ it creates an instance and resolves parameters
-  ✓ it creates an instance and resolves also sub parameters
-  ✓ it can resolve builtin value types
-  ✓ it cannot resolve a parameter without type
-
-   PASS  Tests\Unit\Support\Reflection
-  ✓ it gets file name from closure
-  ✓ it gets property values
-
-   PASS  Tests\Unit\TestSuite
-  ✓ it does not allow to add the same test description twice
-  ✓ it alerts users about tests with arguments but no input
-  ✓ it can return an array of all test suite filenames
-  ✓ it can filter the test suite filenames to those with the only method
-  ✓ it does not filter the test suite filenames to those with the only method when working in CI pipeline
-
-   PASS  Tests\Visual\Help
-  ✓ visual snapshot of help command output
-
-   WARN  Tests\Visual\JUnit
-  - it is can successfully call all public methods → Not supported yet.
-
-   PASS  Tests\Visual\SingleTestOrDirectory
-  ✓ allows to run a single test
-  ✓ allows to run a directory
-  ✓ it disable decorating printer when colors is set to never
-
-   WARN  Tests\Visual\Success
-  - visual snapshot of test suite on success
-
-   WARN  Tests\Visual\TeamCity
-  - it is can successfully call all public methods → Not supported yet.
-
-   PASS  Tests\Visual\Version
-  ✓ visual snapshot of help command output
-
-  Tests:    4 incomplete, 1 todo, 18 skipped, 514 passed (1289 assertions)
+PASS  Tests\Features\AfterAll
+✓ deletes file after all
+PASS  Tests\Features\AfterEach
+✓ it does not get executed before the test
+✓ it gets executed after the test
+PASS  Tests\Features\BeforeAll
+✓ it gets executed before tests
+✓ it do not get executed before each test
+PASS  Tests\Features\BeforeEach
+✓ it gets executed before each test
+✓ it gets executed before each test once again
+WARN  Tests\Features\Coverage
+✓ it has plugin
+- it adds coverage if --coverage exist → Coverage is not available
+✓ it adds coverage if --min exist
+✓ it generates coverage based on file input
+PASS  Tests\Features\Covers
+✓ it uses the correct PHPUnit attribute for class
+✓ it uses the correct PHPUnit attribute for function
+✓ it removes duplicated attributes
+✓ it guesses if the given argument is a class or function
+✓ it appends CoversNothing to method attributes
+✓ it does not append CoversNothing to other methods
+✓ it throws exception if no class nor method has been found
+PASS  Tests\Features\Datasets
+✓ it throws exception if dataset does not exist
+✓ it throws exception if dataset already exist
+✓ it sets closures
+✓ it sets arrays
+✓ it gets bound to test case object with ('a')
+✓ it gets bound to test case object with ('b')
+✓ it truncates the description with ('FoooFoooFoooFoooFoooFoooFoooF...ooFooo')
+✓ lazy datasets with (1)
+✓ lazy datasets with (2)
+✓ lazy datasets did the job right
+✓ eager datasets with (1)
+✓ eager datasets with (2)
+✓ eager datasets did the job right
+✓ lazy registered datasets with (1)
+✓ lazy registered datasets with (2)
+✓ lazy registered datasets did the job right
+✓ eager registered datasets with (1)
+✓ eager registered datasets with (2)
+✓ eager registered datasets did the job right
+✓ eager wrapped registered datasets with (1)
+✓ eager wrapped registered datasets with (2)
+✓ eager registered wrapped datasets did the job right
+✓ named datasets with data set "one"
+✓ named datasets with data set "two"
+✓ named datasets did the job right
+✓ lazy named datasets with (Bar Object (...))
+✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
+✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #2
+✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), false)
+✓ it creates unique test case names with ('Name 2', Pest\Plugin Object (), false)
+✓ it creates unique test case names with ('Name 2', Pest\Plugin Object (), true)
+✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #3
+✓ it creates unique test case names - count
+✓ lazy multiple datasets with (1) / (3)
+✓ lazy multiple datasets with (1) / (4)
+✓ lazy multiple datasets with (2) / (3)
+✓ lazy multiple datasets with (2) / (4)
+✓ lazy multiple datasets did the job right
+✓ eager multiple datasets with (1) / (3)
+✓ eager multiple datasets with (1) / (4)
+✓ eager multiple datasets with (2) / (3)
+✓ eager multiple datasets with (2) / (4)
+✓ eager multiple datasets did the job right
+✓ lazy registered multiple datasets with (1) / (1)
+✓ lazy registered multiple datasets with (1) / (2)
+✓ lazy registered multiple datasets with (2) / (1)
+✓ lazy registered multiple datasets with (2) / (2)
+✓ lazy registered multiple datasets did the job right
+✓ eager registered multiple datasets with (1) / (1)
+✓ eager registered multiple datasets with (1) / (2)
+✓ eager registered multiple datasets with (2) / (1)
+✓ eager registered multiple datasets with (2) / (2)
+✓ eager registered multiple datasets did the job right
+✓ eager wrapped registered multiple datasets with (1) / (1)
+✓ eager wrapped registered multiple datasets with (1) / (2)
+✓ eager wrapped registered multiple datasets with (2) / (1)
+✓ eager wrapped registered multiple datasets with (2) / (2)
+✓ eager wrapped registered multiple datasets did the job right
+✓ named multiple datasets with data set "one" / data set "three"
+✓ named multiple datasets with data set "one" / data set "four"
+✓ named multiple datasets with data set "two" / data set "three"
+✓ named multiple datasets with data set "two" / data set "four"
+✓ named multiple datasets did the job right
+✓ more than two datasets with (1) / (3) / (5)
+✓ more than two datasets with (1) / (3) / (6)
+✓ more than two datasets with (1) / (4) / (5)
+✓ more than two datasets with (1) / (4) / (6)
+✓ more than two datasets with (2) / (3) / (5)
+✓ more than two datasets with (2) / (3) / (6)
+✓ more than two datasets with (2) / (4) / (5)
+✓ more than two datasets with (2) / (4) / (6)
+✓ more than two datasets did the job right
+✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #1
+✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #2
+✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
+✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
+✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
+✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
+✓ it resolves a potential bound dataset logically with ('foo', Closure Object (...))
+✓ it resolves a potential bound dataset logically even when the closure comes first with (Closure Object (...), 'bar')
+✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (...)) #1
+✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (...)) #2
+✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (...)) #1
+✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (...)) #2
+✓ it can correctly resolve a bound dataset that returns an array with (Closure Object (...))
+✓ it can correctly resolve a bound dataset that returns an array but wants to be spread with (Closure Object (...))
+PASS  Tests\Features\Depends
+✓ first
+✓ second
+✓ depends
+✓ depends with ...params
+✓ depends with defined arguments
+✓ depends run test only once
+✓ it asserts true is true
+✓ depends works with the correct test name
+PASS  Tests\Features\DependsInheritance
+✓ it is a test
+✓ it uses correct parent class
+PASS  Tests\Features\Exceptions
+✓ it gives access the the underlying expectException
+✓ it catch exceptions
+✓ it catch exceptions and messages
+✓ it catch exceptions, messages and code
+✓ it can just define the message
+✓ it can just define the code
+✓ it not catch exceptions if given condition is false
+✓ it catch exceptions if given condition is true
+✓ it catch exceptions and messages if given condition is true
+✓ it catch exceptions, messages and code if given condition is true
+✓ it can just define the message if given condition is true
+✓ it can just define the code if given condition is true
+✓ it can just define the message if given condition is 1
+✓ it can just define the code if given condition is 1
+PASS  Tests\Features\Expect\HigherOrder\methods
+✓ it can access methods
+✓ it can access multiple methods
+✓ it works with not
+✓ it can accept arguments
+✓ it works with each
+✓ it works inside of each
+✓ it works with sequence
+✓ it can compose complex expectations
+✓ it can handle nested method calls
+✓ it works with higher order tests
+✓ it can use the scoped method to lock into the given level for expectations
+✓ it works consistently with the json expectation method
+PASS  Tests\Features\Expect\HigherOrder\methodsAndProperties
+✓ it can access methods and properties
+✓ it can handle nested methods and properties
+✓ it works with higher order tests
+✓ it can start a new higher order expectation using the and syntax
+✓ it can start a new higher order expectation using the and syntax in higher order tests
+✓ it can start a new higher order expectation using the and syntax without nesting expectations
+PASS  Tests\Features\Expect\HigherOrder\properties
+✓ it allows properties to be accessed from the value
+✓ it can access multiple properties from the value
+✓ it works with not
+✓ it works with each
+✓ it works inside of each
+✓ it works with sequence
+✓ it can compose complex expectations
+✓ it works with objects
+✓ it works with nested properties
+✓ it works with higher order tests
+PASS  Tests\Features\Expect\each
+✓ an exception is thrown if the the type is not iterable
+✓ it expects on each item
+✓ it chains expectations on each item
+✓ opposite expectations on each item
+✓ chained opposite and non-opposite expectations
+✓ it can add expectations via "and"
+✓ it accepts callables
+✓ it passes the key of the current item to callables
+PASS  Tests\Features\Expect\extend
+✓ it macros true is true
+✓ it macros false is not true
+✓ it macros true is true with argument
+✓ it macros false is not true with argument
+PASS  Tests\Features\Expect\json
+✓ it properly parses json string
+✓ fails with broken json string
+PASS  Tests\Features\Expect\matchExpectation
+✓ it pass
+✓ it failures
+✓ it runs with truthy
+✓ it runs with falsy
+✓ it runs with truthy closure condition
+✓ it runs with falsy closure condition
+✓ it can be passed non-callable values
+✓ it fails with unhandled match
+✓ it can be used in higher order tests
+PASS  Tests\Features\Expect\not
+✓ not property calls
+PASS  Tests\Features\Expect\pipes
+✓ pipe is applied and can stop pipeline
+✓ pipe is run and can let the pipeline keep going
+✓ pipe works with negated expectation
+✓ interceptor is applied
+✓ interceptor stops the pipeline
+✓ interceptor is called only when filter is met
+✓ interceptor can be filtered with a closure
+✓ interceptor can be filter the expected parameter as well
+✓ interceptor works with negated expectation
+✓ intercept can add new parameters to the expectation
+PASS  Tests\Features\Expect\ray
+✓ ray calls do not fail when ray is not installed
+PASS  Tests\Features\Expect\sequence
+✓ an exception is thrown if the the type is not iterable
+✓ allows for sequences of checks to be run on iterable data
+✓ loops back to the start if it runs out of sequence items
+✓ fails if the number of iterable items is greater than the number of expectations
+✓ it works with associative arrays
+✓ it can be passed non-callable values
+✓ it can be passed a mixture of value types
+PASS  Tests\Features\Expect\toBe
+✓ strict comparisons
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeArray
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeBool
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeCallable
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeDirectory
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeEmpty
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeFalse
+✓ strict comparisons
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeFalsy
+✓ passes as falsy with (false)
+✓ passes as falsy with ('')
+✓ passes as falsy with (null)
+✓ passes as falsy with (0)
+✓ passes as falsy with ('0')
+✓ passes as not falsy with (true)
+✓ passes as not falsy with (1) #1
+✓ passes as not falsy with ('false')
+✓ passes as not falsy with (1) #2
+✓ passes as not falsy with (-1)
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeFile
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeFloat
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeGreatherThan
+✓ passes
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeGreatherThanOrEqual
+✓ passes
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeIn
+✓ passes
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeInfinite
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeInstanceOf
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeInt
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeIterable
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeJson
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeLessThan
+✓ passes
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeLessThanOrEqual
+✓ passes
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeNAN
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeNull
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeNumeric
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeObject
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeReadableDirectory
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeReadableFile
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeResource
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeScalar
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeString
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeTrue
+✓ strict comparisons
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeTruthy
+✓ passes as truthy with (true)
+✓ passes as truthy with (1) #1
+✓ passes as truthy with ('false')
+✓ passes as truthy with (1) #2
+✓ passes as truthy with (-1)
+✓ passes as not truthy with (false)
+✓ passes as not truthy with ('')
+✓ passes as not truthy with (null)
+✓ passes as not truthy with (0)
+✓ passes as not truthy with ('0')
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeWritableDirectory
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toBeWritableFile
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toContain
+✓ passes strings
+✓ passes strings with multiple needles
+✓ passes arrays
+✓ passes arrays with multiple needles
+✓ passes with array needles
+✓ failures
+✓ failures with multiple needles (all failing)
+✓ failures with multiple needles (some failing)
+✓ not failures
+✓ not failures with multiple needles (all failing)
+✓ not failures with multiple needles (some failing)
+PASS  Tests\Features\Expect\toContainOnlyInstancesOf
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toEndWith
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toEqual
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toEqualCanonicalizing
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toEqualWithDelta
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toHaveCount
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toHaveKey
+✓ pass
+✓ pass with nested key
+✓ pass with plain key with dots
+✓ pass with value check
+✓ pass with value check and nested key
+✓ pass with value check and plain key with dots
+✓ failures
+✓ failures with nested key
+✓ failures with plain key with dots
+✓ fails with wrong value
+✓ fails with wrong value and nested key
+✓ fails with wrong value and plain key with dots
+✓ not failures
+✓ not failures with nested key
+✓ not failures with plain key with dots
+✓ not failures with correct value
+✓ not failures with correct value and with nested key
+✓ not failures with correct value and with plain key with dots
+PASS  Tests\Features\Expect\toHaveKeys
+✓ pass
+✓ pass with multi-dimensional arrays
+✓ failures
+✓ failures with multi-dimensional arrays
+✓ not failures
+✓ not failures with multi-dimensional arrays
+PASS  Tests\Features\Expect\toHaveLength
+✓ it passes with ('Fortaleza')
+✓ it passes with ('Sollefteå')
+✓ it passes with ('Ιεράπετρα')
+✓ it passes with (stdClass Object (...))
+✓ it passes with array
+✓ it passes with *not*
+✓ it properly fails with *not*
+✓ it fails with (1)
+✓ it fails with (1.5)
+✓ it fails with (true)
+✓ it fails with (null)
+PASS  Tests\Features\Expect\toHaveProperties
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toHaveProperty
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toMatch
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toMatchArray
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toMatchConstraint
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toMatchObject
+✓ pass
+✓ pass with class
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toStartWith
+✓ pass
+✓ failures
+✓ not failures
+PASS  Tests\Features\Expect\toThrow
+✓ passes
+✓ failures 1
+✓ failures 2
+✓ failures 3
+✓ failures 4
+✓ failures 5
+✓ failures 6
+✓ failures 7
+✓ not failures
+✓ closure missing parameter
+✓ closure missing type-hint
+✓ it can handle a non-defined exception
+✓ it can handle a class not found Error
+PASS  Tests\Features\Expect\unless
+✓ it pass
+✓ it failures
+✓ it runs with truthy
+✓ it skips with falsy
+✓ it runs with truthy closure condition
+✓ it skips with falsy closure condition
+✓ it can be used in higher order tests
+PASS  Tests\Features\Expect\when
+✓ it pass
+✓ it failures
+✓ it runs with truthy
+✓ it skips with falsy
+✓ it runs with truthy closure condition
+✓ it skips with falsy closure condition
+✓ it can be used in higher order tests
+PASS  Tests\Features\Helpers
+✓ it can set/get properties on $this
+✓ it throws error if property do not exist
+✓ it allows to call underlying protected/private methods
+✓ it throws error if method do not exist
+✓ it can forward unexpected calls to any global function
+✓ it can use helpers from helpers file
+PASS  Tests\Features\HigherOrderTests
+✓ it proxies calls to object
+✓ it is capable doing multiple assertions
+✓ it resolves expect callables correctly
+✓ does not treat method names as callables
+✓ it can defer a method until after test setup
+✓ it can pass datasets into the expect callables with (1, 2, 3)
+✓ it can pass datasets into the defer callable with (1, 2, 3)
+✓ it can pass shared datasets into callables with (1)
+✓ it can pass shared datasets into callables with (2)
+WARN  Tests\Features\Incompleted
+… incompleted
+… it is incompleted
+… it is incompleted even with method calls like skip
+… it is incompleted even with method calls like group
+✓ it is not incompleted because of expect
+✓ it is not incompleted because of assert
+✓ it is not incompleted because of test with assertions
+PASS  Tests\Features\It
+✓ it is a test
+✓ it is a higher order message test
+PASS  Tests\Features\PendingHigherOrderTests
+✓ get 'foo'
+✓ get 'foo' → get 'bar' → expect true → toBeTrue
+✓ get 'foo' → expect true → toBeTrue
+WARN  Tests\Features\Skip
+✓ it do not skips
+- it skips with truthy → 1
+- it skips with truthy condition by default
+- it skips with message → skipped because bar
+- it skips with truthy closure condition
+✓ it do not skips with falsy closure condition
+- it skips with condition and message → skipped because foo
+- it skips when skip after assertion
+- it can use something in the test case as a condition → This test was skipped
+- it can user higher order callables and skip
+PASS  Tests\Features\Test
+✓ a test
+✓ higher order message test
+PASS  Tests\Features\ThrowsNoExceptions
+✓ it allows access to the underlying expectNotToPerformAssertions method
+✓ it allows performing no expectations without being risky
+PASS  Tests\Features\Todo
+↓ something todo later
+✓ it does something within a file with a todo
+PASS  Tests\Fixtures\DirectoryWithTests\ExampleTest
+✓ it example 1
+PASS  Tests\Fixtures\ExampleTest
+✓ it example 2
+PASS  Tests\Hooks\AfterAllTest
+✓ global afterAll execution order
+✓ it only gets called once per file
+PASS  Tests\Hooks\AfterEachTest
+✓ global afterEach execution order
+PASS  Tests\Hooks\BeforeAllTest
+✓ global beforeAll execution order
+✓ it only gets called once per file
+PASS  Tests\Hooks\BeforeEachTest
+✓ global beforeEach execution order
+PASS  Tests\PHPUnit\CustomAffixes\InvalidTestName
+✓ it runs file names like `@#$%^&()-_=+.php`
+PASS  Tests\PHPUnit\CustomAffixes\ATestWithSpaces
+✓ it runs file names like `A Test With Spaces.php`
+PASS  Tests\PHPUnit\CustomAffixes\AdditionalFileExtension
+✓ it runs file names like `AdditionalFileExtension.spec.php`
+PASS  Tests\PHPUnit\CustomAffixes\FolderWithAn\ExampleTest
+✓ custom traits can be used
+✓ trait applied in this file
+PASS  Tests\PHPUnit\CustomAffixes\ManyExtensions
+✓ it runs file names like `ManyExtensions.class.test.php`
+PASS  Tests\PHPUnit\CustomAffixes\TestCaseWithQuotes
+✓ it runs file names like `Test 'Case' With Quotes.php`
+PASS  Tests\PHPUnit\CustomAffixes\kebabcasespec
+✓ it runs file names like `kebab-case-spec.php`
+PASS  Tests\PHPUnit\CustomAffixes\snakecasespec
+✓ it runs file names like `snake_case_spec.php`
+PASS  Tests\PHPUnit\CustomTestCase\UsesPerDirectory
+✓ closure was bound to CustomTestCase
+PASS  Tests\PHPUnit\CustomTestCaseInSubFolders\SubFolder\SubFolder\UsesPerSubDirectory
+✓ closure was bound to CustomTestCase
+PASS  Tests\PHPUnit\CustomTestCaseInSubFolders\SubFolder2\UsesPerFile
+✓ custom traits can be used
+✓ trait applied in this file
+PASS  Tests\Playground
+✓ basic
+PASS  Tests\Plugins\Traits
+✓ it allows global uses
+✓ it allows multiple global uses registered in the same path
+WARN  Tests\Unit\ConfigLoader
+✓ it fallbacks to default path if no phpunit file is found
+- it fallbacks to default path if phpunit is not a valid XML
+- it fallbacks to default path if failing to read phpunit content
+- it fallbacks to default path if there is no test suites directory
+- it fallbacks to default path if test suite directory has no value
+- it fallbacks to default path if test suite directory does not exist
+- it returns the parent folder of first test suite directory
+PASS  Tests\Unit\Console\Help
+✓ it outputs the help information when --help is used
+PASS  Tests\Unit\Datasets
+✓ it show only the names of named datasets in their description
+✓ it show the actual dataset of non-named datasets in their description
+✓ it show only the names of multiple named datasets in their description
+✓ it show the actual dataset of multiple non-named datasets in their description
+✓ it show the correct description for mixed named and not-named datasets
+PASS  Tests\Unit\Plugins\Environment
+✓ environment is set to CI when --ci option is used
+✓ environment is set to Local when --ci option is not used
+PASS  Tests\Unit\Plugins\Retry
+✓ it retries if --retry argument is used
+PASS  Tests\Unit\Support\Backtrace
+✓ it gets file name from called file
+PASS  Tests\Unit\Support\Container
+✓ it exists
+✓ it gets an instance
+✓ autowire
+✓ it creates an instance and resolves parameters
+✓ it creates an instance and resolves also sub parameters
+✓ it can resolve builtin value types
+✓ it cannot resolve a parameter without type
+PASS  Tests\Unit\Support\Reflection
+✓ it gets file name from closure
+✓ it gets property values
+PASS  Tests\Unit\TestSuite
+✓ it does not allow to add the same test description twice
+✓ it alerts users about tests with arguments but no input
+✓ it can return an array of all test suite filenames
+✓ it can filter the test suite filenames to those with the only method
+✓ it does not filter the test suite filenames to those with the only method when working in CI pipeline
+PASS  Tests\Visual\Help
+✓ visual snapshot of help command output
+WARN  Tests\Visual\JUnit
+- it is can successfully call all public methods → Not supported yet.
+PASS  Tests\Visual\SingleTestOrDirectory
+✓ allows to run a single test
+✓ allows to run a directory
+✓ it disable decorating printer when colors is set to never
+WARN  Tests\Visual\Success
+- visual snapshot of test suite on success
+WARN  Tests\Visual\TeamCity
+- it is can successfully call all public methods → Not supported yet.
+PASS  Tests\Visual\Version
+✓ visual snapshot of help command output

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -220,30 +220,37 @@ PASS  Tests\Features\Expect\sequence
 PASS  Tests\Features\Expect\toBe
 ✓ strict comparisons
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeArray
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeBool
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeCallable
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeDirectory
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeEmpty
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeFalse
 ✓ strict comparisons
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeFalsy
 ✓ passes as falsy with (false)
@@ -257,94 +264,117 @@ PASS  Tests\Features\Expect\toBeFalsy
 ✓ passes as not falsy with (1) #2
 ✓ passes as not falsy with (-1)
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeFile
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeFloat
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeGreatherThan
 ✓ passes
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeGreatherThanOrEqual
 ✓ passes
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeIn
 ✓ passes
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeInfinite
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeInstanceOf
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeInt
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeIterable
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeJson
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeLessThan
 ✓ passes
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeLessThanOrEqual
 ✓ passes
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeNAN
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeNull
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeNumeric
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeObject
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeReadableDirectory
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeReadableFile
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeResource
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeScalar
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeString
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeTrue
 ✓ strict comparisons
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeTruthy
 ✓ passes as truthy with (true)
@@ -358,14 +388,17 @@ PASS  Tests\Features\Expect\toBeTruthy
 ✓ passes as not truthy with (0)
 ✓ passes as not truthy with ('0')
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeWritableDirectory
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toBeWritableFile
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toContain
 ✓ passes strings
@@ -382,26 +415,31 @@ PASS  Tests\Features\Expect\toContain
 PASS  Tests\Features\Expect\toContainOnlyInstancesOf
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toEndWith
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toEqual
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toEqualCanonicalizing
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toEqualWithDelta
 ✓ pass
-✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toHaveCount
 ✓ pass
 ✓ failures
+✓ failures with message
 ✓ not failures
 PASS  Tests\Features\Expect\toHaveKey
 ✓ pass
@@ -411,7 +449,9 @@ PASS  Tests\Features\Expect\toHaveKey
 ✓ pass with value check and nested key
 ✓ pass with value check and plain key with dots
 ✓ failures
+✓ failures with custom message
 ✓ failures with nested key
+✓ failures with nested key and custom message
 ✓ failures with plain key with dots
 ✓ fails with wrong value
 ✓ fails with wrong value and nested key
@@ -426,7 +466,9 @@ PASS  Tests\Features\Expect\toHaveKeys
 ✓ pass
 ✓ pass with multi-dimensional arrays
 ✓ failures
+✓ failures with custom message
 ✓ failures with multi-dimensional arrays
+✓ failures with multi-dimensional arrays and custom message
 ✓ not failures
 ✓ not failures with multi-dimensional arrays
 PASS  Tests\Features\Expect\toHaveLength
@@ -437,38 +479,43 @@ PASS  Tests\Features\Expect\toHaveLength
 ✓ it passes with array
 ✓ it passes with *not*
 ✓ it properly fails with *not*
-✓ it fails with (1)
-✓ it fails with (1.5)
-✓ it fails with (true)
-✓ it fails with (null)
+✓ it fails
+✓ it fails with message
 PASS  Tests\Features\Expect\toHaveProperties
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toHaveProperty
 ✓ pass
 ✓ failures
+✓ failures with message
 ✓ not failures
 PASS  Tests\Features\Expect\toMatch
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toMatchArray
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toMatchConstraint
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toMatchObject
 ✓ pass
 ✓ pass with class
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toStartWith
 ✓ pass
 ✓ failures
+✓ failures with custom message
 ✓ not failures
 PASS  Tests\Features\Expect\toThrow
 ✓ passes
@@ -479,6 +526,7 @@ PASS  Tests\Features\Expect\toThrow
 ✓ failures 5
 ✓ failures 6
 ✓ failures 7
+✓ failures with custom message
 ✓ not failures
 ✓ closure missing parameter
 ✓ closure missing type-hint

--- a/tests/Features/Expect/toBe.php
+++ b/tests/Features/Expect/toBe.php
@@ -15,6 +15,10 @@ test('failures', function () {
     expect(1)->toBe(2);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(1)->toBe(2, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(1)->not->toBe(1);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeArray.php
+++ b/tests/Features/Expect/toBeArray.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(null)->toBeArray();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeArray('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(['a', 'b', 'c'])->not->toBeArray();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeBool.php
+++ b/tests/Features/Expect/toBeBool.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(null)->toBeBool();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeBool('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(false)->not->toBeBool();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeCallable.php
+++ b/tests/Features/Expect/toBeCallable.php
@@ -14,6 +14,12 @@ test('failures', function () {
     expect($hello)->toBeCallable();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    $hello = 5;
+
+    expect($hello)->toBeCallable('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(function () {
         return 42;

--- a/tests/Features/Expect/toBeDirectory.php
+++ b/tests/Features/Expect/toBeDirectory.php
@@ -12,6 +12,10 @@ test('failures', function () {
     expect('/random/path/whatever')->toBeDirectory();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever')->toBeDirectory('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('.')->not->toBeDirectory();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeEmpty.php
+++ b/tests/Features/Expect/toBeEmpty.php
@@ -12,6 +12,11 @@ test('failures', function () {
     expect(' ')->toBeEmpty();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect([1, 2])->toBeEmpty('oh no!');
+    expect(' ')->toBeEmpty('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect([])->not->toBeEmpty();
     expect(null)->not->toBeEmpty();

--- a/tests/Features/Expect/toBeFalse.php
+++ b/tests/Features/Expect/toBeFalse.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('')->toBeFalse();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('')->toBeFalse('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(false)->not->toBe(false);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeFalsy.php
+++ b/tests/Features/Expect/toBeFalsy.php
@@ -14,6 +14,10 @@ test('failures', function () {
     expect(1)->toBeFalsy();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(1)->toBeFalsy('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(null)->not->toBeFalsy();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeFile.php
+++ b/tests/Features/Expect/toBeFile.php
@@ -18,6 +18,10 @@ test('failures', function () {
     expect('/random/path/whatever.file')->toBeFile();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever.file')->toBeFile('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->tempFile)->not->toBeFile();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeFloat.php
+++ b/tests/Features/Expect/toBeFloat.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(42)->toBeFloat();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(42)->toBeFloat('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(log(3))->not->toBeFloat();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeGreatherThan.php
+++ b/tests/Features/Expect/toBeGreatherThan.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(4)->toBeGreaterThan(4);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(4)->toBeGreaterThan(4, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(5)->not->toBeGreaterThan(4);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeGreatherThanOrEqual.php
+++ b/tests/Features/Expect/toBeGreatherThanOrEqual.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(4)->toBeGreaterThanOrEqual(4.1);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(4)->toBeGreaterThanOrEqual(4.1, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(5)->not->toBeGreaterThanOrEqual(5);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeIn.php
+++ b/tests/Features/Expect/toBeIn.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect('d')->toBeIn(['a', 'b', 'c']);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('d')->toBeIn(['a', 'b', 'c'], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('a')->not->toBeIn(['a', 'b', 'c']);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeInfinite.php
+++ b/tests/Features/Expect/toBeInfinite.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(asin(2))->toBeInfinite();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(asin(2))->toBeInfinite('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(INF)->not->toBeInfinite();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeInstanceOf.php
+++ b/tests/Features/Expect/toBeInstanceOf.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(new Exception())->toBeInstanceOf(RuntimeException::class);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(new Exception())->toBeInstanceOf(RuntimeException::class, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(new Exception())->not->toBeInstanceOf(Exception::class);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeInt.php
+++ b/tests/Features/Expect/toBeInt.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(42.0)->toBeInt();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(42.0)->toBeInt('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(6 * 7)->not->toBeInt();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeIterable.php
+++ b/tests/Features/Expect/toBeIterable.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(42)->toBeIterable();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(42)->toBeIterable('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     function gen(): iterable
     {

--- a/tests/Features/Expect/toBeJson.php
+++ b/tests/Features/Expect/toBeJson.php
@@ -12,6 +12,10 @@ test('failures', function () {
     expect(':"world"}')->toBeJson();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(':"world"}')->toBeJson('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('{"hello":"world"}')->not->toBeJson();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThan.php
+++ b/tests/Features/Expect/toBeLessThan.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(4)->toBeLessThan(4);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(4)->toBeLessThan(4, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(5)->not->toBeLessThan(6);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThanOrEqual.php
+++ b/tests/Features/Expect/toBeLessThanOrEqual.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(4)->toBeLessThanOrEqual(3.9);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(4)->toBeLessThanOrEqual(3.9, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(5)->not->toBeLessThanOrEqual(5);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeNAN.php
+++ b/tests/Features/Expect/toBeNAN.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(1)->toBeNan();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(1)->toBeNan('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(acos(1.5))->not->toBeNan();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeNull.php
+++ b/tests/Features/Expect/toBeNull.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect('hello')->toBeNull();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('hello')->toBeNull('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(null)->not->toBeNull();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeNumeric.php
+++ b/tests/Features/Expect/toBeNumeric.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(null)->toBeNumeric();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeNumeric('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(6 * 7)->not->toBeNumeric();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeObject.php
+++ b/tests/Features/Expect/toBeObject.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(null)->toBeObject();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeObject('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect((object) 'ciao')->not->toBeObject();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeReadableDirectory.php
+++ b/tests/Features/Expect/toBeReadableDirectory.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('/random/path/whatever')->toBeReadableDirectory();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever')->toBeReadableDirectory('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(sys_get_temp_dir())->not->toBeReadableDirectory();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeReadableFile.php
+++ b/tests/Features/Expect/toBeReadableFile.php
@@ -18,6 +18,10 @@ test('failures', function () {
     expect('/random/path/whatever.file')->toBeReadableFile();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever.file')->toBeReadableFile('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->tempFile)->not->toBeReadableFile();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeResource.php
+++ b/tests/Features/Expect/toBeResource.php
@@ -17,6 +17,10 @@ test('failures', function () {
     expect(null)->toBeResource();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeResource('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () use ($resource) {
     expect($resource)->not->toBeResource();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeScalar.php
+++ b/tests/Features/Expect/toBeScalar.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect(null)->toBeScalar();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeScalar('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(42)->not->toBeScalar();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeString.php
+++ b/tests/Features/Expect/toBeString.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(null)->toBeString();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeString('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('42')->not->toBeString();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeTrue.php
+++ b/tests/Features/Expect/toBeTrue.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('')->toBeTrue();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('')->toBeTrue('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(false)->not->toBe(false);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeTruthy.php
+++ b/tests/Features/Expect/toBeTruthy.php
@@ -14,6 +14,10 @@ test('failures', function () {
     expect(null)->toBeTruthy();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(null)->toBeTruthy('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(1)->not->toBeTruthy();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeWritableDirectory.php
+++ b/tests/Features/Expect/toBeWritableDirectory.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('/random/path/whatever')->toBeWritableDirectory();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever')->toBeWritableDirectory('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(sys_get_temp_dir())->not->toBeWritableDirectory();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeWritableFile.php
+++ b/tests/Features/Expect/toBeWritableFile.php
@@ -18,6 +18,10 @@ test('failures', function () {
     expect('/random/path/whatever.file')->toBeWritableFile();
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('/random/path/whatever.file')->toBeWritableFile('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->tempFile)->not->toBeWritableFile();
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainOnlyInstancesOf.php
+++ b/tests/Features/Expect/toContainOnlyInstancesOf.php
@@ -15,6 +15,10 @@ test('failures', function () {
     expect($this->times)->toContainOnlyInstancesOf(DateTime::class);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect($this->times)->toContainOnlyInstancesOf(DateTime::class, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->times)->not->toContainOnlyInstancesOf(DateTimeImmutable::class);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEndWith.php
+++ b/tests/Features/Expect/toEndWith.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('username')->toEndWith('password');
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('username')->toEndWith('password', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('username')->not->toEndWith('name');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEqual.php
+++ b/tests/Features/Expect/toEqual.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect(['a', 'b', 'c'])->toEqual(['a', 'b']);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(['a', 'b', 'c'])->toEqual(['a', 'b'], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('042')->not->toEqual(42);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEqualCanonicalizing.php
+++ b/tests/Features/Expect/toEqualCanonicalizing.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect([3, 2, 1])->toEqualCanonicalizing([1, 2]);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect([3, 2, 1])->toEqualCanonicalizing([1, 2], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(['a', 'b', 'c'])->not->toEqualCanonicalizing(['b', 'a', 'c']);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEqualWithDelta.php
+++ b/tests/Features/Expect/toEqualWithDelta.php
@@ -6,9 +6,9 @@ test('pass', function () {
     expect(1.0)->toEqualWithDelta(1.3, .4);
 });
 
-test('failures', function () {
-    expect(1.0)->toEqualWithDelta(1.5, .1);
-})->throws(ExpectationFailedException::class);
+test('failures with custom message', function () {
+    expect(1.0)->toEqualWithDelta(1.5, .1, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
 
 test('not failures', function () {
     expect(1.0)->not->toEqualWithDelta(1.6, .7);

--- a/tests/Features/Expect/toHaveCount.php
+++ b/tests/Features/Expect/toHaveCount.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect([1, 2, 3])->toHaveCount(4);
 })->throws(ExpectationFailedException::class);
 
+test('failures with message', function () {
+    expect([1, 2, 3])->toHaveCount(4, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect([1, 2, 3])->not->toHaveCount(3);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveKey.php
+++ b/tests/Features/Expect/toHaveKey.php
@@ -24,9 +24,17 @@ test('failures', function () use ($test_array) {
     expect($test_array)->toHaveKey('foo');
 })->throws(ExpectationFailedException::class, "Failed asserting that an array has the key 'foo'");
 
+test('failures with custom message', function () use ($test_array) {
+    expect($test_array)->toHaveKey('foo', message: 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('failures with nested key', function () use ($test_array) {
     expect($test_array)->toHaveKey('d.bar');
 })->throws(ExpectationFailedException::class, "Failed asserting that an array has the key 'd.bar'");
+
+test('failures with nested key and custom message', function () use ($test_array) {
+    expect($test_array)->toHaveKey('d.bar', message: 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
 
 test('failures with plain key with dots', function () use ($test_array) {
     expect($test_array)->toHaveKey('missing.key.with.dots');

--- a/tests/Features/Expect/toHaveKeys.php
+++ b/tests/Features/Expect/toHaveKeys.php
@@ -14,9 +14,17 @@ test('failures', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'd', 'foo.bar', 'hello.world']);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'd', 'foo.bar', 'hello.world'], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('failures with multi-dimensional arrays', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => ['bir' => 'biz']]])->toHaveKeys(['a', 'd', 'foo' => ['bar' => 'bir'], 'hello.world']);
 })->throws(ExpectationFailedException::class);
+
+test('failures with multi-dimensional arrays and custom message', function () {
+    expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => ['bir' => 'biz']]])->toHaveKeys(['a', 'd', 'foo' => ['bar' => 'bir'], 'hello.world'], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
 
 test('not failures', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->not->toHaveKeys(['foo.bar', 'c', 'z']);

--- a/tests/Features/Expect/toHaveLength.php
+++ b/tests/Features/Expect/toHaveLength.php
@@ -20,9 +20,13 @@ it('passes with *not*', function () {
 });
 
 it('properly fails with *not*', function () {
-    expect('pest')->not->toHaveLength(4);
+    expect('pest')->not->toHaveLength(4, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+it('fails', function () {
+    expect([1, 1.5, true, null])->toHaveLength(1);
 })->throws(ExpectationFailedException::class);
 
-it('fails', function ($value) {
-    expect($value)->toHaveLength(1);
-})->with([1, 1.5, true, null])->throws(BadMethodCallException::class);
+it('fails with message', function () {
+    expect([1, 1.5, true, null])->toHaveLength(1, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');

--- a/tests/Features/Expect/toHaveProperties.php
+++ b/tests/Features/Expect/toHaveProperties.php
@@ -17,6 +17,13 @@ test('failures', function () {
     expect($object)->toHaveProperties(['name', 'age']);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    $object = new stdClass();
+    $object->name = 'Jhon';
+
+    expect($object)->toHaveProperties(['name', 'age'], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     $object = new stdClass();
     $object->name = 'Jhon';

--- a/tests/Features/Expect/toHaveProperty.php
+++ b/tests/Features/Expect/toHaveProperty.php
@@ -17,6 +17,10 @@ test('failures', function () use ($obj) {
     expect($obj)->toHaveProperty('bar');
 })->throws(ExpectationFailedException::class);
 
+test('failures with message', function () use ($obj) {
+    expect($obj)->toHaveProperty(name: 'bar', message: 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () use ($obj) {
     expect($obj)->not->toHaveProperty('foo');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toMatch.php
+++ b/tests/Features/Expect/toMatch.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('Hello World')->toMatch('/^hello$/i');
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('Hello World')->toMatch('/^hello$/i', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('Hello World')->not->toMatch('/^hello wo.*$/i');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toMatchArray.php
+++ b/tests/Features/Expect/toMatchArray.php
@@ -24,6 +24,13 @@ test('failures', function () {
     ]);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect($this->user)->toMatchArray([
+        'name' => 'Not the same name',
+        'email' => 'enunomaduro@gmail.com',
+    ], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->user)->not->toMatchArray([
         'id' => 1,

--- a/tests/Features/Expect/toMatchConstraint.php
+++ b/tests/Features/Expect/toMatchConstraint.php
@@ -11,6 +11,10 @@ test('failures', function () {
     expect(false)->toMatchConstraint(new IsTrue());
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(false)->toMatchConstraint(new IsTrue(), 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(true)->not->toMatchConstraint(new IsTrue());
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toMatchObject.php
+++ b/tests/Features/Expect/toMatchObject.php
@@ -36,6 +36,13 @@ test('failures', function () {
     ]);
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect($this->user)->toMatchObject([
+        'name' => 'Not the same name',
+        'email' => 'enunomaduro@gmail.com',
+    ], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect($this->user)->not->toMatchObject([
         'id' => 1,

--- a/tests/Features/Expect/toStartWith.php
+++ b/tests/Features/Expect/toStartWith.php
@@ -10,6 +10,10 @@ test('failures', function () {
     expect('username')->toStartWith('password');
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect('username')->toStartWith('password', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect('username')->not->toStartWith('user');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toThrow.php
+++ b/tests/Features/Expect/toThrow.php
@@ -79,6 +79,12 @@ test('failures 7', function () {
     })->toThrow(RuntimeException::class, 'expected message');
 })->throws(ExpectationFailedException::class);
 
+test('failures with custom message', function () {
+    expect(function () {
+        throw new RuntimeException('actual message');
+    })->toThrow(RuntimeException::class, 'expected message', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
 test('not failures', function () {
     expect(function () {
         throw new RuntimeException();

--- a/tests/Visual/Success.php
+++ b/tests/Visual/Success.php
@@ -26,17 +26,17 @@ test('visual snapshot of test suite on success', function () {
         ], $process->getOutput());
     };
 
+    $outputContent = explode("\n", $output());
+    $outputContent = array_map(fn (string $line) => trim($line), $outputContent);
+    $outputContent = array_filter($outputContent, fn (string $line) => $line !== '');
+
+    array_pop($outputContent);
+    array_pop($outputContent);
+
     if (getenv('REBUILD_SNAPSHOTS')) {
-        // Strip time from end of snapshot
-        $outputContent = preg_replace('/Time\: \s+\d+\.\d+s\s+/m', '', $output());
-
-        file_put_contents($snapshot, $outputContent);
+        file_put_contents($snapshot, implode("\n", $outputContent));
     } elseif (! getenv('EXCLUDE')) {
-        $output = explode("\n", $output());
-        array_pop($output);
-        array_pop($output);
-
-        expect(implode("\n", $output))->toContain(file_get_contents($snapshot));
+        expect(implode("\n", $outputContent))->toBe(file_get_contents($snapshot));
     }
 })->skip(! getenv('REBUILD_SNAPSHOTS') && getenv('EXCLUDE'))
     ->skip(PHP_OS_FAMILY === 'Windows');


### PR DESCRIPTION
This PR will implement custom messages for expectation failures

a trailing optional `message` parameter has been added to all expectations, in order to let the user to set a custom error message like this one:

```php
 expect($obj)->toHaveProperty(name: 'bar', message: 'oh no!');
```

**note**

1. couldn't add the custom message to the `toContain()` expectation, as it is the only expectation to have variadic parameters the trailing `$message`  is not allowed.

2. fixed a bug in expectation pipelines, they didn't handle named parameters in expectations

3. cleaned up success snapshot 