### PR TITLE
[2.x] Fix tests when coverage is not available

### DIFF
--- a/tests/Features/Coverage.php
+++ b/tests/Features/Coverage.php
@@ -17,7 +17,7 @@ it('adds coverage if --coverage exist', function () {
     $arguments = $plugin->handleArguments(['--coverage']);
     expect($arguments)->toEqual(['--coverage-php', Coverage::getPath()])
         ->and($plugin->coverage)->toBeTrue();
-})->skip(! \Pest\Support\Coverage::isAvailable() || ! in_array('coverage', xdebug_info('mode'), true), 'Coverage is not available');
+})->skip(! \Pest\Support\Coverage::isAvailable() || ! function_exists('xdebug_info') || ! in_array('coverage', xdebug_info('mode'), true), 'Coverage is not available');
 
 it('adds coverage if --min exist', function () {
     $plugin = new CoveragePlugin(new ConsoleOutput());


### PR DESCRIPTION
This PR will skip coverage test when `xdebug_info` function is not available

this will avoid an exception when tests are started:

![image](https://user-images.githubusercontent.com/8792274/190962803-16352a76-e8a6-4676-9dd8-c5126a3f953a.png)
