### PR TITLE
[2.x] Fix lint composer command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "bin/pest"
     ],
     "scripts": {
-        "lint": "pint --test",
+        "lint": "pint",
         "test:lint": "pint --test",
         "test:types": "phpstan analyse --ansi --memory-limit=-1 --debug",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration --compact",


### PR DESCRIPTION
this will remove `--test` option from `composer lint` script
