### PR TITLE
[2.x] Fix Backtrace cross-plataform compatibility

### DIFF
--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -28,7 +28,9 @@ final class Backtrace
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
             assert(array_key_exists(self::FILE, $trace));
 
-            if (Str::endsWith($trace[self::FILE], 'overrides/Runner/TestSuiteLoader.php')) {
+            $traceFile = str_replace(DIRECTORY_SEPARATOR, '/', $trace[self::FILE]);
+
+            if (Str::endsWith($traceFile, 'overrides/Runner/TestSuiteLoader.php')) {
                 break;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | 

This PR fixes tests not running in Windows OS.

The Windows directory format `C:\Users\dansysanalyst\projects\pest\overrides\Runner\TestSuiteLoader.php` is incompatible with:

```php
if (Str::endsWith($trace[self::FILE], 'overrides/Runner/TestSuiteLoader.php')) {
    break;
}
``` 

This results in `Pest\Factories\TestCaseMethodFactory` having: 

```php
    ["filename"]=> string(35) "C:\Users\dansysanalyst\projects\pest\bin\pest"
```

instead of:

```php
["filename"]=> string(51) "4) "C:\Users\dansysanalyst\projects\pest\tests\Features\AfterAll.php"
```

Leading to the exception:

```
   Pest\Exceptions\TestAlreadyExist

  A test with the description `it works with higher order tests` already exist in the filename `C:\Users\dansysanalyst\projects\pest\bin\pest`.
``` 