### PR TITLE
[2.x] Add the ability to publish and use test stubs

### DIFF
--- a/src/Laravel/Commands/PestPublishCommand.php
+++ b/src/Laravel/Commands/PestPublishCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+/**
+ * @internal
+ */
+final class PestPublishCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'pest:publish
+                    {--existing : Publish and overwrite only the files that have already been published}
+                    {--force : Overwrite any existing files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish Pest test stubs';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (!File::isDirectory($stubsPath = $this->laravel->basePath('stubs'))) {
+            File::makeDirectory($stubsPath, 0777, true, true);
+        }
+
+        // pest.stub and pest.unit.stub are compatible with `make:test --pest`
+        $files = [
+            realpath(__DIR__ . '/../../../stubs/Feature.php') => $stubsPath . '/pest.stub',
+            realpath(__DIR__ . '/../../../stubs/Unit.php')    => $stubsPath . '/pest.unit.stub',
+            realpath(__DIR__ . '/../../../stubs/Browser.php') => $stubsPath . '/pest.browser.stub',
+        ];
+
+        foreach ($files as $from => $to) {
+            if ((!(bool) $this->option('existing') && (!File::exists($to) || (bool) $this->option('force')))
+                || ((bool) $this->option('existing') && File::exists($to))) {
+                File::put($to, File::get((string) $from));
+            }
+        }
+
+        $this->output->success('Test stubs published successfully');
+    }
+}

--- a/src/Laravel/Commands/PestTestCommand.php
+++ b/src/Laravel/Commands/PestTestCommand.php
@@ -62,11 +62,20 @@ final class PestTestCommand extends Command
             throw new InvalidConsoleArgument(sprintf('%s already exist', $target));
         }
 
-        $contents = File::get(implode(DIRECTORY_SEPARATOR, [
+        $stubPath = implode(DIRECTORY_SEPARATOR, [
             dirname(__DIR__, 3),
             'stubs',
             sprintf('%s.php', $type),
-        ]));
+        ]);
+
+        // pest.stub and pest.unit.stub are compatible with `make:test --pest`
+        $stubOverrideFilename = 'pest' . ($type != 'Feature' ? '.' . strtolower($type) : '') . '.stub';
+        /* @phpstan-ignore-next-line */
+        $stubPath             = file_exists($stubOverridePath = base_path() . '/stubs/' . $stubOverrideFilename)
+            ? $stubOverridePath
+            : $stubPath;
+
+        $contents = File::get($stubPath);
 
         $name = mb_strtolower($name);
         $name = Str::endsWith($name, 'test') ? mb_substr($name, 0, -4) : $name;

--- a/src/Laravel/PestServiceProvider.php
+++ b/src/Laravel/PestServiceProvider.php
@@ -9,6 +9,7 @@ use Laravel\Dusk\Console\DuskCommand;
 use Pest\Laravel\Commands\PestDatasetCommand;
 use Pest\Laravel\Commands\PestDuskCommand;
 use Pest\Laravel\Commands\PestInstallCommand;
+use Pest\Laravel\Commands\PestPublishCommand;
 use Pest\Laravel\Commands\PestTestCommand;
 
 final class PestServiceProvider extends ServiceProvider
@@ -23,6 +24,7 @@ final class PestServiceProvider extends ServiceProvider
                 PestInstallCommand::class,
                 PestTestCommand::class,
                 PestDatasetCommand::class,
+                PestPublishCommand::class,
             ]);
 
             if (class_exists(DuskCommand::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

- Allow for feature, unit and browser test stubs to be publish to /stubs in a Laravel project
- When any of these stubs exist, use them for creating new test with `pest:test`
- Achieve compatibility with stubs used from calls to `make:test`