### PR TITLE
chore: narrow types for `it()` and `test()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: src/Factories/TestCaseFactory.php
 
 		-
-			message: "#^Function it\\(\\) should return Pest\\\\PendingObjects\\\\TestCall but returns mixed\\.$#"
-			count: 1
-			path: src/Functions.php
-
-		-
 			message: "#^Parameter \\#2 \\$classAndTraits of class Pest\\\\PendingObjects\\\\UsesCall constructor expects array\\<int, string\\>, array\\<int\\|string, string\\> given\\.$#"
 			count: 1
 			path: src/Functions.php
@@ -247,16 +242,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Support/ExceptionTrace.php
-
-		-
-			message: "#^Cannot access offset 'file' on mixed\\.$#"
-			count: 1
-			path: src/Support/ExceptionTrace.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, mixed given\\.$#"
 			count: 1
 			path: src/Support/ExceptionTrace.php
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -86,6 +86,7 @@ if (!function_exists('test')) {
      * a closure that contains the test expectations.
      *
      * @return TestCall|TestCase|mixed
+     *
      * @phpstan-return ($description is null ? TestCase|mixed : TestCall)
      */
     function test(string $description = null, Closure $closure = null)
@@ -105,8 +106,6 @@ if (!function_exists('it')) {
      * Adds the given closure as a test. The first argument
      * is the test description; the second argument is
      * a closure that contains the test expectations.
-     *
-     * @return TestCall
      */
     function it(string $description, Closure $closure = null): TestCall
     {

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -86,6 +86,7 @@ if (!function_exists('test')) {
      * a closure that contains the test expectations.
      *
      * @return TestCall|TestCase|mixed
+     * @phpstan-return ($description is null ? TestCase|mixed : TestCall)
      */
     function test(string $description = null, Closure $closure = null)
     {
@@ -105,7 +106,7 @@ if (!function_exists('it')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
-     * @return TestCall|TestCase|mixed
+     * @return TestCall
      */
     function it(string $description, Closure $closure = null): TestCall
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

Because `it()` sets a description, it will always return `TestCall`. This also adds a conditional PHPStan return type for `test()` as we can work out what it returns based on this. 👍🏻