### PR TITLE
[2.x] chore: narrow types for `it()` and `test()`

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -86,6 +86,8 @@ if (! function_exists('test')) {
      * a closure that contains the test expectations.
      *
      * @return TestCall|TestCase|mixed
+     *
+     * @phpstan-return ($description is null ? TestCase|mixed : TestCall)
      */
     function test(string $description = null, Closure $closure = null)
     {
@@ -105,16 +107,13 @@ if (! function_exists('it')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
-     * @return TestCall|TestCase|mixed
+     * @return TestCall
      */
     function it(string $description, Closure $closure = null): TestCall
     {
         $description = sprintf('it %s', $description);
 
-        /** @var TestCall $test */
-        $test = test($description, $closure);
-
-        return $test;
+        return test($description, $closure);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

Because `it()` sets a description, it will always return `TestCall`. This also adds a conditional PHPStan return type for `test()` as we can work out what it returns based on this. 👍🏻

Original PR for 1.x: https://github.com/pestphp/pest/pull/599