### PR TITLE
[1.x] Fix storing of lazy datasets into internal array

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -122,7 +122,7 @@ final class Datasets
             }
 
             if ($datasets[$index] instanceof Traversable) {
-                $datasets[$index] = iterator_to_array($datasets[$index]);
+                $datasets[$index] = iterator_to_array($datasets[$index], false);
             }
 
             foreach ($datasets[$index] as $key => $values) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -96,6 +96,11 @@
   ✓ more than two datasets with (2) / (4) / (5)
   ✓ more than two datasets with (2) / (4) / (6)
   ✓ more than two datasets did the job right
+  ✓ eager registered wrapped datasets with Generator functions with (1)
+  ✓ eager registered wrapped datasets with Generator functions with (2)
+  ✓ eager registered wrapped datasets with Generator functions with (3)
+  ✓ eager registered wrapped datasets with Generator functions with (4)
+  ✓ eager registered wrapped datasets with Generator functions did the job right
   ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
   ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
   ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
@@ -722,5 +727,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 480 passed
+  Tests:  4 incompleted, 9 skipped, 485 passed
   

--- a/tests/Datasets/Numbers.php
+++ b/tests/Datasets/Numbers.php
@@ -13,3 +13,20 @@ dataset('numbers.closure.wrapped', function () {
 dataset('numbers.array', [[1], [2]]);
 
 dataset('numbers.array.wrapped', [1, 2]);
+
+dataset('numbers.generators.wrapped', function () {
+    yield from firstSetOfNumber();
+    yield from secondSetOfNumbers();
+});
+
+function firstSetOfNumber(): Generator
+{
+    yield 1;
+    yield 2;
+}
+
+function secondSetOfNumbers(): Generator
+{
+    yield 3;
+    yield 4;
+}

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -228,10 +228,31 @@ test('more than two datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('121212121212131423241314232411122122111221221112212213142324135136145146235236245246');
 });
 
+$wrapped_generator_state             = new stdClass();
+$wrapped_generator_state->text       = '';
+$wrapped_generator_function_datasets = [1, 2, 3, 4];
+
+test(
+    'eager registered wrapped datasets with Generator functions',
+    function (int $text) use (
+        $wrapped_generator_state,
+        $wrapped_generator_function_datasets
+    ) {
+        $wrapped_generator_state->text .= $text;
+        expect(in_array($text, $wrapped_generator_function_datasets))->toBe(true);
+    }
+)->with('numbers.generators.wrapped');
+
+test('eager registered wrapped datasets with Generator functions did the job right', function () use ($wrapped_generator_state) {
+    expect($wrapped_generator_state->text)->toBe('1234');
+});
+
 it('can resolve a dataset after the test case is available', function ($result) {
     expect($result)->toBe('bar');
 })->with([
-    function () { return $this->foo; },
+    function () {
+        return $this->foo;
+    },
 ]);
 
 it('can resolve a dataset after the test case is available with shared yield sets', function ($result) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #.

## Description

I was refactoring a large PHPUnit test suit (https://github.com/spatie/laravel-data/pull/239) into Pest and I observed that there was a large dataset that was organized like this, with other functions.

```php
public function attributesDataProvider(): Generator
{
   
    yield from $this->acceptedIfAttributesDataProvider();
    yield from $this->afterAttributesDataProvider();
    yield from $this->afterOrEqualAttributesDataProvider();
    yield from $this->arrayTypeAttributesDataProvider();

   // other Generator methods

```

I thought that was nice and I tried to refactor into Pest's dataset and it looked like this.

```php
dataset('attributes', function() {
    yield from acceptedIfAttributes();
    yield from afterAttributes();
    yield from afterOrEqualAttributes();
    yield from arrayTypeAttributes();

   // other Generator functions

});

function acceptedIfAttributes(): Generator {
    // ...
}

// ... 

```
I ran the tests and observed that the generator functions' datasets didn't run.

I saw that the issue was on storing the datasets into an array using the function `iterator_to_array`. The issue is that when the generator is converting to an array it does not have different array keys for other generator functions from inside of the main Generator function.

https://github.com/pestphp/pest/blob/3c766c15d56c4ff0b03c000c117f16c9ecb57692/src/Datasets.php#L125

I fixed this by changing the `use_keys` parameter to false. In this way, the generator will use different keys for other Generator functions from the inside of the function. Example:

```php
<?php
function inner() {
    yield 1; // key 0
    yield 2; // key 1
    yield 3; // key 2
}
function gen() {
    yield 0; // key 0
    yield from inner(); // keys 0-2
    yield 4; // key 1
}

var_dump(iterator_to_array(gen())); // 1 4 3
var_dump(iterator_to_array(gen(), false)); // 0 1 2 3 4
``` 

More details: https://www.php.net/manual/en/language.generators.syntax.php
