### PR TITLE
[1.x] Fixes ignored dataset description only for string description

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest;
 
 use Closure;
+use Generator;
 use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
 use SebastianBergmann\Exporter\Exporter;
@@ -122,7 +123,10 @@ final class Datasets
             }
 
             if ($datasets[$index] instanceof Traversable) {
-                $datasets[$index] = iterator_to_array($datasets[$index], false);
+                $preserveKeysForArrayIterator = $datasets[$index] instanceof Generator
+                    && is_string($datasets[$index]->key());
+
+                $datasets[$index] = iterator_to_array($datasets[$index], $preserveKeysForArrayIterator);
             }
 
             foreach ($datasets[$index] as $key => $values) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -101,6 +101,8 @@
   ✓ eager registered wrapped datasets with Generator functions with (3)
   ✓ eager registered wrapped datasets with Generator functions with (4)
   ✓ eager registered wrapped datasets with Generator functions did the job right
+  ✓ eager registered wrapped datasets with Generator functions display description with data set "taylor"
+  ✓ eager registered wrapped datasets with Generator functions display description with data set "james"
   ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
   ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
   ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
@@ -727,5 +729,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 485 passed
+  Tests:  4 incompleted, 9 skipped, 487 passed
   

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -250,8 +250,8 @@ test('eager registered wrapped datasets with Generator functions did the job rig
 test('eager registered wrapped datasets with Generator functions display description', function ($wrapped_generator_state_with_description) {
     expect($wrapped_generator_state_with_description)->not->toBeEmpty();
 })->with(function () {
-    yield 'taylor' => 'foo@bar.com';
-    yield 'james' => 'bar@foo.com';
+    yield 'taylor' => 'taylor@laravel.com';
+    yield 'james' => 'james@laravel.com';
 });
 
 it('can resolve a dataset after the test case is available', function ($result) {

--- a/tests/Features/Datasets.php
+++ b/tests/Features/Datasets.php
@@ -247,6 +247,13 @@ test('eager registered wrapped datasets with Generator functions did the job rig
     expect($wrapped_generator_state->text)->toBe('1234');
 });
 
+test('eager registered wrapped datasets with Generator functions display description', function ($wrapped_generator_state_with_description) {
+    expect($wrapped_generator_state_with_description)->not->toBeEmpty();
+})->with(function () {
+    yield 'taylor' => 'foo@bar.com';
+    yield 'james' => 'bar@foo.com';
+});
+
 it('can resolve a dataset after the test case is available', function ($result) {
     expect($result)->toBe('bar');
 })->with([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #608

This PR fixes this issue (https://github.com/pestphp/pest/issues/608) where the description for generators is not displayed. This PR will display the description of the dataset, only when it is a string.  I think it's the best because logically the description should be a string.

I created this PR for `1.x`, in order to fix this issue. If this one is fine I will also make one for `2.x`.

### Example

#### With string

```php
test('has emails', function ($email) {
    expect($email)->not->toBeEmpty();
})->with(function () {
    yield 'taylor' => 'taylor@laravel.com';
    yield 'james' => 'james@laravel.com';
});
```

Will display: 

```
✓ has emails with data set "taylor"
✓ has emails with data set "james"
```

#### With int (or any other type)

```php
test('has emails', function ($email) {
    expect($email)->not->toBeEmpty();
})->with(function () {
    yield 1 => 'taylor@laravel.com';
    yield 2 => 'james@laravel.com';
});
```

Will display:

```
✓ has email with ('taylor@laravel.com')
✓ has email with ('james@laravel.com')
```

