### PR TITLE
Exit only if $exit is true

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -119,7 +119,11 @@ final class Command extends BaseCommand
         $result = parent::run($argv, false);
         $result = InteractsWithPlugins::addOutput($result);
 
-        exit($result);
+        if ($exit) {
+            exit($result);
+        }
+
+        return $result;
     }
 
     protected function showHelp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

The `run` method of the `Pest\Console\Command` class executes `exit()` regardless of the `$exit` parameter.

Fix the above phenomenon.

