### PR TITLE
[2.x] Fix: ignored dataset description for string description

### DIFF
--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Repositories;
 
 use Closure;
+use Generator;
 use Pest\Exceptions\DatasetAlreadyExists;
 use Pest\Exceptions\DatasetDoesNotExist;
 use Pest\Exceptions\ShouldNotHappen;
@@ -155,7 +156,10 @@ final class DatasetsRepository
             }
 
             if ($datasets[$index] instanceof Traversable) {
-                $datasets[$index] = iterator_to_array($datasets[$index], false);
+                $preserveKeysForArrayIterator = $datasets[$index] instanceof Generator
+                    && is_string($datasets[$index]->key());
+
+                $datasets[$index] = iterator_to_array($datasets[$index], $preserveKeysForArrayIterator);
             }
 
             // @phpstan-ignore-next-line

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -107,6 +107,8 @@
   ✓ eager registered wrapped datasets with Generator functions with (3)
   ✓ eager registered wrapped datasets with Generator functions with (4)
   ✓ eager registered wrapped datasets with Generator functions did the job right
+  ✓ eager registered wrapped datasets with Generator functions display description with data set "taylor"
+  ✓ eager registered wrapped datasets with Generator functions display description with data set "james"
   ✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #1
   ✓ it can resolve a dataset after the test case is available with (Closure Object (...)) #2
   ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
@@ -890,4 +892,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    4 incomplete, 2 todos, 18 skipped, 619 passed (1529 assertions)
+  Tests:    4 incomplete, 2 todos, 18 skipped, 621 passed (1531 assertions)

--- a/tests/Features/DatasetsTests.php
+++ b/tests/Features/DatasetsTests.php
@@ -249,6 +249,13 @@ test('eager registered wrapped datasets with Generator functions did the job rig
     expect($wrapped_generator_state->text)->toBe('1234');
 });
 
+test('eager registered wrapped datasets with Generator functions display description', function ($wrapped_generator_state_with_description) {
+    expect($wrapped_generator_state_with_description)->not->toBeEmpty();
+})->with(function () {
+    yield 'taylor' => 'taylor@laravel.com';
+    yield 'james' => 'james@laravel.com';
+});
+
 it('can resolve a dataset after the test case is available', function ($result) {
     expect($result)->toBe('bar');
 })->with([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #608 

Same as https://github.com/pestphp/pest/pull/612, but for `2.x`.

