### PR TITLE
[1.x] Bugfix/test directory

### DIFF
--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -27,7 +27,7 @@ final class Backtrace
 
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
             assert(array_key_exists(self::FILE, $trace));
-            if (Str::endsWith($trace[self::FILE], (string) realpath('vendor/phpunit/phpunit/src/Util/FileLoader.php'))) {
+            if (Str::endsWith($trace[self::FILE], (string) realpath(__DIR__.'/../../../../phpunit/phpunit/src/Util/FileLoader.php'))) {
                 break;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | n/a

I am trying to run tests inside a GitHub Action and I have a subfolder that contains the Laravel app.

 `dir/vendor/bin/pest --configuration dir/phpunit.xml --test-directory dir/tests`

Resulted in 'file not found' error due to the Backtrace testFile method not taking the test directory option in to account. This PR fixes the issue

