### PR TITLE
[2.x] Fix #638 #641 windows test failing due directory separators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # "windows-latest" is waiting for https://github.com/pestphp/pest/issues/638
+        os: [ubuntu-latest, macos-latest, windows-latest]
         php: ['8.1', '8.2']
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']

--- a/src/Logging/TeamCity/Converter.php
+++ b/src/Logging/TeamCity/Converter.php
@@ -175,7 +175,7 @@ final class Converter
     private function toRelativePath(string $path): string
     {
         // Remove cwd from the path.
-        return str_replace("$this->rootPath/", '', $path);
+        return str_replace("$this->rootPath".DIRECTORY_SEPARATOR, '', $path);
     }
 
     /**

--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -54,7 +54,9 @@ final class Backtrace
         foreach (debug_backtrace(self::BACKTRACE_OPTIONS) as $trace) {
             assert(array_key_exists(self::FILE, $trace));
 
-            if (Str::endsWith($trace['file'], 'Bootstrappers/BootFiles.php') || Str::endsWith($trace[self::FILE], 'overrides/Runner/TestSuiteLoader.php')) {
+            $traceFile = str_replace(DIRECTORY_SEPARATOR, '/', $trace[self::FILE]);
+
+            if (Str::endsWith($traceFile, 'Bootstrappers/BootFiles.php') || Str::endsWith($traceFile, 'overrides/Runner/TestSuiteLoader.php')) {
                 break;
             }
 

--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -1,4 +1,4 @@
-##teamcity[testSuiteStarted name='Tests\tests\Failure' locationHint='file://tests/.tests/Failure.php' flowId='1234']
+##teamcity[testSuiteStarted name='Tests/tests/Failure' locationHint='file://tests/.tests/Failure.php' flowId='1234']
 ##teamcity[testStarted name='it can fail with comparison' locationHint='pest_qn://tests/.tests/Failure.php::it can fail with comparison' flowId='1234']
 ##teamcity[testFailed name='it can fail with comparison' message='Failed asserting that true matches expected false.' details='at src/Mixins/Expectation.php:312|nat src/Support/ExpectationPipeline.php:75|nat src/Support/ExpectationPipeline.php:79|nat src/Expectation.php:300|nat tests/.tests/Failure.php:6|nat src/Factories/TestCaseMethodFactory.php:106|nat src/Concerns/Testable.php:262|nat src/Support/ExceptionTrace.php:28|nat src/Concerns/Testable.php:262|nat src/Concerns/Testable.php:217|nat src/Kernel.php:79' type='comparisonFailure' actual='true' expected='false' flowId='1234']
 ##teamcity[testFinished name='it can fail with comparison' duration='100000' flowId='1234']
@@ -17,7 +17,7 @@
 ##teamcity[testStarted name='build this one.' locationHint='pest_qn://tests/.tests/Failure.php::build this one.' flowId='1234']
 ##teamcity[testIgnored name='build this one.' message='This test was ignored.' details='' flowId='1234']
 ##teamcity[testFinished name='build this one.' duration='100000' flowId='1234']
-##teamcity[testSuiteFinished name='Tests\tests\Failure' flowId='1234']
+##teamcity[testSuiteFinished name='Tests/tests/Failure' flowId='1234']
 
   [90mTests:[39m    [31;1m2 failed[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m (2 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m

--- a/tests/.snapshots/SuccessOnly.php.inc
+++ b/tests/.snapshots/SuccessOnly.php.inc
@@ -1,9 +1,9 @@
-##teamcity[testSuiteStarted name='Tests\tests\SuccessOnly' locationHint='file://tests/.tests/SuccessOnly.php' flowId='1234']
+##teamcity[testSuiteStarted name='Tests/tests/SuccessOnly' locationHint='file://tests/.tests/SuccessOnly.php' flowId='1234']
 ##teamcity[testStarted name='it can pass with comparison' locationHint='pest_qn://tests/.tests/SuccessOnly.php::it can pass with comparison' flowId='1234']
 ##teamcity[testFinished name='it can pass with comparison' duration='100000' flowId='1234']
 ##teamcity[testStarted name='can also pass' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can also pass' flowId='1234']
 ##teamcity[testFinished name='can also pass' duration='100000' flowId='1234']
-##teamcity[testSuiteFinished name='Tests\tests\SuccessOnly' flowId='1234']
+##teamcity[testSuiteFinished name='Tests/tests/SuccessOnly' flowId='1234']
 
   [90mTests:[39m    [32;1m2 passed[39;22m[90m (2 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m

--- a/tests/Visual/TeamCity.php
+++ b/tests/Visual/TeamCity.php
@@ -1,5 +1,12 @@
 <?php
 
+function normalize_windows_os_output(string $text): string
+{
+    $text = str_replace('\r', '', $text);
+
+    return str_replace('\\', '/', $text);
+}
+
 test('visual snapshot of team city', function (string $testFile) {
     $testsPath = dirname(__DIR__)."/.tests/$testFile";
 
@@ -28,13 +35,9 @@ test('visual snapshot of team city', function (string $testFile) {
     };
 
     if (getenv('REBUILD_SNAPSHOTS')) {
-        $outputContent = explode("\n", $output());
-
-        file_put_contents($snapshot, implode("\n", $outputContent));
+        file_put_contents($snapshot, normalize_windows_os_output($output()));
     } elseif (! getenv('EXCLUDE')) {
-        $output = explode("\n", $output());
-
-        expect(implode("\n", $output))->toEqual(file_get_contents($snapshot));
+        expect(normalize_windows_os_output($output()))->toEqual(file_get_contents($snapshot));
     }
 })->with([
     'Failure.php',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #638 #641

this PR will fix directory separator issue with windows OS


One quick **note** for team city snapshot: in the file there is a mix of slashes and backslashes, so it would be really difficult to achieve (and maintain) a proper replacement for windows backslashes in paths, leaving untouched printed class namespaces backslashes. I opted for replacing all backslashes to slashes in to obtain the same result without too many lines or code 