### PR TITLE
Ensures toHaveKey() has a iterable value

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -560,14 +560,18 @@ final class Expectation
      */
     public function toHaveKey(string|int $key, mixed $value = new Any(), string $message = ''): self
     {
-        if (! is_iterable($this->value)) {
-            InvalidExpectationValue::expected('iterable');
-        }
+        $array = $this->value;
 
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $array = $this->value->toArray();
-        } else {
+        }
+
+        if (is_object($array)) {
             $array = (array) $this->value;
+        }
+
+        if (! is_iterable($array)) {
+            InvalidExpectationValue::expected('iterable');
         }
 
         try {

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -560,6 +560,10 @@ final class Expectation
      */
     public function toHaveKey(string|int $key, mixed $value = new Any(), string $message = ''): self
     {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
         if (is_object($this->value) && method_exists($this->value, 'toArray')) {
             $array = $this->value->toArray();
         } else {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -528,6 +528,7 @@
   ✓ fails with wrong value
   ✓ fails with wrong value and nested key
   ✓ fails with wrong value and plain key with dots
+  ✓ fails with a non-iterable value
   ✓ not failures
   ✓ not failures with nested key
   ✓ not failures with plain key with dots
@@ -899,4 +900,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    4 incomplete, 4 todos, 18 skipped, 624 passed (1511 assertions)
+  Tests:    4 incomplete, 4 todos, 18 skipped, 625 passed (1513 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -535,6 +535,8 @@
   ✓ not failures with correct value
   ✓ not failures with correct value and with nested key
   ✓ not failures with correct value and with plain key with dots
+  ✓ pass with a class
+  ✓ pass with a class (opposite)
 
    PASS  Tests\Features\Expect\toHaveKeys
   ✓ pass
@@ -545,6 +547,8 @@
   ✓ failures with multi-dimensional arrays and custom message
   ✓ not failures
   ✓ not failures with multi-dimensional arrays
+  ✓ pass with a class
+  ✓ pass with a class (opposite)
 
    PASS  Tests\Features\Expect\toHaveLength
   ✓ it passes with ('Fortaleza')
@@ -900,4 +904,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    4 incomplete, 4 todos, 18 skipped, 625 passed (1513 assertions)
+  Tests:    4 incomplete, 4 todos, 18 skipped, 629 passed (1519 assertions)

--- a/tests/Features/Expect/toHaveKey.php
+++ b/tests/Features/Expect/toHaveKey.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 $test_array = [
@@ -59,6 +60,10 @@ test('fails with wrong value and nested key', function () use ($test_array) {
 test('fails with wrong value and plain key with dots', function () use ($test_array) {
     expect($test_array)->toHaveKey('key.with.dots', true);
 })->throws(ExpectationFailedException::class);
+
+test('fails with a non-iterable value', function () {
+    expect('this is a string')->toHaveKey('a');
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [iterable].');
 
 test('not failures', function () use ($test_array) {
     expect($test_array)->not->toHaveKey('c');

--- a/tests/Features/Expect/toHaveKey.php
+++ b/tests/Features/Expect/toHaveKey.php
@@ -13,6 +13,11 @@ $test_array = [
     'key.with.dots' => false,
 ];
 
+class ExampleClassKey
+{
+    public $foo = 'foo';
+}
+
 test('pass')->expect($test_array)->toHaveKey('c');
 test('pass with nested key')->expect($test_array)->toHaveKey('d.e');
 test('pass with plain key with dots')->expect($test_array)->toHaveKey('key.with.dots');
@@ -88,3 +93,7 @@ test('not failures with correct value and  with nested key', function () use ($t
 test('not failures with correct value and  with plain key with dots', function () use ($test_array) {
     expect($test_array)->not->toHaveKey('key.with.dots', false);
 })->throws(ExpectationFailedException::class);
+
+test('pass with a class')->expect((new ExampleClassKey()))->toHaveKey('foo');
+
+test('pass with a class (opposite)')->expect((new ExampleClassKey()))->not()->toHaveKey('foo1234');

--- a/tests/Features/Expect/toHaveKeys.php
+++ b/tests/Features/Expect/toHaveKeys.php
@@ -2,6 +2,13 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
+class ExampleClassKeys
+{
+    public $foo = 'foo';
+
+    public $bar = 'bar';
+}
+
 test('pass', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'c', 'foo.bar']);
 });
@@ -33,3 +40,7 @@ test('not failures', function () {
 test('not failures with multi-dimensional arrays', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => ['bir' => 'biz']]])->not->toHaveKeys(['foo' => ['bar' => 'bir'], 'c', 'z']);
 })->throws(ExpectationFailedException::class);
+
+test('pass with a class')->expect((new ExampleClassKeys()))->toHaveKeys(['foo', 'bar']);
+
+test('pass with a class (opposite)')->expect((new ExampleClassKeys()))->not()->toHaveKeys(['foo1234', 'bar5678']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | -

This PR ensures the `$value` is of type `iterable` for the `toHaveKey()` and  `toHaveKeys()` Expectations. 

Both will throw an `InvalidExpectationValue` exception, like some other Expectations do.

This proposed change also improves consistency with PHPUnit 9.5, as the  [ArrayHasKey](https://phpunit.readthedocs.io/en/9.5/assertions.html?highlight=arrayHasKey#assertarrayhaskey) assertion throws an exception when a string is passed:

```php
$this->assertArrayHasKey('foo', 'hello world') 
//PHPUnit\Framework\Assert::assertArrayHasKey(): Argument #2 ($array) must be of type ArrayAccess|array, string given
```

### Motivation

As questioned by the user SomaiyaUtsav on [Twitter](https://twitter.com/SomaiyaUtsav/status/1612068864229257218), there is a strange/misleading behavior resulting in a false positive when checking if a `string` has keys:

<img src="https://user-images.githubusercontent.com/79267265/212540849-dd8a1483-7a7f-4ed7-b1a9-de1cf6f23a70.jpg" width="500" height="318" />

Under the hood, the string `'for the best Pest content follow'` is converted to an array `[0 => 'for the best Pest content follow']` and the test passes.

### Open points

` 📚 ` The Pest Doc accordingly will be updated should this PR be accepted.
` ❓ ` Is this 2.x change or a bug fix to be included in 1.x?