### PR TITLE
[1.x] Compact datasets description

### DIFF
--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -8,7 +8,7 @@ use Closure;
 use Generator;
 use Pest\Exceptions\DatasetAlreadyExist;
 use Pest\Exceptions\DatasetDoesNotExist;
-use SebastianBergmann\Exporter\Exporter;
+use Pest\Exporters\Exporter;
 use Traversable;
 
 /**

--- a/src/Exporters/Exporter.php
+++ b/src/Exporters/Exporter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exporters;
+
+use SebastianBergmann\Exporter\Exporter as BaseExporter;
+use SebastianBergmann\RecursionContext\Context;
+
+/**
+ * @internal
+ */
+final class Exporter extends BaseExporter
+{
+    /**
+     * Exports a value into a single-line string recursively.
+     */
+    public function shortenedRecursiveExport(&$data, Context $context = null)
+    {
+        $result   = [];
+        $array    = $data;
+        $exporter = new static();
+        $context  = $context ?? new Context();
+
+        $context->add($data);
+
+        foreach ($array as $key => $value) {
+            if (!is_array($value)) {
+                $result[] = $exporter->shortenedExport($value);
+                continue;
+            }
+
+            $result[] = $context->contains($data[$key]) !== false
+                ? '*RECURSION*'
+                : sprintf('[%s]', $this->shortenedRecursiveExport($data[$key], $context));
+        }
+
+        return implode(', ', $result);
+    }
+
+    /**
+     * Exports a value into a single-line string.
+     */
+    public function shortenedExport(mixed $value): string
+    {
+        return (string) preg_replace(['#\.{3}#', '#\\\n\s*#'], ['…'], parent::shortenedExport($value));
+    }
+}

--- a/src/Exporters/Exporter.php
+++ b/src/Exporters/Exporter.php
@@ -40,8 +40,10 @@ final class Exporter extends BaseExporter
 
     /**
      * Exports a value into a single-line string.
+     *
+     * @phpstan-ignore-next-line
      */
-    public function shortenedExport(mixed $value): string
+    public function shortenedExport($value)
     {
         return (string) preg_replace(['#\.{3}#', '#\\\n\s*#'], ['…'], parent::shortenedExport($value));
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -30,7 +30,7 @@
   ✓ it sets arrays
   ✓ it gets bound to test case object with ('a')
   ✓ it gets bound to test case object with ('b')
-  ✓ it truncates the description with ('FoooFoooFoooFoooFoooFoooFoooF...ooFooo')
+  ✓ it truncates the description with ('FoooFoooFoooFoooFoooFoooFoooF…ooFooo')
   ✓ lazy datasets with (1)
   ✓ lazy datasets with (2)
   ✓ lazy datasets did the job right
@@ -49,7 +49,7 @@
   ✓ named datasets with data set "one"
   ✓ named datasets with data set "two"
   ✓ named datasets did the job right
-  ✓ lazy named datasets with (Bar Object (...))
+  ✓ lazy named datasets with (Bar Object (…))
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #2
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), false)
@@ -103,11 +103,11 @@
   ✓ eager registered wrapped datasets with Generator functions did the job right
   ✓ eager registered wrapped datasets with Generator functions display description with data set "taylor"
   ✓ eager registered wrapped datasets with Generator functions display description with data set "james"
-  ✓ it can resolve a dataset after the test case is available with (Closure Object (...))
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #1
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (...)) #2
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #1
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (...)) #2
+  ✓ it can resolve a dataset after the test case is available with (Closure Object (…))
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (…)) #1
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (…)) #2
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (…)) #1
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (…)) #2
 
    PASS  Tests\Features\Exceptions
   ✓ it gives access the the underlying expectException
@@ -446,8 +446,8 @@
   ✓ it passes with ('Fortaleza')
   ✓ it passes with ('Sollefteå')
   ✓ it passes with ('Ιεράπετρα')
-  ✓ it passes with (stdClass Object (...))
-  ✓ it passes with (Illuminate\Support\Collection Object (...))
+  ✓ it passes with (stdClass Object (…))
+  ✓ it passes with (Illuminate\Support\Collection Object (…))
   ✓ it passes with array
   ✓ it passes with *not*
   ✓ it properly fails with *not*
@@ -665,6 +665,7 @@
   ✓ it show only the names of multiple named datasets in their description
   ✓ it show the actual dataset of multiple non-named datasets in their description
   ✓ it show the correct description for mixed named and not-named datasets
+  ✓ it shows the correct description for long texts with newlines
 
    PASS  Tests\Unit\Plugins\Environment
   ✓ environment is set to CI when --ci option is used
@@ -729,5 +730,5 @@
   ✓ it is a test
   ✓ it uses correct parent class
 
-  Tests:  4 incompleted, 9 skipped, 487 passed
+  Tests:  4 incompleted, 9 skipped, 488 passed
   

--- a/tests/Unit/Datasets.php
+++ b/tests/Unit/Datasets.php
@@ -23,7 +23,7 @@ it('show the actual dataset of non-named datasets in their description', functio
     ]));
 
     expect($descriptions[0])->toBe('test description with (1)');
-    expect($descriptions[1])->toBe('test description with (array(2))');
+    expect($descriptions[1])->toBe('test description with ([2])');
 });
 
 it('show only the names of multiple named datasets in their description', function () {
@@ -57,9 +57,9 @@ it('show the actual dataset of multiple non-named datasets in their description'
     ]));
 
     expect($descriptions[0])->toBe('test description with (1) / (3)');
-    expect($descriptions[1])->toBe('test description with (1) / (array(4))');
-    expect($descriptions[2])->toBe('test description with (array(2)) / (3)');
-    expect($descriptions[3])->toBe('test description with (array(2)) / (array(4))');
+    expect($descriptions[1])->toBe('test description with (1) / ([4])');
+    expect($descriptions[2])->toBe('test description with ([2]) / (3)');
+    expect($descriptions[3])->toBe('test description with ([2]) / ([4])');
 });
 
 it('show the correct description for mixed named and not-named datasets', function () {
@@ -76,6 +76,16 @@ it('show the correct description for mixed named and not-named datasets', functi
 
     expect($descriptions[0])->toBe('test description with data set "one" / (3)');
     expect($descriptions[1])->toBe('test description with data set "one" / data set "four"');
-    expect($descriptions[2])->toBe('test description with (array(2)) / (3)');
-    expect($descriptions[3])->toBe('test description with (array(2)) / data set "four"');
+    expect($descriptions[2])->toBe('test description with ([2]) / (3)');
+    expect($descriptions[3])->toBe('test description with ([2]) / data set "four"');
+});
+
+it('shows the correct description for long texts with newlines', function () {
+    $descriptions = array_keys(Datasets::resolve('test description', [
+        [
+            ['some very \nlong text with \n     newlines'],
+        ],
+    ]));
+
+    expect($descriptions[0])->toBe('test description with (\'some very long text with …wlines\')');
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | none

Hello guys! This PR compacts datasets description to make it more readable and avoid cluttering the tests output.

Here is how dataset descriptions looked before this PR:

```
  ✓ it supports multiple JSON pointers with ('[\n       {\n             "id": "0001",\n         "ty...}\n]\n', array('/-1', '/-2'), array())
  ✓ it supports multiple JSON pointers with ('[\n       {\n             "id": "0001",\n         "ty...}\n]\n', array('/-/id', '/-/batters/batter/-/type'), array(array('0001', '0002', '0003'), array('Regular', 'Chocolate', 'Blueberry', 'Devil's Food', 'Regular', 'Regular', 'Chocolate')))
  ✓ it supports multiple JSON pointers with ('[\n       {\n             "id": "0001",\n         "ty...}\n]\n', array('/-/name', '/-/topping/-/type', '/-/id'), array(array('0001', '0002', '0003'), array('Cake', 'Raised', 'Old Fashioned'), array('None', 'Glazed', 'Sugar', 'Powdered Sugar', 'Chocolate with Sprinkles', 'Chocolate', 'Maple', 'None', 'Glazed', 'Sugar', 'Chocolate', 'Maple', 'None', 'Glazed', 'Chocolate', 'Maple')))
  ✓ it supports multiple JSON pointers with ('[\n       {\n             "id": "0001",\n         "ty...}\n]\n', array('/-/batters/batter/-', '/-/name'), array(array('Cake', 'Raised', 'Old Fashioned'), array(array('1001', 'Regular'), array('1001', 'Regular'), array('1001', 'Regular')), array(array('1002', 'Chocolate'), array('1002', 'Chocolate')), array('1003', 'Blueberry'), array('1004', 'Devil's Food')))
  ✓ it supports multiple JSON pointers with ('{\n       "id": "0001",\n "type": "...]\n}\n', array('/-1', '/-2'), array())
  ✓ it supports multiple JSON pointers with ('{\n       "id": "0001",\n "type": "...]\n}\n', array('/id', '/batters/batter/-/type'), array('0001', array('Regular', 'Chocolate', 'Blueberry', 'Devil's Food')))
  ✓ it supports multiple JSON pointers with ('{\n       "id": "0001",\n "type": "...]\n}\n', array('/name', '/topping/-/type', '/id'), array('0001', 'Cake', array('None', 'Glazed', 'Sugar', 'Powdered Sugar', 'Chocolate with Sprinkles', 'Chocolate', 'Maple')))
  ✓ it supports multiple JSON pointers with ('{\n       "id": "0001",\n "type": "...]\n}\n', array('/batters/batter/-', '/type'), array('donut', array('1001', 'Regular'), array('1002', 'Chocolate'), array('1003', 'Blueberry'), array('1004', 'Devil's Food')))
```

And here is how they look after this PR:

```
  ✓ it supports multiple JSON pointers with ('[{"id": "0001","ty…}]', ['/-1', '/-2'], [])
  ✓ it supports multiple JSON pointers with ('[{"id": "0001","ty…}]', ['/-/id', '/-/batters/batter/-/type'], [['0001', '0002', '0003'], ['Regular', 'Chocolate', 'Blueberry', 'Devil's Food', 'Regular', 'Regular', 'Chocolate']])
  ✓ it supports multiple JSON pointers with ('[{"id": "0001","ty…}]', ['/-/name', '/-/topping/-/type', '/-/id'], [['0001', '0002', '0003'], ['Cake', 'Raised', 'Old Fashioned'], ['None', 'Glazed', 'Sugar', 'Powdered Sugar', 'Chocolate with Sprinkles', 'Chocolate', 'Maple', 'None', 'Glazed', 'Sugar', 'Chocolate', 'Maple', 'None', 'Glazed', 'Chocolate', 'Maple']])
  ✓ it supports multiple JSON pointers with ('[{"id": "0001","ty…}]', ['/-/batters/batter/-', '/-/name'], [['Cake', 'Raised', 'Old Fashioned'], [['1001', 'Regular'], ['1001', 'Regular'], ['1001', 'Regular']], [['1002', 'Chocolate'], ['1002', 'Chocolate']], ['1003', 'Blueberry'], ['1004', 'Devil's Food']])
  ✓ it supports multiple JSON pointers with ('{"id": "0001","type": "…]}', ['/-1', '/-2'], [])
  ✓ it supports multiple JSON pointers with ('{"id": "0001","type": "…]}', ['/id', '/batters/batter/-/type'], ['0001', ['Regular', 'Chocolate', 'Blueberry', 'Devil's Food']])
  ✓ it supports multiple JSON pointers with ('{"id": "0001","type": "…]}', ['/name', '/topping/-/type', '/id'], ['0001', 'Cake', ['None', 'Glazed', 'Sugar', 'Powdered Sugar', 'Chocolate with Sprinkles', 'Chocolate', 'Maple']])
  ✓ it supports multiple JSON pointers with ('{"id": "0001","type": "…]}', ['/batters/batter/-', '/type'], ['donut', ['1001', 'Regular'], ['1002', 'Chocolate'], ['1003', 'Blueberry'], ['1004', 'Devil's Food']])
```

Please note that I'm getting some errors from parallel tests - is there anything I can do to make them pass? Thank you :)

Also note that this PR is for the branch `1.x` as I thought that also v1 can benefit from this feature. Please let me know if I should point to the v2 branch instead.