### PR TITLE
fixes duplicate --coverage-php option

### DIFF
--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -76,8 +76,12 @@ final class Coverage implements AddsOutput, HandlesArguments
         $input = new ArgvInput($arguments, new InputDefinition($inputs));
         if ((bool) $input->getOption(self::COVERAGE_OPTION)) {
             $this->coverage      = true;
-            $originals[]         = '--coverage-php';
-            $originals[]         = \Pest\Support\Coverage::getPath();
+
+            // If --coverage-php exists, we don't need to add it.
+            if (! in_array('--coverage-php', $originals, true)) {
+                $originals[] = '--coverage-php';
+                $originals[]         = \Pest\Support\Coverage::getPath();
+            }
         }
 
         if ($input->getOption(self::MIN_OPTION) !== null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This is a multi-tiered issue, running pest in my CI environment, all tests are failing as it's trying to write to the vendor directory - but given that directory is read only (it's mounted as RO in a container) - this fails.

Looking further into the issue - the --coverage-php option sets where coverage.php is actually written - though, when if you set the option in the CLI, it does not respect that and still tries writing to a temp directory within the vendor directory.

This PR just adds a check to only set that flag if it doesn't exist already - so no duplicate, and the override actually works.
