### PR TITLE
[2.x] Docker support for OSS contributors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /art                     export-ignore
+/docker                  export-ignore
 /docs                    export-ignore
 /tests                   export-ignore
 /scripts                 export-ignore
@@ -11,5 +12,6 @@ phpstan.neon             export-ignore
 /phpunit.xml             export-ignore
 CHANGELOG.md             export-ignore
 CONTRIBUTING.md          export-ignore
+docker-compose.yml       export-ignore
 README.md                export-ignore
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,22 @@ Integration tests:
 ```bash
 composer test:integration
 ```
+
+## Simplified setup using Docker
+
+If you have Docker installed, you can quickly get all dependencies for Pest in place using
+our Docker files. Assuming you have the repository cloned, you may run the following
+commands:
+
+1. `docker compose build` to build the Docker image
+2. `docker compose run --rm composer install` to install Composer dependencies
+3. `docker compose run --rm composer test` to run the project tests and analysis tools
+
+If you want to check things work against a specific version of PHP, you may include
+the `PHP` build argument when building the image:
+
+```bash
+docker compose build --build-arg PHP=8.2
+```
+
+The default PHP version will always be the lowest version of PHP supported by Pest.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  php:
+    build:
+      context: ./docker
+    volumes:
+      - .:/var/www/html
+  composer:
+    build:
+      context: ./docker
+    volumes:
+      - .:/var/www/html
+    entrypoint: ["composer"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+ARG PHP=8.1
+FROM php:${PHP}-cli-alpine
+
+RUN apk update \
+    && apk add zip libzip-dev icu-dev
+
+RUN docker-php-ext-configure zip
+RUN docker-php-ext-install zip
+RUN docker-php-ext-enable zip
+
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl
+RUN docker-php-ext-enable intl
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+ENTRYPOINT ["php"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds support for building Docker images that are capable of running all the checks required to submit a PR to the Pest codebase. This will allow developers to very quickly get the project up and running locally so that they are able to contribute.

Here is how simple it is to get started:

1. `docker compose build` to build the Docker image
2. `docker compose run --rm composer install` to install Composer dependencies
3. `docker compose run --rm composer test` to run the project tests and analysis tools

The docker image is built on a minimal Alpine image to keep it as small as possible.

By default, the Docker image uses PHP 8.1, as this is the lowest supported PHP version. One nice thing about adding support for this is how easy it is to try out a PR against other PHP versions. For example, to test against PHP 8.2, a developer would run the following:

1. `docker compose build --build-arg PHP=8.2`
2. `docker compose run --rm composer update`
3. `docker compose run --rm composer test`

#LetsPestThis