### PR TITLE
[2.x] Fix missing parameter to `Style→writeRecap()` method

### DIFF
--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -211,7 +211,7 @@ final class TeamCityLogger
             );
         }
 
-        $style->writeRecap($state, $telemetry);
+        $style->writeRecap($state, $telemetry, $result);
     }
 
     public function output(ServiceMessage $message): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | -

this will fix a phpstan error after this change in Collision codebase: https://github.com/nunomaduro/collision/commit/51a4ed012920b2e20b3e7bdef0d446b575cf640e

![image](https://user-images.githubusercontent.com/8792274/217665957-6c408116-7017-4478-8223-5225627e1cfa.png)
