### PR TITLE
Fix tests and static analysis

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -88,7 +88,7 @@ if (! function_exists('test')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
-     * @return HigherOrderTapProxy<TestCall|TestCase>|TestCall|mixed
+     * @return HigherOrderTapProxy<TestCall|TestCase>|TestCall
      */
     function test(string $description = null, Closure $closure = null): HigherOrderTapProxy|TestCall
     {

--- a/src/TestCases/IgnorableTestCase.php
+++ b/src/TestCases/IgnorableTestCase.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
+ * @phpstan-ignore-next-line
  */
 final class IgnorableTestCase extends TestCase
 {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -884,9 +884,9 @@
   ✓ it gets property values
 
    PASS  Tests\Unit\Support\Str
-  ✓ it evaluates the code with ('version()', 'version__')
-  ✓ it evaluates the code with ('version__ ', 'version___')
-  ✓ it evaluates the code with ('version\', 'version_')
+  ✓ it evaluates the code with ('version()', '__pest_evaluable_version__')
+  ✓ it evaluates the code with ('version__ ', '__pest_evaluable_version___')
+  ✓ it evaluates the code with ('version\', '__pest_evaluable_version_')
 
    PASS  Tests\Unit\TestSuite
   ✓ it does not allow to add the same test description twice


### PR DESCRIPTION
Fix failing larastan tests and updates snapshost to match changes in `tests/Unit/Support/Str.php`

![image](https://user-images.githubusercontent.com/8792274/219867382-86517102-47ce-41da-84b0-f590450e7726.png)


