### PR TITLE
Store interceptors for use with Collision

### DIFF
--- a/src/Concerns/Pipeable.php
+++ b/src/Concerns/Pipeable.php
@@ -20,6 +20,13 @@ trait Pipeable
     private static array $pipes = [];
 
     /**
+     * The list of interceptors.
+     *
+     * @var array<string, array<Closure(Closure, mixed ...$arguments): void>>
+     */
+    private static array $interceptors = [];
+
+    /**
      * Register a pipe to be applied before an expectation is checked.
      */
     public function pipe(string $name, Closure $pipe): void
@@ -37,6 +44,8 @@ trait Pipeable
         if (is_string($filter)) {
             $filter = fn ($value): bool => $value instanceof $filter;
         }
+
+        self::$interceptors[$name][] = $handler;
 
         $this->pipe($name, function ($next, ...$arguments) use ($handler, $filter): void {
             /* @phpstan-ignore-next-line */


### PR DESCRIPTION
this is a temporary workaround for PHP 8.1 and 8.2 bug https://github.com/php/php-src/issues/10623, that prevents Collision to retrieve info about the interceptor handler closure. (see https://github.com/nunomaduro/collision/pull/255), waiting for it to be fixed in PHP core

we should store interceptor closures in order to allow collision to check if the exception trace snippet belongs to an interceptor