### PR TITLE
Enhancement: Run tests against `phpunit/phpunit:dev-main` every 12 hours

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Nightly Tests
 
 on:
   push:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 */12 * * *'
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        php: ['8.1']
+        phpunit-branch: [main]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.phpunit-branch }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        tools: composer:v2
+        coverage: none
+
+    - name: Setup Problem Matchers
+      run: |
+        echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+    - name: Install PHP dependencies with phpunit/phpunit:dev-${{ matrix.phpunit-branch }}
+      run: composer require phpunit/phpunit:dev-${{ matrix.phpunit-branch }} --ansi --no-interaction --no-progress
+
+    - name: Unit Tests
+      run: composer test:unit
+
+    - name: Unit Tests in Parallel
+      run: composer test:parallel
+
+    - name: Integration Tests
+      run: composer test:integration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | n/a

This pull request

- [x] adds a workflow running tests against `phpunit/phpunit:dev-main` every 12 hours (as briefly discussed in the Pest Telegram group)