### PR TITLE
[2.x] Add `toEqualObjects` method in Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -894,6 +894,13 @@ final class Expectation
         throw new ExpectationFailedException("Exception \"$exception\" not thrown.");
     }
 
+    public function toEqualObjects(object $expected, string $method = 'equals', string $message = ''): self
+    {
+        Assert::assertObjectEquals($expected, $this->value, $method, $message);
+
+        return $this;
+    }
+
     /**
      * Exports the given value.
      */

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -894,6 +894,11 @@ final class Expectation
         throw new ExpectationFailedException("Exception \"$exception\" not thrown.");
     }
 
+    /**
+     * Asserts that the value is equals with $expected.
+     *
+     * @return self<TValue>
+     */
     public function toEqualObjects(object $expected, string $method = 'equals', string $message = ''): self
     {
         Assert::assertObjectEquals($expected, $this->value, $method, $message);

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -899,7 +899,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toEqualObjects(object $expected, string $method = 'equals', string $message = ''): self
+    public function toEqualObject(object $expected, string $method = 'equals', string $message = ''): self
     {
         Assert::assertObjectEquals($expected, $this->value, $method, $message);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

```php
$a = new Email('user@example.org');
$b = new Email('user@example.org');

expect($a)->toEqualObject($b); // pass
```

