### PR TITLE
Refactor Expectation `unless` method

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -254,11 +254,7 @@ final class Expectation
      */
     public function unless(callable|bool $condition, callable $callback): Expectation
     {
-        $condition = is_callable($condition)
-            ? $condition
-            : static fn (): bool => $condition;
-
-        return $this->when(! $condition(), $callback);
+        return $this->when(! (is_bool($condition) ? $condition : $condition()), $callback);
     }
 
     /**


### PR DESCRIPTION
Hello 👋🏻 

While checking `Expectation` class I have found that this code block is duplicated on `unless` and `when`, so when we call the `unless` method, this block got executed twice.
```php
$condition = is_callable($condition)
            ? $condition
            : static fn (): bool => $condition;
```
So in this PR I have tried to make it better.
