### PR TITLE
Fix test Case Name starts with a P

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -277,7 +277,7 @@ trait Testable
      */
     public static function getPrintableTestCaseName(): string
     {
-        return ltrim(self::class, 'P\\');
+        return preg_replace('/P\\\/', '', self::class, 1);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

In this Pr I have fixed a bug that removes the first P from test `Case Name`.

### Before
![Screenshot 2023-03-19 174241](https://user-images.githubusercontent.com/60013703/226196392-fa6a6fe5-6e3a-4f7d-9f14-fac258c9d515.png)


### After
![Screenshot 2023-03-19 174345](https://user-images.githubusercontent.com/60013703/226196403-5bd46118-9dd2-465f-9fcc-091bc31a67a6.png)

