### PR TITLE
[2.x] feat(parallel): Adds support for plugins to filter parallel arguments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG PHP=8.1
 FROM php:${PHP}-cli-alpine
 
 RUN apk update \
-    && apk add zip libzip-dev icu-dev
+    && apk add zip libzip-dev icu-dev git
 
 RUN docker-php-ext-configure zip
 RUN docker-php-ext-install zip

--- a/src/Contracts/Plugins/HandlesArguments.php
+++ b/src/Contracts/Plugins/HandlesArguments.php
@@ -10,7 +10,7 @@ namespace Pest\Contracts\Plugins;
 interface HandlesArguments
 {
     /**
-     * Adds arguments before of the Test Suite execution.
+     * Adds arguments before the Test Suite execution.
      *
      * @param  array<int, string>  $arguments
      * @return array<int, string>

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -79,6 +79,7 @@ final class Parallel implements HandlesArguments
 
         foreach ($placesToCheck as $location) {
             if (array_key_exists(self::GLOBAL_PREFIX.$key, $location)) {
+                // @phpstan-ignore-next-line
                 return json_decode($location[self::GLOBAL_PREFIX.$key], true)['value'] ?? null;
             }
         }

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -67,7 +67,7 @@ final class Parallel implements HandlesArguments
     {
         $data = ['value' => $value instanceof Stringable ? $value->__toString() : $value];
 
-        $_ENV[self::GLOBAL_PREFIX.$key] = json_encode($data);
+        $_ENV[self::GLOBAL_PREFIX.$key] = json_encode($data, JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -80,7 +80,7 @@ final class Parallel implements HandlesArguments
         foreach ($placesToCheck as $location) {
             if (array_key_exists(self::GLOBAL_PREFIX.$key, $location)) {
                 // @phpstan-ignore-next-line
-                return json_decode($location[self::GLOBAL_PREFIX.$key], true)['value'] ?? null;
+                return json_decode((string) $location[self::GLOBAL_PREFIX.$key], true, 512, JSON_THROW_ON_ERROR)['value'] ?? null;
             }
         }
 

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -73,7 +73,7 @@ final class Parallel implements HandlesArguments
 
         foreach ($placesToCheck as $location) {
             if (array_key_exists(self::GLOBAL_PREFIX.$key, $location)) {
-                return json_decode($location[self::GLOBAL_PREFIX.$key])['value'] ?? null;
+                return json_decode($location[self::GLOBAL_PREFIX.$key], true)['value'] ?? null;
             }
         }
 

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -15,9 +15,7 @@ use Pest\Support\Container;
 use Pest\TestSuite;
 use function Pest\version;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\OutputInterface;
 
 final class Parallel implements HandlesArguments
 {
@@ -86,12 +84,6 @@ final class Parallel implements HandlesArguments
      */
     private function runTestSuiteInParallel(array $arguments): int
     {
-        if (! class_exists(ParaTestCommand::class)) {
-            $this->askUserToInstallParatest();
-
-            return Command::FAILURE;
-        }
-
         $handlers = array_filter(
             array_map(fn ($handler): object|string => Container::getInstance()->get($handler), self::HANDLERS),
             fn ($handler): bool => $handler instanceof HandlesArguments,
@@ -126,20 +118,6 @@ final class Parallel implements HandlesArguments
             fn ($arguments, HandlersWorkerArguments $handler): array => $handler->handleWorkerArguments($arguments),
             $arguments
         );
-    }
-
-    /**
-     * Outputs a message to the user asking them to install ParaTest as a dev dependency.
-     */
-    private function askUserToInstallParatest(): void
-    {
-        /** @var OutputInterface $output */
-        $output = Container::getInstance()->get(OutputInterface::class);
-
-        $output->writeln([
-            '<fg=red>Pest Parallel requires ParaTest to run.</>',
-            'Please run <fg=yellow>composer require --dev brianium/paratest</>.',
-        ]);
     }
 
     /**

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -60,6 +60,9 @@ final class Parallel implements HandlesArguments
         return ((int) $argvValue) === 1;
     }
 
+    /**
+     * Sets a global value that can be accessed by the parent process and all workers.
+     */
     public static function setGlobal(string $key, string|int|bool|Stringable $value): void
     {
         $data = ['value' => $value instanceof Stringable ? $value->__toString() : $value];
@@ -67,6 +70,9 @@ final class Parallel implements HandlesArguments
         $_ENV[self::GLOBAL_PREFIX.$key] = json_encode($data);
     }
 
+    /**
+     * Returns the given global value if one has been set.
+     */
     public static function getGlobal(string $key): string|int|bool|null
     {
         $placesToCheck = [$_SERVER, $_ENV];

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -64,7 +64,7 @@ final class Parallel implements HandlesArguments
     {
         $data = ['value' => $value instanceof Stringable ? $value->__toString() : $value];
 
-        $_SERVER[self::GLOBAL_PREFIX.$key] = json_encode($data);
+        $_ENV[self::GLOBAL_PREFIX.$key] = json_encode($data);
     }
 
     public static function getGlobal(string $key): string|int|bool|null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Fixed tickets | #682

Basically, `CallsHandlesArguments` is not executed fully in parallel (and rightly so). However, this means that plugins have no way of altering arguments and thus supporting parallel execution.

This PR adds a new action and contract that allows plugins to alter parallel arguments before parallel execution.