### PR TITLE
Improve types in Greater/Lesser Expectations

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -124,7 +124,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThan(int|float $expected, string $message = ''): self
+    public function toBeGreaterThan(int|float|\DateTime|\DateTimeImmutable $expected, string $message = ''): self
     {
         Assert::assertGreaterThan($expected, $this->value, $message);
 
@@ -136,7 +136,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThanOrEqual(int|float $expected, string $message = ''): self
+    public function toBeGreaterThanOrEqual(int|float|\DateTime|\DateTimeImmutable $expected, string $message = ''): self
     {
         Assert::assertGreaterThanOrEqual($expected, $this->value, $message);
 
@@ -148,7 +148,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThan(int|float $expected, string $message = ''): self
+    public function toBeLessThan(int|float|\DateTime|\DateTimeImmutable $expected, string $message = ''): self
     {
         Assert::assertLessThan($expected, $this->value, $message);
 
@@ -160,7 +160,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThanOrEqual(int|float $expected, string $message = ''): self
+    public function toBeLessThanOrEqual(int|float|\DateTime|\DateTimeImmutable $expected, string $message = ''): self
     {
         Assert::assertLessThanOrEqual($expected, $this->value, $message);
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -334,12 +334,14 @@
 
    PASS  Tests\Features\Expect\toBeGreatherThan
   ✓ passes
+  ✓ passes with DateTime and DateTimeImmutable
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
 
    PASS  Tests\Features\Expect\toBeGreatherThanOrEqual
   ✓ passes
+  ✓ passes with DateTime and DateTimeImmutable
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
@@ -382,12 +384,14 @@
 
    PASS  Tests\Features\Expect\toBeLessThan
   ✓ passes
+  ✓ passes with DateTime and DateTimeImmutable
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
 
    PASS  Tests\Features\Expect\toBeLessThanOrEqual
   ✓ passes
+  ✓ passes with DateTime and DateTimeImmutable
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
@@ -944,4 +948,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 12 skipped, 649 passed (1588 assertions)
+  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 12 skipped, 653 passed (1604 assertions)

--- a/tests/Features/Expect/toBeGreatherThan.php
+++ b/tests/Features/Expect/toBeGreatherThan.php
@@ -7,6 +7,15 @@ test('passes', function () {
     expect(4)->toBeGreaterThan(3.9);
 });
 
+test('passes with DateTime and DateTimeImmutable', function () {
+    $now = new DateTime();
+    $past = (new DateTimeImmutable())->modify('-1 day');
+
+    expect($now)->toBeGreaterThan($past);
+
+    expect($past)->not->toBeGreaterThan($now);
+});
+
 test('failures', function () {
     expect(4)->toBeGreaterThan(4);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeGreatherThanOrEqual.php
+++ b/tests/Features/Expect/toBeGreatherThanOrEqual.php
@@ -7,6 +7,17 @@ test('passes', function () {
     expect(4)->toBeGreaterThanOrEqual(4);
 });
 
+test('passes with DateTime and DateTimeImmutable', function () {
+    $now = new DateTime();
+    $past = (new DateTimeImmutable())->modify('-1 day');
+
+    expect($now)->toBeGreaterThanOrEqual($now);
+
+    expect($now)->toBeGreaterThanOrEqual($past);
+
+    expect($past)->not->toBeGreaterThanOrEqual($now);
+});
+
 test('failures', function () {
     expect(4)->toBeGreaterThanOrEqual(4.1);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThan.php
+++ b/tests/Features/Expect/toBeLessThan.php
@@ -7,6 +7,15 @@ test('passes', function () {
     expect(4)->toBeLessThan(5);
 });
 
+test('passes with DateTime and DateTimeImmutable', function () {
+    $now = new DateTime();
+    $past = (new DateTimeImmutable())->modify('-1 day');
+
+    expect($past)->toBeLessThan($now);
+
+    expect($now)->not->toBeLessThan($now);
+});
+
 test('failures', function () {
     expect(4)->toBeLessThan(4);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThanOrEqual.php
+++ b/tests/Features/Expect/toBeLessThanOrEqual.php
@@ -7,6 +7,17 @@ test('passes', function () {
     expect(4)->toBeLessThanOrEqual(4);
 });
 
+test('passes with DateTime and DateTimeImmutable', function () {
+    $now = new DateTime();
+    $past = (new DateTimeImmutable())->modify('-1 day');
+
+    expect($now)->toBeLessThanOrEqual($now);
+
+    expect($past)->toBeLessThanOrEqual($now);
+
+    expect($now)->not->toBeLessThanOrEqual($past);
+});
+
 test('failures', function () {
     expect(4)->toBeLessThanOrEqual(3.9);
 })->throws(ExpectationFailedException::class);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -15,6 +15,6 @@ $run = function () {
 };
 
 test('parallel', function () use ($run) {
-    expect($run())->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 9 skipped, 640 passed (1576 assertions)')
+    expect($run())->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 9 skipped, 644 passed (1592 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skip(PHP_OS_FAMILY === 'Windows');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | https://github.com/pestphp/pest/issues/713

This PR adds `DateTime`and `DateTimeImmutable`to the following expectations:

- toBeGreaterThan
- toBeGreaterThanOrEqual
- toBeLessThan
- toBeLessThanOrEqual



