### PR TITLE
Fix multibyte character test names

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -61,7 +61,7 @@ final class Str
     {
         $code = self::PREFIX.str_replace(' ', '_', $code);
 
-        return (string) preg_replace('/[^A-Z_a-z0-9]/', '_', $code);
+        return (string) preg_replace('/[^A-Z_a-z一-龯ぁ-んァ-ン0-9]/', '_', $code);
     }
 
     /**

--- a/tests/Unit/Support/Str.php
+++ b/tests/Unit/Support/Str.php
@@ -10,4 +10,5 @@ it('evaluates the code', function ($evaluatable, $expected) {
     ['version()', '__pest_evaluable_version__'],
     ['version__ ', '__pest_evaluable_version___'],
     ['version\\', '__pest_evaluable_version_'],
+    ['ほげ', '__pest_evaluable_ほげ'],
 ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Fixed tickets | #714

In this PR I have fixed the bug when describing tests using multibyte characters.
