### PR TITLE
[2.x] Fix `--dirty` not working on Windows

### DIFF
--- a/src/TestCaseFilters/GitDirtyTestCaseFilter.php
+++ b/src/TestCaseFilters/GitDirtyTestCaseFilter.php
@@ -32,6 +32,7 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
         assert(is_array($this->changedFiles));
 
         $relativePath = str_replace($this->projectRoot, '', $testCaseFilename);
+        $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', $relativePath);
 
         if (str_starts_with($relativePath, '/')) {
             $relativePath = substr($relativePath, 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | 

Due to separators `Dirty Files Filter` can't detect changed files on `Windows`.
so In this PR I have fixed it by making sure separators are the same so changed files can be found.
