### PR TITLE
[2.x] Add `toContainOnly` into Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -837,6 +837,8 @@ final class Expectation
     }
 
     /**
+     * Asserts that contain only.
+     *
      * @return self<TValue>
      */
     public function toContainOnly(string $class, bool $isNativeType = null, string $message = ''): self

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -837,6 +837,20 @@ final class Expectation
     }
 
     /**
+     * @return self<TValue>
+     */
+    public function toContainOnly(string $class, bool $isNativeType = null, string $message = ''): self
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        Assert::assertContainsOnly($class, $this->value, $isNativeType, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that executing value throws an exception.
      *
      * @param (Closure(Throwable): mixed)|string $exception

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -841,13 +841,13 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toContainOnly(string $class, bool $isNativeType = null, string $message = ''): self
+    public function toContainOnly(string $type, bool $isNativeType = null, string $message = ''): self
     {
         if (! is_iterable($this->value)) {
             InvalidExpectationValue::expected('iterable');
         }
 
-        Assert::assertContainsOnly($class, $this->value, $isNativeType, $message);
+        Assert::assertContainsOnly($type, $this->value, $isNativeType, $message);
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

If approved, I add related tests.

```php
except(['1', '2', 'milwad'])->toContainOnly('string'); // pass
except(['1', 2, 'milwad'])->toContainOnly('string'); // fail
```
