### PR TITLE
[chore] Remove dataset name from DatasetArgsCountMismatch

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -241,7 +241,7 @@ trait Testable
                     continue;
                 }
 
-                if (in_array($testParameterTypes[$argumentIndex], [\Closure::class, 'callable', 'mixed'])) {
+                if (in_array($testParameterTypes[$argumentIndex], [Closure::class, 'callable', 'mixed'])) {
                     continue;
                 }
 
@@ -255,7 +255,7 @@ trait Testable
             return $arguments;
         }
 
-        if (in_array($testParameterTypes[0], [\Closure::class, 'callable'])) {
+        if (in_array($testParameterTypes[0], [Closure::class, 'callable'])) {
             return $arguments;
         }
 
@@ -291,7 +291,7 @@ trait Testable
             return;
         }
 
-        throw new DatasetArgsCountMismatch($this->dataName(), $requiredParametersCount, $suppliedParametersCount);
+        throw new DatasetArgsCountMismatch($requiredParametersCount, $suppliedParametersCount);
     }
 
     /**

--- a/src/Exceptions/DatasetArgsCountMismatch.php
+++ b/src/Exceptions/DatasetArgsCountMismatch.php
@@ -8,8 +8,8 @@ use Exception;
 
 final class DatasetArgsCountMismatch extends Exception
 {
-    public function __construct(string $dataName, int $requiredCount, int $suppliedCount)
+    public function __construct(int $requiredCount, int $suppliedCount)
     {
-        parent::__construct(sprintf('Test expects %d arguments but dataset [%s] only provides %d', $requiredCount, $dataName, $suppliedCount));
+        parent::__construct(sprintf('Test expects %d arguments but dataset only provides %d', $requiredCount, $suppliedCount));
     }
 }


### PR DESCRIPTION
@nunomaduro I feel that the dataset argument count mismatch error message may be too long for not-named complex datasets

Maybe we could remove it, as the dataset should be stated at the top of the failure message

before:

![image](https://user-images.githubusercontent.com/8792274/227478420-4fd0f0ae-d9da-45b5-a29a-69564ea6a83b.png)

after:

![image](https://user-images.githubusercontent.com/8792274/227478344-2c123fb2-e704-4a5a-9620-ac476e0ca93d.png)
