### PR TITLE
fix: resolve type hint for iterables

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -100,7 +100,7 @@ final class TestCall
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *
-     * @param  array<\Closure|iterable<int|string, mixed>|string>  $data
+     * @param  iterable<\Closure|iterable<int|string, mixed>|string>  $data
      */
     public function with(Closure|iterable|string ...$data): self
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

It seems like PHPStan now complains when you pass in a generator (e.g. like on our [Graphlint](https://github.com/worksome/graphlint/actions/runs/4492231610/jobs/7901834507?pr=30) package), this resolves the issue by type hinting as `iterable`. 