### PR TITLE
Inconsistency in spelling of "dataset"

### DIFF
--- a/overrides/Runner/Filter/NameFilterIterator.php
+++ b/overrides/Runner/Filter/NameFilterIterator.php
@@ -107,7 +107,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
             if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
                 if (isset($matches[3]) && $matches[2] < $matches[3]) {
                     $filter = sprintf(
-                        '%s.*with data set #(\d+)$',
+                        '%s.*with dataset #(\d+)$',
                         $matches[1]
                     );
 
@@ -115,7 +115,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
                     $this->filterMax = (int) $matches[3];
                 } else {
                     $filter = sprintf(
-                        '%s.*with data set #%s$',
+                        '%s.*with dataset #%s$',
                         $matches[1],
                         $matches[2]
                     );
@@ -125,7 +125,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
             //  * testDetermineJsonError@JSON.*
             elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
                 $filter = sprintf(
-                    '%s.*with data set "%s"$',
+                    '%s.*with dataset "%s"$',
                     $matches[1],
                     $matches[2]
                 );

--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -235,6 +235,6 @@ final class DatasetsRepository
             return sprintf('(%s)', $exporter->shortenedRecursiveExport($data));
         }
 
-        return sprintf('data set "%s"', $key);
+        return sprintf('dataset "%s"', $key);
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -60,8 +60,8 @@
   ✓ eager wrapped registered datasets with (1)
   ✓ eager wrapped registered datasets with (2)
   ✓ eager registered wrapped datasets did the job right
-  ✓ named datasets with data set "one"
-  ✓ named datasets with data set "two"
+  ✓ named datasets with dataset "one"
+  ✓ named datasets with dataset "two"
   ✓ named datasets did the job right
   ✓ lazy named datasets with (Bar Object (…))
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
@@ -96,10 +96,10 @@
   ✓ eager wrapped registered multiple datasets with (2) / (1)
   ✓ eager wrapped registered multiple datasets with (2) / (2)
   ✓ eager wrapped registered multiple datasets did the job right
-  ✓ named multiple datasets with data set "one" / data set "three"
-  ✓ named multiple datasets with data set "one" / data set "four"
-  ✓ named multiple datasets with data set "two" / data set "three"
-  ✓ named multiple datasets with data set "two" / data set "four"
+  ✓ named multiple datasets with dataset "one" / dataset "three"
+  ✓ named multiple datasets with dataset "one" / dataset "four"
+  ✓ named multiple datasets with dataset "two" / dataset "three"
+  ✓ named multiple datasets with dataset "two" / dataset "four"
   ✓ named multiple datasets did the job right
   ✓ more than two datasets with (1) / (3) / (5)
   ✓ more than two datasets with (1) / (3) / (6)
@@ -115,8 +115,8 @@
   ✓ eager registered wrapped datasets with Generator functions with (3)
   ✓ eager registered wrapped datasets with Generator functions with (4)
   ✓ eager registered wrapped datasets with Generator functions did the job right
-  ✓ eager registered wrapped datasets with Generator functions display description with data set "taylor"
-  ✓ eager registered wrapped datasets with Generator functions display description with data set "james"
+  ✓ eager registered wrapped datasets with Generator functions display description with dataset "taylor"
+  ✓ eager registered wrapped datasets with Generator functions display description with dataset "james"
   ✓ it can resolve a dataset after the test case is available with (Closure Object (…)) #1
   ✓ it can resolve a dataset after the test case is available with (Closure Object (…)) #2
   ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure Object (…)) / (Closure Object (…)) #1

--- a/tests/Unit/DatasetsTests.php
+++ b/tests/Unit/DatasetsTests.php
@@ -10,8 +10,8 @@ it('show only the names of named datasets in their description', function () {
         ],
     ], __FILE__));
 
-    expect($descriptions[0])->toBe('data set "one"')
-        ->and($descriptions[1])->toBe('data set "two"');
+    expect($descriptions[0])->toBe('dataset "one"')
+        ->and($descriptions[1])->toBe('dataset "two"');
 });
 
 it('show the actual dataset of non-named datasets in their description', function () {
@@ -38,10 +38,10 @@ it('show only the names of multiple named datasets in their description', functi
         ],
     ], __FILE__));
 
-    expect($descriptions[0])->toBe('data set "one" / data set "three"');
-    expect($descriptions[1])->toBe('data set "one" / data set "four"');
-    expect($descriptions[2])->toBe('data set "two" / data set "three"');
-    expect($descriptions[3])->toBe('data set "two" / data set "four"');
+    expect($descriptions[0])->toBe('dataset "one" / dataset "three"');
+    expect($descriptions[1])->toBe('dataset "one" / dataset "four"');
+    expect($descriptions[2])->toBe('dataset "two" / dataset "three"');
+    expect($descriptions[3])->toBe('dataset "two" / dataset "four"');
 });
 
 it('show the actual dataset of multiple non-named datasets in their description', function () {
@@ -74,10 +74,10 @@ it('show the correct description for mixed named and not-named datasets', functi
         ],
     ], __FILE__));
 
-    expect($descriptions[0])->toBe('data set "one" / (3)');
-    expect($descriptions[1])->toBe('data set "one" / data set "four"');
+    expect($descriptions[0])->toBe('dataset "one" / (3)');
+    expect($descriptions[1])->toBe('dataset "one" / dataset "four"');
     expect($descriptions[2])->toBe('([2]) / (3)');
-    expect($descriptions[3])->toBe('([2]) / data set "four"');
+    expect($descriptions[3])->toBe('([2]) / dataset "four"');
 });
 
 it('shows the correct description for long texts with newlines', function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | 

This PR proposes to alter "data set" to "dataset" in test descriptions.

It seems the most often used spelling is "dataset". 

However, in the tests description and in an Exception, it is spelled "data set".

<img width="254" alt="CleanShot 2023-03-24 at 16 08 54@2x" src="https://user-images.githubusercontent.com/79267265/227564213-826fbc42-23a3-486b-9163-f94286e9809a.png">

Below, we have both cases in one sentence.

<img width="479" alt="CleanShot 2023-03-24 at 16 14 59@2x" src="https://user-images.githubusercontent.com/79267265/227566389-ed9533cb-319e-4129-bca8-099f00830689.png">


**Consistent usage**

Documentation: https://pestphp.com/docs/datasets

Docblock:

```php
    /**
     * Ensures dataset items count matches underlying test case required parameters
     * ...
     */
```


