### PR TITLE
[2.x] Run scheduled workflows only on origin repo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   ci:
+    if: github.event_name != 'schedule' || github.repository == 'pestphp/pest'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   static:
+    if: github.event_name != 'schedule' || github.repository == 'pestphp/pest'
     name: Static Tests
 
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   ci:
+    if: github.event_name != 'schedule' || github.repository == 'pestphp/pest'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
After merging this PR, scheduled workflows are going to be triggered only on `pestphp/pest` repository.
