### PR TITLE
[2.x] Adds `uses()` hint

### DIFF
--- a/src/Support/ExceptionTrace.php
+++ b/src/Support/ExceptionTrace.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Support;
 
 use Closure;
+use PHPUnit\Framework\TestCase;
 use Throwable;
 
 /**
@@ -15,8 +16,7 @@ final class ExceptionTrace
     private const UNDEFINED_METHOD = 'Call to undefined method P\\';
 
     /**
-     * Ensures the given closure reports
-     * the good execution context.
+     * Ensures the given closure reports the good execution context.
      *
      * @return mixed
      *
@@ -28,7 +28,13 @@ final class ExceptionTrace
             return $closure();
         } catch (Throwable $throwable) {
             if (Str::startsWith($message = $throwable->getMessage(), self::UNDEFINED_METHOD)) {
+                $class = preg_match('/^Call to undefined method ([^:]+)::/', $message, $matches) === false ? null : $matches[1];
+
                 $message = str_replace(self::UNDEFINED_METHOD, 'Call to undefined method ', $message);
+
+                if (class_exists($class) && count(class_parents($class)) > 0 && array_values(class_parents($class))[0] === TestCase::class) {
+                    $message .= '. Did you forget to use the [uses()] function? https://pestphp.com/docs/configuring-tests';
+                }
 
                 Reflection::setPropertyValue($throwable, 'message', $message);
             }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -903,6 +903,10 @@
   ✓ it computes the dataset scope with ('/var/www/project/tests/Featur…rs.php', '/var/www/project/tests/Featur…rs.php') #2
   ✓ it computes the dataset scope with ('/var/www/project/tests/Featur…ts.php', '/var/www/project/tests/Featur…ollers')
 
+   PASS  Tests\Unit\Support\ExceptionTrace
+  ✓ it ensures the given closures reports the correct class name
+  ✓ it ensures the given closures reports the correct class name and suggests the [uses()] function
+
    PASS  Tests\Unit\Support\Reflection
   ✓ it gets file name from closure
   ✓ it gets property values
@@ -1004,4 +1008,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 703 passed (1702 assertions)
+  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 705 passed (1706 assertions)

--- a/tests/Unit/Support/ExceptionTrace.php
+++ b/tests/Unit/Support/ExceptionTrace.php
@@ -1,0 +1,21 @@
+<?php
+
+use Pest\Support\ExceptionTrace;
+
+it('ensures the given closures reports the correct class name', function () {
+    $closure = function () {
+        throw new Exception('Call to undefined method P\Tests\IntentionallyNotExisting::testBasic().');
+    };
+
+    ExceptionTrace::ensure($closure);
+})->throws(
+    Exception::class,
+    'Call to undefined method Tests\IntentionallyNotExisting::testBasic().',
+);
+
+it('ensures the given closures reports the correct class name and suggests the [uses()] function', function () {
+    $this->get();
+})->throws(
+    Error::class,
+    'Call to undefined method Tests\Unit\Support\ExceptionTrace::get(). Did you forget to use the [uses()] function? https://pestphp.com/docs/configuring-tests',
+);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -15,6 +15,6 @@ $run = function () {
 };
 
 test('parallel', function () use ($run) {
-    expect($run())->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 692 passed (1688 assertions)')
+    expect($run())->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 694 passed (1692 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skip(PHP_OS_FAMILY === 'Windows');


### PR DESCRIPTION
This pull request hints the user that he may have forgot to configure the `uses()` function.

<img width="1072" alt="Screenshot 2023-03-28 at 01 48 16" src="https://user-images.githubusercontent.com/5457236/228098330-02fd2938-efef-48d6-8949-d469019df336.png">
