### PR TITLE
teamcity: add missing test count output

### DIFF
--- a/src/Logging/TeamCity/Converter.php
+++ b/src/Logging/TeamCity/Converter.php
@@ -167,6 +167,14 @@ final class Converter
     }
 
     /**
+     * Gets the test suite size.
+     */
+    public function getTestSuiteSize(TestSuite $testSuite): int
+    {
+        return $testSuite->count();
+    }
+
+    /**
      * Transforms the given path in relative path.
      */
     private function toRelativePath(string $path): string

--- a/src/Logging/TeamCity/ServiceMessage.php
+++ b/src/Logging/TeamCity/ServiceMessage.php
@@ -40,6 +40,13 @@ final class ServiceMessage
         ]);
     }
 
+    public static function testSuiteCount(int $count): self
+    {
+        return new self('testCount', [
+            'count' => $count,
+        ]);
+    }
+
     public static function testSuiteFinished(string $name): self
     {
         return new self('testSuiteFinished', [

--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -44,6 +44,8 @@ final class TeamCityLogger
 {
     private ?HRTime $time = null;
 
+    private bool $isSummaryTestCountPrinted = false;
+
     /**
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
@@ -66,6 +68,15 @@ final class TeamCityLogger
         );
 
         $this->output($message);
+
+        if (! $this->isSummaryTestCountPrinted) {
+            $this->isSummaryTestCountPrinted = true;
+            $message = ServiceMessage::testSuiteCount(
+                $this->converter->getTestSuiteSize($event->testSuite())
+            );
+
+            $this->output($message);
+        }
     }
 
     public function testSuiteFinished(TestSuiteFinished $event): void

--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -1,4 +1,5 @@
 ##teamcity[testSuiteStarted name='Tests/tests/Failure' locationHint='file://tests/.tests/Failure.php' flowId='1234']
+##teamcity[testCount count='6' flowId='1234']
 ##teamcity[testStarted name='it can fail with comparison' locationHint='pest_qn://tests/.tests/Failure.php::it can fail with comparison' flowId='1234']
 ##teamcity[testFailed name='it can fail with comparison' message='Failed asserting that true matches expected false.' details='at src/Mixins/Expectation.php:343|nat src/Support/ExpectationPipeline.php:75|nat src/Support/ExpectationPipeline.php:79|nat src/Expectation.php:300|nat tests/.tests/Failure.php:6|nat src/Factories/TestCaseMethodFactory.php:100|nat src/Concerns/Testable.php:302|nat src/Support/ExceptionTrace.php:28|nat src/Concerns/Testable.php:302|nat src/Concerns/Testable.php:221|nat src/Kernel.php:86' type='comparisonFailure' actual='true' expected='false' flowId='1234']
 ##teamcity[testFinished name='it can fail with comparison' duration='100000' flowId='1234']

--- a/tests/.snapshots/SuccessOnly.php.inc
+++ b/tests/.snapshots/SuccessOnly.php.inc
@@ -1,4 +1,5 @@
 ##teamcity[testSuiteStarted name='Tests/tests/SuccessOnly' locationHint='file://tests/.tests/SuccessOnly.php' flowId='1234']
+##teamcity[testCount count='2' flowId='1234']
 ##teamcity[testStarted name='it can pass with comparison' locationHint='pest_qn://tests/.tests/SuccessOnly.php::it can pass with comparison' flowId='1234']
 ##teamcity[testFinished name='it can pass with comparison' duration='100000' flowId='1234']
 ##teamcity[testStarted name='can also pass' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can also pass' flowId='1234']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #717

This PR (re)adds the missing test count line in the teamcity output.
