### PR TITLE
[2.x] fix: tests in Helpers directory are not executed

### DIFF
--- a/src/Support/Backtrace.php
+++ b/src/Support/Backtrace.php
@@ -30,7 +30,10 @@ final class Backtrace
 
             $traceFile = str_replace(DIRECTORY_SEPARATOR, '/', $trace[self::FILE]);
 
-            if (Str::endsWith($traceFile, 'overrides/Runner/TestSuiteLoader.php')) {
+            if (
+                Str::endsWith($traceFile, 'overrides/Runner/TestSuiteLoader.php') ||
+                Str::endsWith($traceFile, 'src/Bootstrappers/BootFiles.php')
+            ) {
                 break;
             }
 

--- a/tests/.snapshots/collision-parallel.txt
+++ b/tests/.snapshots/collision-parallel.txt
@@ -1,5 +1,5 @@
 
-  ⨯.
+  .⨯.
   ────────────────────────────────────────────────────────────────────────────  
    FAILED  Tests\Fixtures\CollisionTest > error                     Exception   
   error
@@ -19,4 +19,4 @@
   2   src/Factories/TestCaseMethodFactory.php:100
 
 
-  Tests:    1 failed, 1 passed (1 assertions)
+  Tests:    1 failed, 2 passed (2 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -673,6 +673,7 @@
   ✓ it throws error if method do not exist
   ✓ it can forward unexpected calls to any global function
   ✓ it can use helpers from helpers file
+  ✓ it can use helpers from helpers directory
 
    PASS  Tests\Features\HigherOrderTests
   ✓ it proxies calls to object
@@ -788,6 +789,9 @@
 
    PASS  Tests\Fixtures\ExampleTest
   ✓ it example 2
+
+   PASS  Tests\Helpers\TestInHelpers
+  ✓ it executes tests in the Helpers directory
 
    PASS  Tests\Hooks\AfterAllTest
   ✓ global afterAll execution order
@@ -1009,4 +1013,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 706 passed (1707 assertions)
+  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 708 passed (1709 assertions)

--- a/tests/Features/Helpers.php
+++ b/tests/Features/Helpers.php
@@ -44,3 +44,5 @@ it('throws error if method do not exist', function () {
 it('can forward unexpected calls to any global function')->_assertThat();
 
 it('can use helpers from helpers file')->myAssertTrue(true);
+
+it('can use helpers from helpers directory')->myDirectoryAssertTrue(true);

--- a/tests/Helpers/Helper.php
+++ b/tests/Helpers/Helper.php
@@ -1,0 +1,6 @@
+<?php
+
+function myDirectoryAssertTrue($value)
+{
+    test()->assertTrue($value);
+}

--- a/tests/Helpers/TestInHelpers.php
+++ b/tests/Helpers/TestInHelpers.php
@@ -1,0 +1,5 @@
+<?php
+
+it('executes tests in the Helpers directory', function () {
+    expect(true)->toBeTrue();
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -18,10 +18,10 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 694 passed (1692 assertions)')
+        ->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 696 passed (1694 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skip(PHP_OS_FAMILY === 'Windows');
 
 test('a parallel test can extend another test with same name', function () use ($run) {
-    expect($run('tests/Fixtures/Inheritance'))->toContain('Tests:    1 skipped, 1 passed (1 assertions)');
+    expect($run('tests/Fixtures/Inheritance'))->toContain('Tests:    1 skipped, 2 passed (2 assertions)');
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #752 

This PR allows to have tests in the "Helpers" directory.

The reason the tests are not executed is because all PHP files in the "Helpers" directory are loaded before building the test suite.
In this case they have a different backtrace which does not contain "overrides/Runner/TestSuiteLoader.php". Therefore I have extended the "Backtrace" class with an additional path to check for: "src/Bootstrappers/BootFiles.php"

Additionally I've added two new tests:

- `it executes tests in the Helpers directory` in "tests/Helpers/TestInHelpers.php" to ensure tests in the "Helpers" directory are executed.
- `it can use helpers from helpers directory` in "tests/Features/Helpers.php" to ensure the helpers still work (before there was no test covering this feature)



