### PR TITLE
[2.x] Collision custom editor support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1.0",
         "brianium/paratest": "^7.1.2",
-        "nunomaduro/collision": "^7.3.3",
+        "nunomaduro/collision": "^v7.x-dev",
         "nunomaduro/termwind": "^1.15.1",
         "pestphp/pest-plugin": "^2.0.0",
         "pestphp/pest-plugin-arch": "^2.0.1",

--- a/overrides/Event/Value/ThrowableBuilder.php
+++ b/overrides/Event/Value/ThrowableBuilder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *
@@ -7,9 +9,10 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace PHPUnit\Event\Code;
 
-use NunoMaduro\Collision\Contracts\CustomEditor;
+use NunoMaduro\Collision\Contracts\RenderableOnCollisionEditor;
 use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Util\Filter;
@@ -34,8 +37,7 @@ final class ThrowableBuilder
 
         $trace = Filter::getFilteredStacktrace($t);
 
-        if($t instanceof CustomEditor && $t->getCustomEditorFrame()){
-            $frame = $t->getCustomEditorFrame();
+        if ($t instanceof RenderableOnCollisionEditor && $frame = $t->toCollisionEditor()) {
             $file = $frame->getFile();
             $line = $frame->getLine();
 

--- a/overrides/Event/Value/ThrowableBuilder.php
+++ b/overrides/Event/Value/ThrowableBuilder.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Code;
+
+use NunoMaduro\Collision\Contracts\CustomEditor;
+use PHPUnit\Event\NoPreviousThrowableException;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Util\Filter;
+use PHPUnit\Util\ThrowableToStringMapper;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ThrowableBuilder
+{
+    /**
+     * @throws Exception
+     * @throws NoPreviousThrowableException
+     */
+    public static function from(\Throwable $t): Throwable
+    {
+        $previous = $t->getPrevious();
+
+        if ($previous !== null) {
+            $previous = self::from($previous);
+        }
+
+        $trace = Filter::getFilteredStacktrace($t);
+
+        if($t instanceof CustomEditor && $t->getCustomEditorFrame()){
+            $frame = $t->getCustomEditorFrame();
+            $file = $frame->getFile();
+            $line = $frame->getLine();
+
+            $trace = "$file:$line\n$trace";
+        }
+
+        return new Throwable(
+            $t::class,
+            $t->getMessage(),
+            ThrowableToStringMapper::map($t),
+            $trace,
+            $previous
+        );
+    }
+}

--- a/src/Bootstrappers/BootOverrides.php
+++ b/src/Bootstrappers/BootOverrides.php
@@ -24,6 +24,7 @@ final class BootOverrides implements Bootstrapper
         'TextUI/Command/WarmCodeCoverageCacheCommand.php',
         'TextUI/Output/Default/ProgressPrinter/TestSkippedSubscriber.php',
         'TextUI/TestSuiteFilterProcessor.php',
+        'Event/Value/ThrowableBuilder.php',
     ];
 
     /**

--- a/tests/Unit/Overrides/ThrowableBuilder.php
+++ b/tests/Unit/Overrides/ThrowableBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+use NunoMaduro\Collision\Contracts\RenderableOnCollisionEditor;
+use PHPUnit\Event\Code\ThrowableBuilder;
+use Whoops\Exception\Frame;
+
+test('collision editor can be added to the stack trace', function () {
+    $exception = new class extends Exception implements RenderableOnCollisionEditor
+    {
+        public function __construct()
+        {
+            parent::__construct('test exception');
+        }
+
+        public function toCollisionEditor(): Frame
+        {
+            return new Frame([
+                'file' => __DIR__.'/../../Pest.php',
+                'line' => 5,
+            ]);
+        }
+    };
+
+    expect(ThrowableBuilder::from($exception))
+        ->stackTrace()->toStartWith('/data/projects/open-source/pest/tests/Unit/Overrides/../../Pest.php:5')
+        ->and(ThrowableBuilder::from(new Exception('test')))
+        ->stackTrace()->toStartWith('/data/projects/open-source/pest/tests/Unit/Overrides/ThrowableBuilder.php:26');
+
+});

--- a/tests/Unit/Overrides/ThrowableBuilder.php
+++ b/tests/Unit/Overrides/ThrowableBuilder.php
@@ -25,5 +25,4 @@ test('collision editor can be added to the stack trace', function () {
         ->stackTrace()->toStartWith('/data/projects/open-source/pest/tests/Unit/Overrides/../../Pest.php:5')
         ->and(ThrowableBuilder::from(new Exception('test')))
         ->stackTrace()->toStartWith('/data/projects/open-source/pest/tests/Unit/Overrides/ThrowableBuilder.php:26');
-
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes

This PR follows https://github.com/nunomaduro/collision/pull/266 and changes in https://github.com/nunomaduro/collision/commit/932776f1f214616aed073b814ea10e03e7f4953c by adding support for RenderableOnCollisionEditor exception in Pest

as all Pest exceptions are packed by PHPUnit\Event\Code\ThrowableBuilder inside a Throwable, the ThrowableBuilder is overridden in order to add the editor path and line to the Throwable `trace`

this will allow collision to render the right editor

**note before merging**

as collision changes are not released yet, I changed the requirement to `nunomaduro/collision": "^v7.x-dev` in order to let the tests run. It must be updated to the next release of collision before merging
