### PR TITLE
[2.x] Adds `skipOnWindows()`, `skipOnMac()`, and `skipOnLinux()` 

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -184,6 +184,8 @@ final class TestCall
                 );
             }
         }
+
+        return $this;
     }
 
     /**

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -175,12 +175,15 @@ final class TestCall
     /**
      * Skips the current test if the given test is running on given os family.
      */
-    public function skipOsFamily(string $osFamily): self
+    public function skipOsFamily(string ...$osFamilies): self
     {
-        return $this->skip(
-            PHP_OS_FAMILY === $osFamily,
-            "This test is skipped on $osFamily.",
-        );
+        foreach ($osFamilies as $osFamily) {
+            if (PHP_OS_FAMILY === $osFamily) {
+                return $this->skip(
+                    "This test is skipped on $osFamily.",
+                );
+            }
+        }
     }
 
     /**

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -173,6 +173,17 @@ final class TestCall
     }
 
     /**
+     * Skips the current test if the given test is running on Windows.
+     */
+    public function skipOnWindows(): self
+    {
+        return $this->skip(
+            PHP_OS_FAMILY === 'Windows',
+            'This test is skipped on Windows.',
+        );
+    }
+
+    /**
      * Sets the test as "todo".
      */
     public function todo(): self

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -173,27 +173,37 @@ final class TestCall
     }
 
     /**
-     * Skips the current test if the given test is running on given os family.
-     */
-    public function skipOsFamily(string ...$osFamilies): self
-    {
-        foreach ($osFamilies as $osFamily) {
-            if (PHP_OS_FAMILY === $osFamily) {
-                return $this->skip(
-                    "This test is skipped on $osFamily.",
-                );
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Skips the current test if the given test is running on Windows.
      */
     public function skipOnWindows(): self
     {
-        return $this->skipOsFamily('Windows');
+        return $this->skipOn('Windows', 'This test is skipped on [Windows].');
+    }
+
+    /**
+     * Skips the current test if the given test is running on Mac OS.
+     */
+    public function skipOnMac(): self
+    {
+        return $this->skipOn('Darwin', 'This test is skipped on [Mac].');
+    }
+
+    /**
+     * Skips the current test if the given test is running on Linux.
+     */
+    public function skipOnLinux(): self
+    {
+        return $this->skipOn('Linux', 'This test is skipped on [Linux].');
+    }
+
+    /**
+     * Skips the current test if the given test is running on the given operating systems.
+     */
+    private function skipOn(string $osFamily, string $message): self
+    {
+        return PHP_OS_FAMILY === $osFamily
+            ? $this->skip($message)
+            : $this;
     }
 
     /**

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -173,14 +173,22 @@ final class TestCall
     }
 
     /**
+     * Skips the current test if the given test is running on given os family.
+     */
+    public function skipOsFamily(string $osFamily): self
+    {
+        return $this->skip(
+            PHP_OS_FAMILY === $osFamily,
+            "This test is skipped on $osFamily.",
+        );
+    }
+
+    /**
      * Skips the current test if the given test is running on Windows.
      */
     public function skipOnWindows(): self
     {
-        return $this->skip(
-            PHP_OS_FAMILY === 'Windows',
-            'This test is skipped on Windows.',
-        );
+        return $this->skipOsFamily('Windows');
     }
 
     /**

--- a/tests/Visual/Collision.php
+++ b/tests/Visual/Collision.php
@@ -39,4 +39,4 @@ test('collision', function (array $arguments) {
 })->with([
     [['']],
     [['--parallel']],
-])->skip(PHP_OS_FAMILY === 'Windows');
+])->skipOnWindows();

--- a/tests/Visual/Help.php
+++ b/tests/Visual/Help.php
@@ -18,4 +18,4 @@ test('visual snapshot of help command output', function () {
     }
 
     expect($output())->toContain(file_get_contents($snapshot));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -20,7 +20,7 @@ test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
         ->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 697 passed (1696 assertions)')
         ->toContain('Parallel: 3 processes');
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();
 
 test('a parallel test can extend another test with same name', function () use ($run) {
     expect($run('tests/Fixtures/Inheritance'))->toContain('Tests:    1 skipped, 2 passed (2 assertions)');

--- a/tests/Visual/SingleTestOrDirectory.php
+++ b/tests/Visual/SingleTestOrDirectory.php
@@ -24,11 +24,11 @@ $snapshot = function ($name) {
 
 test('allows to run a single test', function () use ($run, $snapshot) {
     expect($run('tests/Fixtures/DirectoryWithTests/ExampleTest.php'))->toContain($snapshot('allows-to-run-a-single-test'));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();
 
 test('allows to run a directory', function () use ($run, $snapshot) {
     expect($run('tests/Fixtures'))->toContain($snapshot('allows-to-run-a-directory'));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();
 
 it('disable decorating printer when colors is set to never', function () use ($snapshot) {
     $process = new Process([
@@ -40,4 +40,4 @@ it('disable decorating printer when colors is set to never', function () use ($s
     $process->run();
     $output = $process->getOutput();
     expect($output)->toContain($snapshot('disable-decorating-printer'));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();

--- a/tests/Visual/Success.php
+++ b/tests/Visual/Success.php
@@ -41,4 +41,4 @@ test('visual snapshot of test suite on success', function () {
         expect(implode("\n", $output))->toContain(file_get_contents($snapshot));
     }
 })->skip(! getenv('REBUILD_SNAPSHOTS') && getenv('EXCLUDE'))
-    ->skip(PHP_OS_FAMILY === 'Windows');
+    ->skipOnWindows();

--- a/tests/Visual/Todo.php
+++ b/tests/Visual/Todo.php
@@ -26,8 +26,8 @@ $snapshot = function ($name) {
 
 test('todo', function () use ($run, $snapshot) {
     expect($run('--todos', false))->toContain($snapshot('todo'));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();
 
 test('todo in parallel', function () use ($run, $snapshot) {
     expect($run('--todos', true))->toContain($snapshot('todo'));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();

--- a/tests/Visual/Version.php
+++ b/tests/Visual/Version.php
@@ -18,4 +18,4 @@ test('visual snapshot of help command output', function () {
     }
 
     expect($output())->toContain(file_get_contents($snapshot));
-})->skip(PHP_OS_FAMILY === 'Windows');
+})->skipOnWindows();


### PR DESCRIPTION
The addition made in this pull request is the `skipOnWindows()`, `skipOnMac()`, and `skipOnLinux()` methods, which allows users to bypass a particular test no those environments.

```php
test('example', function () {
    expect(true)->toBeTrue();
})->skipOnWindows();
```

It's quite typical for open-source developers to have a specific group of tests that aren't compatible with Windows. Therefore, having this "skip" feature integrated into the core of the framework could prove to be beneficial.