### PR TITLE
Skip os families

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -184,6 +184,8 @@ final class TestCall
                 );
             }
         }
+
+        return $this;
     }
 
     /**

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -175,12 +175,15 @@ final class TestCall
     /**
      * Skips the current test if the given test is running on given os family.
      */
-    public function skipOsFamily(string $osFamily): self
+    public function skipOsFamily(string ...$osFamilies): self
     {
-        return $this->skip(
-            PHP_OS_FAMILY === $osFamily,
-            "This test is skipped on $osFamily.",
-        );
+        foreach ($osFamilies as $osFamily) {
+            if (PHP_OS_FAMILY === $osFamily) {
+                return $this->skip(
+                    "This test is skipped on $osFamily.",
+                );
+            }
+        }
     }
 
     /**

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -173,14 +173,22 @@ final class TestCall
     }
 
     /**
+     * Skips the current test if the given test is running on given os family.
+     */
+    public function skipOsFamily(string $osFamily): self
+    {
+        return $this->skip(
+            PHP_OS_FAMILY === $osFamily,
+            "This test is skipped on $osFamily.",
+        );
+    }
+
+    /**
      * Skips the current test if the given test is running on Windows.
      */
     public function skipOnWindows(): self
     {
-        return $this->skip(
-            PHP_OS_FAMILY === 'Windows',
-            'This test is skipped on Windows.',
-        );
+        return $this->skipOsFamily('Windows');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR adds ability to skip:

#### one os family
```php
test('test')->skipOsFamily('Windows');
```
#### multiple os families
```php
test('test')->skipOsFamily('Darwin', 'Windows');
```

