### PR TITLE
Add possibility to check property name and value with toHaveProperties

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -296,8 +296,8 @@ final class Expectation
      */
     public function toHaveProperties(iterable $names, string $message = ''): self
     {
-        foreach ($names as $name) {
-            $this->toHaveProperty($name, message: $message);
+        foreach ($names as $name => $value) {
+            is_int($name) ? $this->toHaveProperty($value, message: $message) : $this->toHaveProperty($name, $value, $message);
         }
 
         return $this;

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1016,4 +1016,4 @@
    PASS  Tests\Visual\Version
   ✓ visual snapshot of help command output
 
-  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 709 passed (1711 assertions)
+  Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 14 skipped, 709 passed (1717 assertions)

--- a/tests/Features/Expect/toHaveProperties.php
+++ b/tests/Features/Expect/toHaveProperties.php
@@ -4,30 +4,49 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
     $object = new stdClass();
-    $object->name = 'Jhon';
+    $object->name = 'John';
     $object->age = 21;
 
-    expect($object)->toHaveProperties(['name', 'age']);
+    expect($object)
+        ->toHaveProperties(['name', 'age'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
 });
 
 test('failures', function () {
     $object = new stdClass();
-    $object->name = 'Jhon';
+    $object->name = 'John';
 
-    expect($object)->toHaveProperties(['name', 'age']);
+    expect($object)
+        ->toHaveProperties(['name', 'age'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
 })->throws(ExpectationFailedException::class);
 
 test('failures with custom message', function () {
     $object = new stdClass();
-    $object->name = 'Jhon';
+    $object->name = 'John';
 
-    expect($object)->toHaveProperties(['name', 'age'], 'oh no!');
+    expect($object)
+        ->toHaveProperties(['name', 'age'], 'oh no!')
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ], 'oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
 
 test('not failures', function () {
     $object = new stdClass();
-    $object->name = 'Jhon';
+    $object->name = 'John';
     $object->age = 21;
 
-    expect($object)->not->toHaveProperties(['name', 'age']);
+    expect($object)->not->toHaveProperties(['name', 'age'])
+        ->not->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
 })->throws(ExpectationFailedException::class);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -18,7 +18,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 697 passed (1696 assertions)')
+        ->toContain('Tests:    2 deprecated, 3 warnings, 4 incomplete, 1 notice, 4 todos, 11 skipped, 697 passed (1702 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | no

This pull request proposes an enhancement to the existing code that deals with testing the presence and values of properties on an object. 

Currently, the `toHaveProperty()` and `toHaveProperties()` methods can be used to test for the existence of properties on an object. 

```php
expect($object)->toHaveProperty('name');
//or
expect($object)->toHaveProperties(['name', 'age']);
```

However, to check the value of a property, only `toHaveProperty()` is available. 

```php
expect($object)->toHaveProperty('name', 'Daniel San');
```

This PR adds the functionality of testing multiple properties and their values using the `toHaveProperties()` method using an associative array.

```php
expect($object)->toHaveProperties([
     'name' => 'Daniel San',
     'age' => 50,
]);
```