### PR TITLE
#785 Resolve typing error

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -387,7 +387,10 @@ final class Expectation
         return ToUseNothing::make($this);
     }
 
-    public function toBeUsed(): never
+    /**
+     * @return never
+     */
+    public function toBeUsed(): void
     {
         throw InvalidExpectation::fromMethods(['toBeUsed']);
     }


### PR DESCRIPTION
Resolves #785 A never-returning function must not return

This typing matches code at line 111:
```
    /**
     * Dump the expectation value and end the script.
     *
     * @return never
     */
    public function dd(mixed ...$arguments): void
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #785

I noticed there are more "never" return types that are causing issues, should this return type be used at all at this point?
<details>
  <summary>Git patch:</summary>

```
diff --git a/src/Exceptions/InvalidExpectation.php b/src/Exceptions/InvalidExpectation.php
index 544baac..9a8002c 100644
--- a/src/Exceptions/InvalidExpectation.php
+++ b/src/Exceptions/InvalidExpectation.php
@@ -19,7 +19,7 @@ final class InvalidExpectation extends LogicException implements ExceptionInterf
      *
      * @throws self
      */
-    public static function fromMethods(array $methods): never
+    public static function fromMethods(array $methods): void
     {
         throw new self(sprintf('Expectation [%s] is not valid.', implode('->', $methods)));
     }
diff --git a/src/Exceptions/InvalidExpectationValue.php b/src/Exceptions/InvalidExpectationValue.php
index 7a223f8..023718e 100644
--- a/src/Exceptions/InvalidExpectationValue.php
+++ b/src/Exceptions/InvalidExpectationValue.php
@@ -14,7 +14,7 @@ final class InvalidExpectationValue extends InvalidArgumentException
     /**
      * @throws self
      */
-    public static function expected(string $type): never
+    public static function expected(string $type): void
     {
         throw new self(sprintf('Invalid expectation value type. Expected [%s].', $type));
     }
diff --git a/src/Expectation.php b/src/Expectation.php
index 537883b..fe29e88 100644
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -387,7 +387,7 @@ final class Expectation
         return ToUseNothing::make($this);
     }
 
-    public function toBeUsed(): never
+    public function toBeUsed(): void
     {
         throw InvalidExpectation::fromMethods(['toBeUsed']);
     }
diff --git a/src/Expectations/OppositeExpectation.php b/src/Expectations/OppositeExpectation.php
index 327676d..54507e0 100644
--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -74,12 +74,12 @@ final class OppositeExpectation
     /**
      * @param  array<int, string>|string  $targets
      */
-    public function toOnlyUse(array|string $targets): never
+    public function toOnlyUse(array|string $targets): void
     {
         throw InvalidExpectation::fromMethods(['not', 'toOnlyUse']);
     }
 
-    public function toUseNothing(): never
+    public function toUseNothing(): void
     {
         throw InvalidExpectation::fromMethods(['not', 'toUseNothing']);
     }
@@ -104,7 +104,7 @@ final class OppositeExpectation
         ), is_string($targets) ? [$targets] : $targets));
     }
 
-    public function toOnlyBeUsedIn(): never
+    public function toOnlyBeUsedIn(): void
     {
         throw InvalidExpectation::fromMethods(['not', 'toOnlyBeUsedIn']);
     }
@@ -112,7 +112,7 @@ final class OppositeExpectation
     /**
      * Asserts that the given expectation dependency is not used.
      */
-    public function toBeUsedInNothing(): never
+    public function toBeUsedInNothing(): void
     {
         throw InvalidExpectation::fromMethods(['not', 'toBeUsedInNothing']);
     }
@@ -121,7 +121,7 @@ final class OppositeExpectation
      * Handle dynamic method calls into the original expectation.
      *
      * @param  array<int, mixed>  $arguments
-     * @return Expectation<TValue>|Expectation<mixed>|never
+     * @return Expectation<TValue>|Expectation<mixed>|void
      */
     public function __call(string $name, array $arguments): Expectation
     {
@@ -138,7 +138,7 @@ final class OppositeExpectation
     /**
      * Handle dynamic properties gets into the original expectation.
      *
-     * @return Expectation<TValue>|Expectation<mixed>|never
+     * @return Expectation<TValue>|Expectation<mixed>|void
      */
     public function __get(string $name): Expectation
     {
@@ -156,7 +156,7 @@ final class OppositeExpectation
      *
      * @param  array<int, mixed>|string  $arguments
      */
-    public function throwExpectationFailedException(string $name, array|string $arguments = []): never
+    public function throwExpectationFailedException(string $name, array|string $arguments = []): void
     {
         $arguments = is_array($arguments) ? $arguments : [$arguments];
 
diff --git a/src/Logging/TeamCity/TeamCityLogger.php b/src/Logging/TeamCity/TeamCityLogger.php
index f8c4d1a..f6c7fd0 100644
--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -101,7 +101,7 @@ final class TeamCityLogger
         $this->time = $event->telemetryInfo()->time();
     }
 
-    public function testMarkedIncomplete(MarkedIncomplete $event): never
+    public function testMarkedIncomplete(MarkedIncomplete $event): void
     {
         throw ShouldNotHappen::fromMessage('testMarkedIncomplete not implemented.');
     }
diff --git a/src/Panic.php b/src/Panic.php
index 6d6ae1f..1fed78c 100644
--- a/src/Panic.php
+++ b/src/Panic.php
@@ -25,7 +25,7 @@ final class Panic
     /**
      * Creates a new Panic instance, and exits the application.
      */
-    public static function with(Throwable $throwable): never
+    public static function with(Throwable $throwable): void
     {
         $panic = new self($throwable);
 
diff --git a/src/Repositories/DatasetsRepository.php b/src/Repositories/DatasetsRepository.php
index 07c4a42..e5018bb 100644
--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -66,7 +66,7 @@ final class DatasetsRepository
     }
 
     /**
-     * @return Closure|array<int|string, mixed>|never
+     * @return Closure|array<int|string, mixed>|void
      *
      * @throws ShouldNotHappen
      */
```
</details>