### PR TITLE
[2.x] allow to expect `toThrow` against an exception instance

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -842,7 +842,7 @@ final class Expectation
      * @param (Closure(Throwable): mixed)|string $exception
      * @return self<TValue>
      */
-    public function toThrow(callable|string $exception, string $exceptionMessage = null, string $message = ''): self
+    public function toThrow(callable|string|Throwable $exception, string $exceptionMessage = null, string $message = ''): self
     {
         $callback = NullClosure::create();
 
@@ -864,6 +864,15 @@ final class Expectation
         try {
             ($this->value)();
         } catch (Throwable $e) {
+
+            if ($exception instanceof Throwable) {
+                expect($e)
+                    ->toBeInstanceOf($exception::class, $message)
+                    ->and($e->getMessage())->toBe($exceptionMessage ?? $exception->getMessage(), $message);
+
+                return $this;
+            }
+
             if (! class_exists($exception)) {
                 if ($e instanceof Error && $e->getMessage() === "Class \"$exception\" not found") {
                     Assert::assertTrue(true);
@@ -888,7 +897,7 @@ final class Expectation
 
         Assert::assertTrue(true);
 
-        if (! class_exists($exception)) {
+        if (! $exception instanceof Throwable && ! class_exists($exception)) {
             throw new ExpectationFailedException("Exception with message \"$exception\" not thrown.");
         }
 

--- a/tests/Features/Expect/toThrow.php
+++ b/tests/Features/Expect/toThrow.php
@@ -2,6 +2,10 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
+class CustomException extends Exception
+{
+}
+
 test('passes', function () {
     expect(function () {
         throw new RuntimeException();
@@ -33,6 +37,9 @@ test('passes', function () {
         throw new RuntimeException('actual message');
     })->toThrow(function (RuntimeException $e) {
     }, 'actual message');
+    expect(function () {
+        throw new CustomException('foo');
+    })->toThrow(new CustomException('foo'));
 });
 
 test('failures 1', function () {
@@ -77,6 +84,12 @@ test('failures 7', function () {
     expect(function () {
         throw new RuntimeException('actual message');
     })->toThrow(RuntimeException::class, 'expected message');
+})->throws(ExpectationFailedException::class);
+
+test('failures 8', function () {
+    expect(function () {
+        throw new CustomException('actual message');
+    })->toThrow(new CustomException('expected message'));
 })->throws(ExpectationFailedException::class);
 
 test('failures with custom message', function () {


### PR DESCRIPTION
This PR implements Throwable support as argument of a `toThrow` expectation. This will allow to:

```php
expect(fn() => $user->subscribe($team))
        ->toThrow(new TeamException("user is already subscribed to team"));
```

in this case, the expectation will pass if the Throwable is an instance of `TeamException` and has `user is already subscribed to team` as exception message

this will allow a fast check when using static exception constructors like the following one, without the need to enter the code and check the exception message: 

```php
expect(fn() => $user->subscribe($team))
        ->toThrow(TeamException::alreadySubscribed());
```