### PR TITLE
Allow traits to be covered

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -227,7 +227,7 @@ final class TestCall
     public function covers(string ...$classesOrFunctions): self
     {
         foreach ($classesOrFunctions as $classOrFunction) {
-            $isClass = class_exists($classOrFunction);
+            $isClass = class_exists($classOrFunction) || trait_exists($classOrFunction);
             $isMethod = function_exists($classOrFunction);
 
             if (! $isClass && ! $isMethod) {

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Tests\Fixtures\Covers\CoversClass1;
 use Tests\Fixtures\Covers\CoversClass2;
 use Tests\Fixtures\Covers\CoversClass3;
+use Tests\Fixtures\Covers\CoversTrait;
 
 $runCounter = 0;
 
@@ -42,6 +43,13 @@ it('guesses if the given argument is a class or function', function () {
     expect($attributes[3]->getName())->toBe(CoversClass::class);
     expect($attributes[3]->getArguments()[0])->toBe(CoversClass3::class);
 })->covers(CoversClass3::class, 'testCoversFunction');
+
+it('uses the correct PHPUnit attribute for trait', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[4]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[4]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversTrait');
+})->coversClass(CoversTrait::class);
 
 it('appends CoversNothing to method attributes', function () {
     $phpDoc = (new ReflectionClass($this))->getMethod($this->name());

--- a/tests/Fixtures/Covers/CoversTrait.php
+++ b/tests/Fixtures/Covers/CoversTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Covers;
+
+trait CoversTrait
+{
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Fixed tickets | None

PHPUnit allows traits to be covered as [stated here](https://docs.phpunit.de/en/10.0/code-coverage.html) under _Class and Trait Coverage_. This PR adds in a test for traits and adds to coverage.