### PR TITLE
Adding ability to set @define-env annotation for Orchestra/Testbench

### DIFF
--- a/src/Factories/Annotations/Environment.php
+++ b/src/Factories/Annotations/Environment.php
@@ -8,11 +8,17 @@ use Pest\Contracts\AddsAnnotations;
 use Pest\Factories\Testbench\Environment as EnvironmentFactory;
 use Pest\Factories\TestCaseMethodFactory;
 
+/**
+ * @internal
+ */
 final class Environment implements AddsAnnotations
 {
+    /**
+     * {@inheritdoc}
+     */
     public function __invoke(TestCaseMethodFactory $method, array $annotations): array
     {
-        if(($method->environment[0] ?? null) instanceof EnvironmentFactory) {
+        if (($method->environment[0] ?? null) instanceof EnvironmentFactory) {
             $annotations[] = "@define-env {$method->environment[0]->name}";
         }
 

--- a/src/Factories/Annotations/Environment.php
+++ b/src/Factories/Annotations/Environment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Pest\Factories\Annotations;
+
+use Pest\Contracts\AddsAnnotations;
+use Pest\Factories\Testbench\Environment as EnvironmentFactory;
+use Pest\Factories\TestCaseMethodFactory;
+
+final class Environment implements AddsAnnotations
+{
+    public function __invoke(TestCaseMethodFactory $method, array $annotations): array
+    {
+        if(($method->environment[0] ?? null) instanceof EnvironmentFactory) {
+            $annotations[] = "@define-env {$method->environment[0]->name}";
+        }
+
+        return $annotations;
+    }
+}

--- a/src/Factories/Annotations/Environment.php
+++ b/src/Factories/Annotations/Environment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pest\Factories\Annotations;
 
 use Pest\Contracts\AddsAnnotations;

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -36,7 +36,7 @@ final class TestCaseFactory
         Annotations\Groups::class,
         Annotations\CoversNothing::class,
         Annotations\TestDox::class,
-        Annotations\Environment::class
+        Annotations\Environment::class,
     ];
 
     /**

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -36,6 +36,7 @@ final class TestCaseFactory
         Annotations\Groups::class,
         Annotations\CoversNothing::class,
         Annotations\TestDox::class,
+        Annotations\Environment::class
     ];
 
     /**

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -157,6 +157,11 @@ final class TestCaseMethodFactory
             static fn ($attribute): string => sprintf("\n        %s", $attribute), $attributes,
         ));
 
+        $define_env_method = '';
+        if ($this->environment !== []) {
+            $define_env_method = $this->buildDefineEnvForEvaluation($this->environment[0]->name, $methodName);
+        }
+
         return <<<PHP
 
                 /**$annotations
@@ -172,6 +177,7 @@ final class TestCaseMethodFactory
                     );
                 }
                 $datasetsCode
+                $define_env_method
             PHP;
     }
 
@@ -187,6 +193,23 @@ final class TestCaseMethodFactory
                 public static function $dataProviderName()
                 {
                     return __PestDatasets::get(self::\$__filename, "$methodName");
+                }
+
+        EOF;
+    }
+
+    /**
+     * Creates a DefineEnv method
+     */
+    private function buildDefineEnvForEvaluation(string $environmentMethodName, string $methodName): string
+    {
+        $m = $environmentMethodName.'_'.$methodName;
+
+        return <<<EOF
+
+                public function define_env_$m(\$app)
+                {
+                    $methodName(\$app);
                 }
 
         EOF;

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -57,6 +57,8 @@ final class TestCaseMethodFactory
 
     /**
      * The defined environment used with Testbench
+     *
+     * @var array<\Pest\Factories\Testbench\Environment>
      */
     public array $environment = [];
 

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -8,6 +8,7 @@ use Closure;
 use Pest\Contracts\AddsAnnotations;
 use Pest\Exceptions\ShouldNotHappen;
 use Pest\Factories\Concerns\HigherOrderable;
+use Pest\Factories\Testbench\Environment;
 use Pest\Repositories\DatasetsRepository;
 use Pest\Support\Str;
 use Pest\TestSuite;
@@ -53,6 +54,11 @@ final class TestCaseMethodFactory
      * @var array<int, \Pest\Factories\Covers\CoversClass|\Pest\Factories\Covers\CoversFunction|\Pest\Factories\Covers\CoversNothing>
      */
     public array $covers = [];
+
+    /**
+     * The defined environment used with Testbench
+     */
+    public array $environment = [];
 
     /**
      * Creates a new Factory instance.

--- a/src/Factories/Testbench/Environment.php
+++ b/src/Factories/Testbench/Environment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Pest\Factories\Testbench;
+
+final class Environment
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Factories/Testbench/Environment.php
+++ b/src/Factories/Testbench/Environment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pest\Factories\Testbench;
 
 final class Environment

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Pest\Factories\Covers\CoversClass;
 use Pest\Factories\Covers\CoversFunction;
 use Pest\Factories\Covers\CoversNothing;
+use Pest\Factories\Testbench\Environment;
 use Pest\Factories\TestCaseMethodFactory;
 use Pest\Plugins\Only;
 use Pest\Support\Backtrace;
@@ -286,6 +287,16 @@ final class TestCall
     public function throwsNoExceptions(): self
     {
         $this->testCaseMethod->proxies->add(Backtrace::file(), Backtrace::line(), 'expectNotToPerformAssertions', []);
+
+        return $this;
+    }
+
+    /**
+     * Sets an environment when using Orchestra Testbench
+     */
+    public function environment(string $name): self
+    {
+        $this->testCaseMethod->environment = [new Environment($name)];
 
         return $this;
     }

--- a/tests/Features/Testbench.php
+++ b/tests/Features/Testbench.php
@@ -1,0 +1,10 @@
+<?php
+
+function my_environment($app)
+{
+}
+
+test('it will add a define-env annotation', function() {
+    $phpDoc = (new ReflectionClass($this))->getMethod($this->name());
+    expect(str_contains($phpDoc->getDocComment(), '* @define-env my_environment'))->toBeTrue();
+})->environment('my_environment');

--- a/tests/Features/Testbench.php
+++ b/tests/Features/Testbench.php
@@ -4,7 +4,7 @@ function my_environment($app)
 {
 }
 
-test('it will add a define-env annotation', function() {
+test('it will add a define-env annotation', function () {
     $phpDoc = (new ReflectionClass($this))->getMethod($this->name());
     expect(str_contains($phpDoc->getDocComment(), '* @define-env my_environment'))->toBeTrue();
 })->environment('my_environment');

--- a/tests/Features/Testbench.php
+++ b/tests/Features/Testbench.php
@@ -8,3 +8,9 @@ test('it will add a define-env annotation', function () {
     $phpDoc = (new ReflectionClass($this))->getMethod($this->name());
     expect($phpDoc->getDocComment())->toContain('* @define-env my_environment');
 })->environment('my_environment');
+
+test('it will add the method', function () {
+    $methods = (new ReflectionClass($this))->getMethods();
+    //dump($methods);
+    expect(array_column($methods, 'name'))->toContain('define_env_my_environment___pest_evaluable_it_will_add_the_method');
+})->environment('my_environment');

--- a/tests/Features/Testbench.php
+++ b/tests/Features/Testbench.php
@@ -6,5 +6,5 @@ function my_environment($app)
 
 test('it will add a define-env annotation', function () {
     $phpDoc = (new ReflectionClass($this))->getMethod($this->name());
-    expect(str_contains($phpDoc->getDocComment(), '* @define-env my_environment'))->toBeTrue();
+    expect($phpDoc->getDocComment())->toContain('* @define-env my_environment');
 })->environment('my_environment');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR enables the ability to integrate Orchestra Testbench environment annotation @define-env. Usage as per test:

```php
function my_environment($app)
{
    //define environment
}

test('it will do soemthing', function() {
    
    //test

})->environment('my_environment');
```
I did look at doing this as a plugin but I'm not sure this is possible? If it is, please let me know and I will try and rework as such. If not, I can add the '@define-routes' annotation also in a future PR.
