### PR TITLE
fix teamcity output for tests throwing an exception before the first assertion

### DIFF
--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -1,5 +1,5 @@
 ##teamcity[testSuiteStarted name='Tests/tests/Failure' locationHint='file://tests/.tests/Failure.php' flowId='1234']
-##teamcity[testCount count='6' flowId='1234']
+##teamcity[testCount count='8' flowId='1234']
 ##teamcity[testStarted name='it can fail with comparison' locationHint='pest_qn://tests/.tests/Failure.php::it can fail with comparison' flowId='1234']
 ##teamcity[testFailed name='it can fail with comparison' message='Failed asserting that true matches expected false.' details='at src/Mixins/Expectation.php:343|nat src/Support/ExpectationPipeline.php:75|nat src/Support/ExpectationPipeline.php:79|nat src/Expectation.php:300|nat tests/.tests/Failure.php:6|nat src/Factories/TestCaseMethodFactory.php:100|nat src/Concerns/Testable.php:302|nat src/Support/ExceptionTrace.php:28|nat src/Concerns/Testable.php:302|nat src/Concerns/Testable.php:221|nat src/Kernel.php:86' type='comparisonFailure' actual='true' expected='false' flowId='1234']
 ##teamcity[testFinished name='it can fail with comparison' duration='100000' flowId='1234']
@@ -12,14 +12,19 @@
 ##teamcity[testStarted name='it can fail' locationHint='pest_qn://tests/.tests/Failure.php::it can fail' flowId='1234']
 ##teamcity[testFailed name='it can fail' message='oh noo' details='at tests/.tests/Failure.php:18|nat src/Factories/TestCaseMethodFactory.php:100|nat src/Concerns/Testable.php:302|nat src/Support/ExceptionTrace.php:28|nat src/Concerns/Testable.php:302|nat src/Concerns/Testable.php:221|nat src/Kernel.php:86' flowId='1234']
 ##teamcity[testFinished name='it can fail' duration='100000' flowId='1234']
+##teamcity[testStarted name='it throws exception' locationHint='pest_qn://tests/.tests/Failure.php::it throws exception' flowId='1234']
+##teamcity[testFailed name='it throws exception' message='Exception: test error' details='at tests/.tests/Failure.php:22|nat src/Factories/TestCaseMethodFactory.php:100|nat src/Concerns/Testable.php:302|nat src/Support/ExceptionTrace.php:28|nat src/Concerns/Testable.php:302|nat src/Concerns/Testable.php:221|nat src/Kernel.php:86' flowId='1234']
+##teamcity[testFinished name='it throws exception' duration='100000' flowId='1234']
 ##teamcity[testStarted name='it is not done yet' locationHint='pest_qn://tests/.tests/Failure.php::it is not done yet' flowId='1234']
 ##teamcity[testIgnored name='it is not done yet' message='This test was ignored.' details='' flowId='1234']
 ##teamcity[testFinished name='it is not done yet' duration='100000' flowId='1234']
 ##teamcity[testStarted name='build this one.' locationHint='pest_qn://tests/.tests/Failure.php::build this one.' flowId='1234']
 ##teamcity[testIgnored name='build this one.' message='This test was ignored.' details='' flowId='1234']
 ##teamcity[testFinished name='build this one.' duration='100000' flowId='1234']
+##teamcity[testStarted name='it is passing' locationHint='pest_qn://tests/.tests/Failure.php::it is passing' flowId='1234']
+##teamcity[testFinished name='it is passing' duration='100000' flowId='1234']
 ##teamcity[testSuiteFinished name='Tests/tests/Failure' flowId='1234']
 
-  [90mTests:[39m    [31;1m2 failed[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m (2 assertions)[39m
+  [90mTests:[39m    [31;1m3 failed[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m,[39m[39m [39m[32;1m1 passed[39;22m[90m (3 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m
 

--- a/tests/.tests/Failure.php
+++ b/tests/.tests/Failure.php
@@ -18,9 +18,17 @@ it('can fail', function () {
     $this->fail("oh noo");
 });
 
+it('throws exception', function () {
+    throw new Exception('test error');
+});
+
 it('is not done yet', function () {
 
 })->todo();
 
 todo("build this one.");
+
+it('is passing', function () {
+    expect(true)->toEqual(true);
+});
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #800 

This PR resolves the Teamcity output problem for tests throwing an exception before the first assertion.

Background:
With the latest version of PHPUnit (10.1.2) `PHPUnit\Event\Test\ConsideredRisky` events are triggered for tests throwing an exception before the first assertion. This lead to two errors with Teamcity fixed with this PR:
- Exception is not always visible in the output (overriden by the `risky test` warning)
- Number of successful tests is incorrect


