### PR TITLE
Add container registration for Kernel self

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -67,10 +67,14 @@ final class Kernel
 
         CallsBoot::execute();
 
-        return new self(
+        $kernel = new self(
             new Application(),
             $output,
         );
+
+        Container::getInstance()->add(self::class, $kernel);
+
+        return $kernel;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I hope to be able to access the `$kernel` object within the Plugin.

```php
class FooPlugin implements HandlesArguments
{
    public function handleArguments(array $arguments): array
    {
        $kernel = Container::getInstance()->get(Kernel::class);
        // do something
        exit($kernel->handle($arguments));
    }
}
```

https://github.com/friendsofhyperf/pest-plugin-hyperf/blob/63ab49219c81468a0f940deab233a1fab2f210f1/src/Plugin.php#L53-L76
