### PR TITLE
[2.x] Compact output when using datasets

### DIFF
--- a/src/Support/Exporter.php
+++ b/src/Support/Exporter.php
@@ -77,6 +77,12 @@ final class Exporter
      */
     public function shortenedExport(mixed $value): string
     {
-        return (string) preg_replace(['#\.{3}#', '#\\\n\s*#'], ['…'], $this->exporter->shortenedExport($value));
+        $map = [
+            '#\.{3}#' => '…',
+            '#\\\n\s*#' => '',
+            '# Object \(…\)#' => '',
+        ];
+
+        return (string) preg_replace(array_keys($map), array_values($map), $this->exporter->shortenedExport($value));
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -80,7 +80,7 @@
   ✓ named datasets with dataset "one"
   ✓ named datasets with dataset "two"
   ✓ named datasets did the job right
-  ✓ lazy named datasets with (Bar Object (…))
+  ✓ lazy named datasets with (Bar)
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #2
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), false)
@@ -134,24 +134,24 @@
   ✓ eager registered wrapped datasets with Generator functions did the job right
   ✓ eager registered wrapped datasets with Generator functions display description with dataset "taylor"
   ✓ eager registered wrapped datasets with Generator functions display description with dataset "james"
-  ✓ it can resolve a dataset after the test case is available with (Closure Object (…)) #1
-  ✓ it can resolve a dataset after the test case is available with (Closure Object (…)) #2
-  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure Object (…)) / (Closure Object (…)) #1
-  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure Object (…)) / (Closure Object (…)) #2
-  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure Object (…)) / (Closure Object (…)) #3
-  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure Object (…)) / (Closure Object (…)) #4
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (…)) #1
-  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure Object (…)) #2
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (…)) #1
-  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure Object (…)) #2
-  ✓ it resolves a potential bound dataset logically with ('foo', Closure Object (…))
-  ✓ it resolves a potential bound dataset logically even when the closure comes first with (Closure Object (…), 'bar')
-  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (…)) #1
-  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure Object (…)) #2
-  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (…)) #1
-  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure Object (…)) #2
-  ✓ it can correctly resolve a bound dataset that returns an array with (Closure Object (…))
-  ✓ it can correctly resolve a bound dataset that returns an array but wants to be spread with (Closure Object (…))
+  ✓ it can resolve a dataset after the test case is available with (Closure) #1
+  ✓ it can resolve a dataset after the test case is available with (Closure) #2
+  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure) / (Closure) #1
+  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure) / (Closure) #2
+  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure) / (Closure) #3
+  ✓ it can resolve a dataset after the test case is available with multiple datasets with (Closure) / (Closure) #4
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure) #1
+  ✓ it can resolve a dataset after the test case is available with shared yield sets with (Closure) #2
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure) #1
+  ✓ it can resolve a dataset after the test case is available with shared array sets with (Closure) #2
+  ✓ it resolves a potential bound dataset logically with ('foo', Closure)
+  ✓ it resolves a potential bound dataset logically even when the closure comes first with (Closure, 'bar')
+  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure) #1
+  ✓ it will not resolve a closure if it is type hinted as a closure with (Closure) #2
+  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure) #1
+  ✓ it will not resolve a closure if it is type hinted as a callable with (Closure) #2
+  ✓ it can correctly resolve a bound dataset that returns an array with (Closure)
+  ✓ it can correctly resolve a bound dataset that returns an array but wants to be spread with (Closure)
   ↓ forbids to define tests in Datasets dirs and Datasets.php files
 
    PASS  Tests\Features\Depends
@@ -586,7 +586,7 @@
   ✓ it passes with ('Fortaleza')
   ✓ it passes with ('Sollefteå')
   ✓ it passes with ('Ιεράπετρα')
-  ✓ it passes with (stdClass Object (…))
+  ✓ it passes with (stdClass)
   ✓ it passes with array
   ✓ it passes with *not*
   ✓ it properly fails with *not*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

Hello :) this PR redacts the object annotations to print a more compact output when using datasets.

Before:
```
PASS  Tests\Feature\SourcesTest
  ✓ it throws an exception when a JSON source is not supported                                                                                                             0.03s
  ✓ it throws an exception when Guzzle is required but not installed with (Mockery_0_Cerbero_JsonParser_Sources_Endpoint Object (…))
  ✓ it throws an exception when Guzzle is required but not installed with (Mockery_1_Cerbero_JsonParser_Sources_Psr7Request Object (…))
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\AnySource Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\CustomSource Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_4_Cerbero_JsonParser_Sources_Endpoint Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Filename Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\IterableSource Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Json Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\JsonResource Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_5_Cerbero_JsonParser_Sources_LaravelClientRequest Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\LaravelClientResponse Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Psr7Message Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_7_Cerbero_JsonParser_Sources_Psr7Request Object (…), 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Psr7Stream Object (…), 64, [1, '', 'foo', …])
```

After:
```
PASS  Tests\Feature\SourcesTest
  ✓ it throws an exception when a JSON source is not supported                                                                                                             0.03s
  ✓ it throws an exception when Guzzle is required but not installed with (Mockery_0_Cerbero_JsonParser_Sources_Endpoint)
  ✓ it throws an exception when Guzzle is required but not installed with (Mockery_1_Cerbero_JsonParser_Sources_Psr7Request)
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\AnySource, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\CustomSource, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_4_Cerbero_JsonParser_Sources_Endpoint, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Filename, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\IterableSource, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Json, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\JsonResource, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_5_Cerbero_JsonParser_Sources_LaravelClientRequest, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\LaravelClientResponse, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Psr7Message, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Mockery_7_Cerbero_JsonParser_Sources_Psr7Request, 64, [1, '', 'foo', …])
  ✓ it supports multiple sources with (Cerbero\JsonParser\Sources\Psr7Stream, 64, [1, '', 'foo', …])
```