### PR TITLE
[2.x] Make dataset method return values by name

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -57,10 +57,15 @@ if (! function_exists('dataset')) {
     /**
      * Registers the given dataset.
      *
-     * @param  Closure|iterable<int|string, mixed>  $dataset
+     * @param  Closure|iterable<int|string, mixed>|null  $dataset
+     * @return array|void
      */
-    function dataset(string $name, Closure|iterable $dataset): void
+    function dataset(string $name, Closure|iterable $dataset = null)
     {
+        if ($dataset === null) {
+            return DatasetsRepository::getValue($name, Backtrace::file());
+        }
+
         $scope = DatasetInfo::scope(Backtrace::datasetsFile());
 
         DatasetsRepository::set($name, $dataset, $scope);

--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -147,20 +147,7 @@ final class DatasetsRepository
         foreach ($datasets as $index => $data) {
             $processedDataset = [];
 
-            if (is_string($data)) {
-                $datasets[$index] = self::getScopedDataset($data, $currentTestFile);
-            }
-
-            if (is_callable($datasets[$index])) {
-                $datasets[$index] = call_user_func($datasets[$index]);
-            }
-
-            if ($datasets[$index] instanceof Traversable) {
-                $preserveKeysForArrayIterator = $datasets[$index] instanceof Generator
-                    && is_string($datasets[$index]->key());
-
-                $datasets[$index] = iterator_to_array($datasets[$index], $preserveKeysForArrayIterator);
-            }
+            $datasets[$index] = self::getValue($data, $currentTestFile);
 
             foreach ($datasets[$index] as $key => $values) {
                 $values = is_array($values) ? $values : [$values];
@@ -174,6 +161,31 @@ final class DatasetsRepository
         }
 
         return $processedDatasets;
+    }
+
+    /**
+     * @param  Closure|iterable<int|string, mixed>|string  $data
+     */
+    public static function getValue(Closure|iterable|string $data, string $currentTestFile): array
+    {
+        $dataset = [];
+
+        if (is_string($data)) {
+            $dataset = self::getScopedDataset($data, $currentTestFile);
+        }
+
+        if (is_callable($dataset)) {
+            $dataset = call_user_func($dataset);
+        }
+
+        if ($dataset instanceof Traversable) {
+            $preserveKeysForArrayIterator = $dataset instanceof Generator
+                && is_string($dataset->key());
+
+            $dataset = iterator_to_array($dataset, $preserveKeysForArrayIterator);
+        }
+
+        return $dataset;
     }
 
     /**

--- a/tests/Features/DatasetsTests.php
+++ b/tests/Features/DatasetsTests.php
@@ -360,4 +360,14 @@ it('can correctly resolve a bound dataset that returns an array but wants to be 
     },
 ]);
 
+it('will return dataset values by name', function () {
+    expect(dataset('numbers.closure'))->toBe([[1], [2]]);
+    expect(dataset('numbers.array'))->toBe([[1], [2]]);
+
+    expect(dataset('numbers.closure.wrapped'))->toBe([1, 2]);
+    expect(dataset('numbers.array.wrapped'))->toBe([1, 2]);
+
+    expect(dataset('numbers.generators.wrapped'))->toBe([1, 2, 3, 4]);
+});
+
 todo('forbids to define tests in Datasets dirs and Datasets.php files');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

This PR makes it possible to get the specified dataset values by its name:

```php
dataset('foo', [1, 2]);

test('can get dataset values', function () {
    expect(dataset('foo'))->toBe([1, 2]);
});
```

