### PR TITLE
[2.x] Add support for nested properties for `toHaveProperties`

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -294,7 +294,7 @@ final class Expectation
      * This has been abstracted out so that it can be called recursively.
      *
      * @param  iterable<array-key, mixed>  $incoming The incoming array
-     * @param  iterable<array-key, mixed>  $expected The expected array
+     * @param  array $expected The expected array
      * @param  string  $message The message to display if the assertion fails
      */
     private function assert_object(mixed $incoming, iterable $expected, string $message): void
@@ -305,7 +305,7 @@ final class Expectation
         foreach ($expected as $name => $value) {
 
             // Check if the key from $expected exists in $incoming
-            $key = is_int($name) && (is_string($value) || is_int($value)) ? $value : $name;
+            $key = array_is_list($expected) ? $value : $name;
 
             // Create a default useful message if one was not provided
             $non_existent = $message;
@@ -313,7 +313,11 @@ final class Expectation
                 $non_existent = "Failed asserting that `{$key}` exists";
             }
 
-            Assert::assertTrue(array_key_exists($key, $incoming_array), $non_existent);
+            if (array_is_list($incoming_array)) {
+                Assert::assertTrue(in_array($key, $incoming_array), $non_existent);
+            } else {
+                Assert::assertTrue(array_key_exists($key, $incoming_array), $non_existent);
+            }
 
             $incoming_value = $incoming_array[$key];
 
@@ -333,15 +337,15 @@ final class Expectation
     }
 
     /**
-     * Asserts that the value contains the provided properties $names.
+     * Asserts that the value contains the provided shape.
      *
      * @param  iterable<array-key, string>  $names
      * @return self<TValue>
      */
-    public function toHaveProperties(iterable $names, string $message = ''): self
+    public function toHaveProperties(iterable $shape, string $message = ''): self
     {
         // @phpstan-ignore-next-line
-        $this->assert_object($this->value, $names, $message);
+        $this->assert_object($this->value, $shape, $message);
 
         return $this;
     }

--- a/tests/Features/Expect/toHaveProperties.php
+++ b/tests/Features/Expect/toHaveProperties.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
-test('pass', function () {
+test('pass objects', function () {
     $object = new stdClass();
     $object->name = 'John';
     $object->age = 21;
@@ -13,9 +13,69 @@ test('pass', function () {
             'name' => 'John',
             'age' => 21,
         ]);
+
+    $nested_object = new stdClass();
+    $nested_object->name = 'John';
+    $nested_object->age = 21;
+    $nested_object->address = new stdClass();
+    $nested_object->address->street = '123 Main St.';
+    $nested_object->address->city = 'Melbourne';
+    $nested_object->address->state = 'VIC';
+    $nested_object->address->zip = '3000';
+
+    expect($nested_object)
+        ->toHaveProperties(['name', 'age', 'address'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
+        ]);
 });
 
-test('failures', function () {
+test('pass arrays', function () {
+    $array = [
+        'name' => 'John',
+        'age' => 21,
+    ];
+
+    expect($array)
+        ->toHaveProperties(['name', 'age'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
+
+    $nested_array = [
+        'name' => 'John',
+        'age' => 21,
+        'address' => [
+            'street' => '123 Main St.',
+            'city' => 'Melbourne',
+            'state' => 'VIC',
+            'zip' => '3000',
+        ],
+    ];
+
+    expect($nested_array)
+        ->toHaveProperties(['name', 'age', 'address'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
+        ]);
+});
+
+test('failures objects', function () {
     $object = new stdClass();
     $object->name = 'John';
 
@@ -24,6 +84,65 @@ test('failures', function () {
         ->toHaveProperties([
             'name' => 'John',
             'age' => 21,
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('failures nested objects', function () {
+    $nested_object = new stdClass();
+    $nested_object->name = 'John';
+    $nested_object->address = new stdClass();
+    $nested_object->address->street = '123 Main St.';
+    $nested_object->address->city = 'Melbourne';
+    $nested_object->address->state = 'VIC';
+
+    expect($nested_object)
+        ->toHaveProperties(['name', 'age', 'address'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('failures arrays', function () {
+    $array = [
+        'name' => 'John',
+    ];
+
+    expect($array)
+        ->toHaveProperties(['name', 'age'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('failures nested arrays', function () {
+    $nested_array = [
+        'name' => 'John',
+        'address' => [
+            'street' => '123 Main St.',
+            'city' => 'Melbourne',
+            'zip' => '3000',
+        ],
+    ];
+
+    expect($nested_array)
+        ->toHaveProperties(['name', 'age', 'address'])
+        ->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
         ]);
 })->throws(ExpectationFailedException::class);
 
@@ -39,7 +158,7 @@ test('failures with custom message', function () {
         ], 'oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
 
-test('not failures', function () {
+test('not failures objects', function () {
     $object = new stdClass();
     $object->name = 'John';
     $object->age = 21;
@@ -48,5 +167,66 @@ test('not failures', function () {
         ->not->toHaveProperties([
             'name' => 'John',
             'age' => 21,
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('not failures arrays', function () {
+    $array = [
+        'name' => 'John',
+        'age' => 21,
+    ];
+
+    expect($array)->not->toHaveProperties(['name', 'age'])
+        ->not->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('not failures nested object', function () {
+    $nested_object = new stdClass();
+    $nested_object->name = 'John';
+    $nested_object->age = 21;
+    $nested_object->address = new stdClass();
+    $nested_object->address->street = '123 Main St.';
+    $nested_object->address->city = 'Melbourne';
+    $nested_object->address->state = 'VIC';
+    $nested_object->address->zip = '3000';
+
+    expect($nested_object)->not->toHaveProperties(['name', 'age', 'address'])
+        ->not->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('not failures nested arrays', function () {
+    $nested_array = [
+        'name' => 'John',
+        'age' => 21,
+        'address' => [
+            'street' => '123 Main St.',
+            'city' => 'Melbourne',
+            'state' => 'VIC',
+            'zip' => '3000',
+        ],
+    ];
+
+    expect($nested_array)->not->toHaveProperties(['name', 'age', 'address'])
+        ->not->toHaveProperties([
+            'name' => 'John',
+            'age' => 21,
+            'address' => [
+                'street' => '123 Main St.',
+                'city' => 'Melbourne',
+                'state' => 'VIC',
+                'zip' => '3000',
+            ],
         ]);
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
…ation

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #852 

This PR adds the ability for `toHaveProperties` expectation to handle nested objects and arrays. Extra tests have been added to check nested properties.

It should not break existing code.