### PR TITLE
[2.x] Add null ability to `and` method in Expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -71,8 +71,12 @@ final class Expectation
      * @param  TAndValue  $value
      * @return self<TAndValue>
      */
-    public function and(mixed $value): Expectation
+    public function and(mixed $value = null): Expectation
     {
+        if (is_null($value)) {
+            return new self($this->value);
+        }
+
         return $value instanceof self ? $value : new self($value);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

We always use the `and` method like this:

```php
expect($name)
    ->toBe('milwad')
    ->and($name)
    ->toBeString();
```

But it's very impressive to use the `and` method like this:

```php
expect($name)
    ->toBe('milwad')
    ->and()
    ->toBeString();
```

Also, you can use `and` without parentheses:

```php
expect($name)->toBe('milwad')->and->toBeString();
```

Here we didn't need to pass the first value for the `and` method and changes are easier than the first way.

