### PR TITLE
feat(arch): Adds support for opposite expectations of `toHavePrefix` and `toHaveSuffix`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "psr-4": {
             "Tests\\Fixtures\\Covers\\": "tests/Fixtures/Covers",
             "Tests\\Fixtures\\Inheritance\\": "tests/Fixtures/Inheritance",
+            "Tests\\Fixtures\\Arch\\": "tests/Fixtures/Arch",
             "Tests\\": "tests/PHPUnit/"
         },
         "files": [

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -595,12 +595,12 @@ final class Expectation
     /**
      * Asserts that the given expectation target to have the given suffix.
      */
-    public function toHavePrefix(string $suffix): ArchExpectation
+    public function toHavePrefix(string $prefix): ArchExpectation
     {
         return Targeted::make(
             $this,
-            fn (ObjectDescription $object): bool => str_starts_with($object->reflectionClass->getName(), $suffix),
-            "to have prefix '{$suffix}'",
+            fn (ObjectDescription $object): bool => str_starts_with($object->reflectionClass->getShortName(), $prefix),
+            "to have prefix '{$prefix}'",
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
         );
     }

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -291,17 +291,27 @@ final class OppositeExpectation
     /**
      * Not supported.
      */
-    public function toHavePrefix(string $suffix): never
+    public function toHavePrefix(string $prefix): ArchExpectation
     {
-        throw InvalidExpectation::fromMethods(['not', 'toHavePrefix']);
+        return Targeted::make(
+            $this->original,
+            fn (ObjectDescription $object): bool => ! str_starts_with($object->reflectionClass->getShortName(), $prefix),
+            "not to have prefix '{$prefix}'",
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
     }
 
     /**
      * Not supported.
      */
-    public function toHaveSuffix(string $suffix): never
+    public function toHaveSuffix(string $suffix): ArchExpectation
     {
-        throw InvalidExpectation::fromMethods(['not', 'toHaveSuffix']);
+        return Targeted::make(
+            $this->original,
+            fn (ObjectDescription $object): bool => ! str_ends_with($object->reflectionClass->getName(), $suffix),
+            "not to have suffix '{$suffix}'",
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
     }
 
     /**

--- a/tests/Features/Expect/toHavePrefix.php
+++ b/tests/Features/Expect/toHavePrefix.php
@@ -1,0 +1,21 @@
+<?php
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('missing prefix')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToHavePrefix\\HasNoPrefix')
+    ->toHavePrefix('Prefix');
+
+test('has prefix')
+    ->expect('Tests\\Fixtures\\Arch\\ToHavePrefix\\HasPrefix')
+    ->toHavePrefix('Prefix');
+
+test('opposite missing prefix')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToHavePrefix\\HasPrefix')
+    ->not->toHavePrefix('Prefix');
+
+test('opposite has prefix')
+    ->expect('Tests\\Fixtures\\Arch\\ToHavePrefix\\HasNoPrefix')
+    ->not->toHavePrefix('Prefix');

--- a/tests/Features/Expect/toHaveSuffix.php
+++ b/tests/Features/Expect/toHaveSuffix.php
@@ -1,0 +1,21 @@
+<?php
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('missing suffix')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveSuffix\\HasNoSuffix')
+    ->toHaveSuffix('Suffix');
+
+test('has suffix')
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveSuffix\\HasSuffix')
+    ->toHaveSuffix('Suffix');
+
+test('opposite missing suffix')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveSuffix\\HasSuffix')
+    ->not->toHaveSuffix('Suffix');
+
+test('opposite has suffix')
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveSuffix\\HasNoSuffix')
+    ->not->toHaveSuffix('Suffix');

--- a/tests/Fixtures/Arch/ToHavePrefix/HasNoPrefix/ClassWithout.php
+++ b/tests/Fixtures/Arch/ToHavePrefix/HasNoPrefix/ClassWithout.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHavePrefix\HasNoPrefix;
+
+class ClassWithout
+{
+}

--- a/tests/Fixtures/Arch/ToHavePrefix/HasPrefix/PrefixClassWith.php
+++ b/tests/Fixtures/Arch/ToHavePrefix/HasPrefix/PrefixClassWith.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHavePrefix\HasPrefix;
+
+class PrefixClassWith
+{
+}

--- a/tests/Fixtures/Arch/ToHaveSuffix/HasNoSuffix/ClassWithout.php
+++ b/tests/Fixtures/Arch/ToHaveSuffix/HasNoSuffix/ClassWithout.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveSuffix\HasNoSuffix;
+
+class ClassWithout
+{
+}

--- a/tests/Fixtures/Arch/ToHaveSuffix/HasSuffix/ClassWithSuffix.php
+++ b/tests/Fixtures/Arch/ToHaveSuffix/HasSuffix/ClassWithSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveSuffix\HasSuffix;
+
+class ClassWithSuffix
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes

This PR adds support for `->not->toHavePrefix('x');` and `->not->toHaveSuffix('x');`, which are very useful for enforcing consistent naming conventions. It also fixes a bug with `toHavePrefix` where the FQCN was being checked for rather than the short class name.
