### PR TITLE
Add `toBeInvokable` arch expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -701,7 +701,7 @@ final class Expectation
     {
         return Targeted::make(
             $this,
-            fn(ObjectDescription $object): bool => $object->reflectionClass->hasMethod('__invoke'),
+            fn (ObjectDescription $object): bool => $object->reflectionClass->hasMethod('__invoke'),
             'to be invokable',
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
         );

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -693,4 +693,17 @@ final class Expectation
     {
         return ToBeUsedInNothing::make($this);
     }
+
+    /**
+     * Asserts that the given expectation dependency is an invokable class.
+     */
+    public function toBeInvokable(): ArchExpectation
+    {
+        return Targeted::make(
+            $this,
+            fn(ObjectDescription $object): bool => $object->reflectionClass->hasMethod('__invoke'),
+            'to be invokable',
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
+        );
+    }
 }

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -372,7 +372,7 @@ final class OppositeExpectation
     {
         return Targeted::make(
             $this->original,
-            fn(ObjectDescription $object): bool => !$object->reflectionClass->hasMethod('__invoke'),
+            fn (ObjectDescription $object): bool => ! $object->reflectionClass->hasMethod('__invoke'),
             'to not be invokable',
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
         );

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -366,6 +366,19 @@ final class OppositeExpectation
     }
 
     /**
+     * Asserts that the given expectation dependency is not an invokable class.
+     */
+    public function toBeInvokable(): ArchExpectation
+    {
+        return Targeted::make(
+            $this->original,
+            fn(ObjectDescription $object): bool => !$object->reflectionClass->hasMethod('__invoke'),
+            'to not be invokable',
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
+        );
+    }
+
+    /**
      * Handle dynamic method calls into the original expectation.
      *
      * @param  array<int, mixed>  $arguments

--- a/tests/Features/Expect/toBeInvokable.php
+++ b/tests/Features/Expect/toBeInvokable.php
@@ -1,0 +1,29 @@
+<?php
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('class is invokable')
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsInvokable\\InvokableClass')
+    ->toBeInvokable();
+
+test('opposite class is invokable')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsInvokable\\InvokableClass')
+    ->not->toBeInvokable();
+
+test('class is invokable via a parent class')
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsInvokable\\InvokableClassViaParent')
+    ->toBeInvokable();
+
+test('class is invokable via a trait')
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsInvokable\\InvokableClassViaTrait')
+    ->toBeInvokable();
+
+test('failure when the class is not invokable')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsNotInvokable\\IsNotInvokableClass')
+    ->toBeInvokable();
+
+test('class is not invokable')
+    ->expect('Tests\\Fixtures\\Arch\\ToBeInvokable\\IsNotInvokable\\IsNotInvokableClass')
+    ->not->toBeInvokable();

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
+
+class InvokableClass
+{
+    public function __invoke(): void
+    {
+
+    }
+}

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClassViaParent.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClassViaParent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
+
+class InvokableClassViaParent extends ParentInvokableClass
+{
+    //
+}

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClassViaTrait.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClassViaTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
+
+class InvokableClassViaTrait
+{
+    use InvokableTrait;
+}

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableTrait.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
+
+trait InvokableTrait
+{
+    public function __invoke(): void
+    {
+        //
+    }
+}

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/ParentInvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/ParentInvokableClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
+
+class ParentInvokableClass
+{
+    public function __invoke(): void
+    {
+
+    }
+}

--- a/tests/Fixtures/Arch/ToBeInvokable/IsNotInvokable/IsNotInvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsNotInvokable/IsNotInvokableClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeInvokable\IsNotInvokable;
+
+class IsNotInvokableClass
+{
+    public function handle(): void
+    {
+
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Fixed tickets | N/A

Hey!

This PR is just a small one, but something that I think could be useful for some devs (including myself). This PR proposes a new `toBeInvokable` expectation that can be used to assert whether a class has an `__invoke` method.

I like to use invokable classes quite a bit (for things like action classes). An example action class might be something like this:

```php
use App\DataTransferObjects\User\NewUserData;

class CreateUser
{
    public function __invoke(NewUserData $userData): void
    {
        // ...
    }
}
```

And then it can be called like so in my controller:

```php
public function store(StoreUserRequest $request, CreateUser $createUser)
{
    // ...

    $createUser($request->toDto());

    // ...
}
```

I like to follow this pattern and like knowing that all my actions are invokable. So I thought it'd be handy to have an expectation that I can use to enforce this.

The expectation can be used like so:

```php
test('class is invokable')
    ->expect('App\Actions')
    ->toBeInvokable();
```

I'm not entirely sure if I've done everything right here, but I've tried my best to make sure there are tests covering the code. If I've done anything wrong though, please give me a shout!

Likewise, if this is something you think might be useful to other devs but you want something changing first, let me know and I'll get to it ASAP! 😄