### PR TITLE
Adds support for Rust-like in source tests.

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 (static function () {
+    $_SERVER['IS_PEST_RUNNING'] = true;
+
     // Ensures Collision's Printer is registered.
     $_SERVER['COLLISION_PRINTER'] = 'DefaultPrinter';
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -18,6 +18,24 @@ use Pest\Support\HigherOrderTapProxy;
 use Pest\TestSuite;
 use PHPUnit\Framework\TestCase;
 
+if(!isset($_SERVER['IS_PEST_RUNNING'])) {
+    if(!function_exists('describe')) {
+        function describe($description, $closure) {
+        }
+    }
+
+    if(!function_exists('it')) {
+        function it($description, $closure) {
+        }
+    }
+
+    if(!function_exists('test')) {
+        function test($description, $closure) {
+        }
+    }
+}
+
+
 if (! function_exists('expect')) {
     /**
      * Creates a new expectation.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | N/A

What this does is set the describe/it/test functions to be empty so there's no errors thrown when run outside of the CLI/Pest context.
This PR is just to serve as an experiment & example of how in source tests could work.

I also created a discussion here #894 

To test this out clone my repo on the in-source-tests branch.
Add the repo to your composer.json
```json
"repositories": {
    "pestphp/pest": {
        "type": "path",
        "url": "path/to/repo",
        "symlink": true
    }
},
```

Then add a testsuite in your phpunit.xml pointing to your source code
```xml
<testsuites>
   <testsuite name="in-source">
       <directory suffix=".php">app</directory>
   </testsuite>
</testsuites>
```

Then write some tests next to your source code and run pest.