### PR TITLE
TestSuiteLoader will always consider classes from the current file

### DIFF
--- a/overrides/Runner/TestSuiteLoader.php
+++ b/overrides/Runner/TestSuiteLoader.php
@@ -61,6 +61,11 @@ final class TestSuiteLoader
     private static array $loadedClasses = [];
 
     /**
+     * @psalm-var array<string, array<class-string>>
+     */
+    private static array $loadedClassesByFilename = [];
+
+    /**
      * @psalm-var list<class-string>
      */
     private static array $declaredClasses = [];
@@ -96,6 +101,17 @@ final class TestSuiteLoader
         );
 
         self::$loadedClasses = array_merge($loadedClasses, self::$loadedClasses);
+
+        foreach ($loadedClasses as $loadedClass) {
+            $reflection = new ReflectionClass($loadedClass);
+            $filename = $reflection->getFileName();
+            self::$loadedClassesByFilename[$filename] = [
+                $loadedClass,
+                ...self::$loadedClassesByFilename[$filename] ?? [],
+            ];
+        }
+
+        $loadedClasses = array_merge(self::$loadedClassesByFilename[$suiteClassFile] ?? [], $loadedClasses);
 
         if (empty($loadedClasses)) {
             return $this->exceptionFor($suiteClassName, $suiteClassFile);

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1015,8 +1015,14 @@
    PASS  Tests\PHPUnit\CustomAffixes\snakecasespec
   ✓ it runs file names like snake_case_spec.php
 
+   PASS  Tests\CustomTestCase\ChildTest
+  ✓ override method
+
    PASS  Tests\CustomTestCase\ExecutedTest
   ✓ that gets executed
+
+   PASS  Tests\CustomTestCase\ParentTest
+  ✓ override method
 
    PASS  Tests\PHPUnit\CustomTestCase\UsesPerDirectory
   ✓ closure was bound to CustomTestCase
@@ -1210,4 +1216,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 860 passed (1975 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 862 passed (1977 assertions)

--- a/tests/.snapshots/todo.txt
+++ b/tests/.snapshots/todo.txt
@@ -19,7 +19,13 @@
   ↓ something todo later chained
   ↓ something todo later chained and with function body
 
+   PASS  Tests\CustomTestCase\ChildTest
+  ✓ override method
+
    PASS  Tests\CustomTestCase\ExecutedTest
   ✓ that gets executed
 
-  Tests:    13 todos, 1 passed (1 assertions)
+   PASS  Tests\CustomTestCase\ParentTest
+  ✓ override method
+
+  Tests:    13 todos, 3 passed (3 assertions)

--- a/tests/PHPUnit/CustomTestCase/ChildTest.php
+++ b/tests/PHPUnit/CustomTestCase/ChildTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CustomTestCase;
+
+class ChildTest extends ParentTest
+{
+    private function getEntity(): bool
+    {
+        return true;
+    }
+}

--- a/tests/PHPUnit/CustomTestCase/ParentTest.php
+++ b/tests/PHPUnit/CustomTestCase/ParentTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CustomTestCase;
+
+use function PHPUnit\Framework\assertTrue;
+use PHPUnit\Framework\TestCase;
+
+class ParentTest extends TestCase
+{
+    private function getEntity(): bool
+    {
+        return false;
+    }
+
+    /** @test */
+    public function testOverrideMethod(): void
+    {
+        assertTrue($this->getEntity() || true);
+    }
+}

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 849 passed (1960 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 851 passed (1962 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

I would like to have test classes which extend from other test classes. This allows for a set of test cases to run in the parent class, then the child class can override certain methods, and have the same test cases run.

This works with PHPUnit 10, but when running the same tests via Pest, some of the parent classes are ignored. This happens because of changes in the override to `TestSuiteLoader`. Once a class is loaded, it's not considered again, so if the child class is loaded before the parent, the parent will never be considered for test cases.

This PR is an attempt to resolve this, but I'd would also like to ask if there is any reason this should not be allowed?