### PR TITLE
[2.x] Allowing Closure Interpretion

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -60,7 +60,9 @@ final class Expectation
     public function __construct(
         public mixed $value
     ) {
-        // ..
+        if ($this->value instanceof Closure) {
+            $this->value = $value();
+        }
     }
 
     /**

--- a/tests/Features/Closure.php
+++ b/tests/Features/Closure.php
@@ -1,0 +1,23 @@
+<?php
+
+test('execute closure and test as arrow function', function (callable $closure, $expected) {
+    expect($closure)->toBe($expected);
+})->with([
+    [fn () => 1, 1],
+    [fn () => [], []],
+    [fn () => 'foo bar', 'foo bar'],
+]);
+
+test('execute closure and test as normal function', function (callable $closure, $expected) {
+    expect($closure)->toBe($expected);
+})->with([
+    [function () {
+        return 1;
+    }, 1],
+    [function () {
+        return [];
+    }, []],
+    [function () {
+        return 'foo bar';
+    }, 'foo bar'],
+]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes

We know that PestPHP aims to offer many facilities, but unfortunately this is not possible:

![CleanShot 2023-08-11 at 4 01 49](https://github.com/pestphp/pest/assets/60591772/a70e08aa-fdb0-42ad-b054-1b8b336c2fb9)

As the **essence of PestPHP** is to bring us new possibilities and many facilities for our tests, **this PR aims to add the possibility to interpret and execute a closure** injected directly via `expect`, allowing us to do things like:

![CleanShot 2023-08-11 at 4 00 47](https://github.com/pestphp/pest/assets/60591772/3df383d3-d37b-431d-8c39-c82ee3028a2c)


