### PR TITLE
add expectations for uppercase, lowercase, alpha and alphanumeric

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -961,4 +961,52 @@ final class Expectation
 
         return $this->exporter->shortenedExport($value);
     }
+
+    /**
+     * Asserts that the value is uppercase.
+     *
+     * @return self<TValue>
+     */
+    public function toBeUppercase(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_upper($this->value), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is lowercase.
+     *
+     * @return self<TValue>
+     */
+    public function toBeLowercase(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_lower($this->value), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is alphanumeric.
+     *
+     * @return self<TValue>
+     */
+    public function toBeAlphaNumeric(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_alnum($this->value), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is alpha.
+     *
+     * @return self<TValue>
+     */
+    public function toBeAlpha(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_alpha($this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -969,7 +969,7 @@ final class Expectation
      */
     public function toBeUppercase(string $message = ''): self
     {
-        Assert::assertTrue(ctype_upper($this->value), $message);
+        Assert::assertTrue(ctype_upper((string) $this->value), $message);
 
         return $this;
     }
@@ -981,7 +981,7 @@ final class Expectation
      */
     public function toBeLowercase(string $message = ''): self
     {
-        Assert::assertTrue(ctype_lower($this->value), $message);
+        Assert::assertTrue(ctype_lower((string) $this->value), $message);
 
         return $this;
     }
@@ -993,7 +993,7 @@ final class Expectation
      */
     public function toBeAlphaNumeric(string $message = ''): self
     {
-        Assert::assertTrue(ctype_alnum($this->value), $message);
+        Assert::assertTrue(ctype_alnum((string) $this->value), $message);
 
         return $this;
     }
@@ -1005,7 +1005,7 @@ final class Expectation
      */
     public function toBeAlpha(string $message = ''): self
     {
-        Assert::assertTrue(ctype_alpha($this->value), $message);
+        Assert::assertTrue(ctype_alpha((string) $this->value), $message);
 
         return $this;
     }

--- a/tests/Features/Expect/toBeAlpha.php
+++ b/tests/Features/Expect/toBeAlpha.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('abc')->toBeAlpha();
+    expect('123')->not->toBeAlpha();
+});
+
+test('failures', function () {
+    expect('123')->toBeAlpha();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('123')->toBeAlpha('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('abc')->not->toBeAlpha();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeAlphaNumeric.php
+++ b/tests/Features/Expect/toBeAlphaNumeric.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('abc123')->toBeAlphaNumeric();
+    expect('-')->not->toBeAlphaNumeric();
+});
+
+test('failures', function () {
+    expect('-')->toBeAlphaNumeric();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('-')->toBeAlphaNumeric('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('abc123')->not->toBeAlphaNumeric();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLowercase.php
+++ b/tests/Features/Expect/toBeLowercase.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('lowercase')->toBeLowercase();
+    expect('UPPERCASE')->not->toBeLowercase();
+});
+
+test('failures', function () {
+    expect('UPPERCASE')->toBeLowercase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('UPPERCASE')->toBeLowercase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('lowercase')->not->toBeLowercase();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeUppercase.php
+++ b/tests/Features/Expect/toBeUppercase.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('UPPERCASE')->toBeUppercase();
+    expect('lowercase')->not->toBeUppercase();
+});
+
+test('failures', function () {
+    expect('lowercase')->toBeUppercase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('lowercase')->toBeUppercase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('UPPERCASE')->not->toBeUppercase();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Fixed tickets | N/A

# Introduction

This PR adds a few more Expectations that would be useful in some projects I work with Pest on, hopefully other people will find them useful too. We have:

- `toBeUppercase()`
- `toBeLowercase()`
- `toBeAlphaNumeric()`
- `toBeAlpha()`

## Usage

```php
it('succeeds if uppercase', function () {
    expect('UPPERCASE')->toBeUppercase();
});

it('succeeds if lowercase', function () {
    expect('lowercase')->toBeLowercase();
});

it('succeeds if alpha', function () {
    expect('abc')->toBeAlpha();
});

it('succeeds if alphanumeric', function () {
    expect('abc123')->toBeAlphaNumeric();
});

it('succeeds if not uppercase', function () {
    expect('lowercase')->not->toBeUppercase();
});

it('succeeds if not lowercase', function () {
    expect('UPPERCASE')->not->toBeLowercase();
});

it('succeeds if not alpha', function () {
    expect('123')->not->toBeAlpha();
});

it('succeeds if not alphanumeric', function () {
    expect('-')->not->toBeAlphaNumeric();
});



