### PR TITLE
[2.x] Introducing `toBeDigits` Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -503,6 +503,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value contains only digits.
+     *
+     * @return self<TValue>
+     */
+    public function toBeDigits(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_digit((string) $this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is of type object.
      *
      * @return self<TValue>

--- a/tests/Features/Expect/toBeDigits.php
+++ b/tests/Features/Expect/toBeDigits.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('123')->toBeDigits();
+    expect('123.14')->not->toBeDigits();
+});
+
+test('failures', function () {
+    expect('123.14')->toBeDigits();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('123.14')->toBeDigits('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('445')->not->toBeDigits();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Considering the `toBeNumeric` expectation for cases where we have dots, for example, we succeed in the test case, because behind the scenes we use `is_numeric` [PHP function](https://www.php.net/manual/en/function.is-numeric.php) for the test:

![image](https://github.com/pestphp/pest/assets/60591772/477c1a94-dfc5-4271-91b3-da985a281960)

This PR aims to introduce the `toBeDigits` expectation to Pest, causing the above test cases to fail due to the fact that we use the `ctype_digits` [PHP function](https://www.php.net/manual/pt_BR/function.ctype-digit.php), which will refuse the test due to the fact that there is a dot sign inside the represented number like string:

![image](https://github.com/pestphp/pest/assets/60591772/2bfa2fe0-69ac-4647-ab0d-a54bb4343845)

