### PR TITLE
[2.x] Print only files below the min coverage

### DIFF
--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -28,6 +28,20 @@ final class Coverage implements AddsOutput, HandlesArguments
     private const MIN_OPTION = 'min';
 
     /**
+     * @var string
+     */
+    private const ERRORS_ONLY_OPTION = 'errors-only';
+
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_OPTIONS = [
+        self::COVERAGE_OPTION,
+        self::MIN_OPTION,
+        self::ERRORS_ONLY_OPTION,
+    ];
+
+    /**
      * Whether it should show the coverage or not.
      */
     public bool $coverage = false;
@@ -36,6 +50,11 @@ final class Coverage implements AddsOutput, HandlesArguments
      * The minimum coverage.
      */
     public float $coverageMin = 0.0;
+
+    /**
+     * Whether it should show only errors or not.
+     */
+    public bool $errorsOnly = false;
 
     /**
      * Creates a new Plugin instance.
@@ -51,7 +70,7 @@ final class Coverage implements AddsOutput, HandlesArguments
     public function handleArguments(array $originals): array
     {
         $arguments = [...[''], ...array_values(array_filter($originals, function (string $original): bool {
-            foreach ([self::COVERAGE_OPTION, self::MIN_OPTION] as $option) {
+            foreach (self::ALLOWED_OPTIONS as $option) {
                 if ($original === sprintf('--%s', $option)) {
                     return true;
                 }
@@ -73,6 +92,7 @@ final class Coverage implements AddsOutput, HandlesArguments
         $inputs = [];
         $inputs[] = new InputOption(self::COVERAGE_OPTION, null, InputOption::VALUE_NONE);
         $inputs[] = new InputOption(self::MIN_OPTION, null, InputOption::VALUE_REQUIRED);
+        $inputs[] = new InputOption(self::ERRORS_ONLY_OPTION, null, InputOption::VALUE_NONE);
 
         $input = new ArgvInput($arguments, new InputDefinition($inputs));
         if ((bool) $input->getOption(self::COVERAGE_OPTION)) {
@@ -106,6 +126,10 @@ final class Coverage implements AddsOutput, HandlesArguments
             $this->coverageMin = (float) $minOption;
         }
 
+        if ((bool) $input->getOption(self::ERRORS_ONLY_OPTION)) {
+            $this->errorsOnly = true;
+        }
+
         return $originals;
     }
 
@@ -122,7 +146,7 @@ final class Coverage implements AddsOutput, HandlesArguments
                 exit(1);
             }
 
-            $coverage = \Pest\Support\Coverage::report($this->output);
+            $coverage = \Pest\Support\Coverage::report($this->output, $this->coverageMin, $this->errorsOnly);
 
             $exitCode = (int) ($coverage < $this->coverageMin);
 

--- a/src/Support/Coverage.php
+++ b/src/Support/Coverage.php
@@ -74,7 +74,7 @@ final class Coverage
      * Reports the code coverage report to the
      * console and returns the result in float.
      */
-    public static function report(OutputInterface $output): float
+    public static function report(OutputInterface $output, float $coverageMin, bool $showErrorsOnly): float
     {
         if (! file_exists($reportPath = self::getPath())) {
             if (self::usingXdebug()) {
@@ -125,6 +125,10 @@ final class Coverage
             $color = $percentage === '100.0' ? 'green' : ($percentage === '0.0' ? 'red' : 'yellow');
 
             $truncateAt = max(1, terminal()->width() - 12);
+
+            if ($showErrorsOnly && (float) $percentage >= $coverageMin) {
+                continue;
+            }
 
             renderUsing($output);
             render(<<<HTML

--- a/tests/Features/Coverage.php
+++ b/tests/Features/Coverage.php
@@ -34,6 +34,18 @@ it('adds coverage if --min exist', function () {
     expect($plugin->coverageMin)->toEqual(2.4);
 });
 
+it('adds coverage if --errors-only exist', function () {
+    $plugin = new CoveragePlugin(new ConsoleOutput());
+    expect($plugin->errorsOnly)->toBeFalse()
+        ->and($plugin->coverage)->toBeFalse();
+
+    $plugin->handleArguments([]);
+    expect($plugin->errorsOnly)->toBeFalse();
+
+    $plugin->handleArguments(['--errors-only']);
+    expect($plugin->errorsOnly)->toBeTrue();
+});
+
 it('generates coverage based on file input', function () {
     expect(Coverage::getMissingCoverage(new class()
     {


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR is adding a new `--errors-only` flag that when passed to the command call will print only the files that have coverage below the value set in with the `--min` argument