### PR TITLE
feat: add string case expectations

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -762,4 +762,26 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the given expectation is iterable and contains kebab-case keys.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveKebabCaseKeys(string $message = ''): self
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        foreach ($this->value as $k => $item) {
+            $this->and($k)->toBeKebabCase($message);
+
+            if (is_array($item)) {
+                $this->and($item)->toHaveKebabCaseKeys($message);
+            }
+        }
+
+        return $this;
+    }
 }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -753,7 +753,9 @@ final class Expectation
         }
 
         foreach ($this->value as $k => $item) {
-            $this->and($k)->toBeSnakeCase($message);
+            if (is_string($k)) {
+                $this->and($k)->toBeSnakeCase($message);
+            }
 
             if (is_array($item)) {
                 $this->and($item)->toHaveSnakeCaseKeys($message);
@@ -775,7 +777,9 @@ final class Expectation
         }
 
         foreach ($this->value as $k => $item) {
-            $this->and($k)->toBeKebabCase($message);
+            if (is_string($k)) {
+                $this->and($k)->toBeKebabCase($message);
+            }
 
             if (is_array($item)) {
                 $this->and($item)->toHaveKebabCaseKeys($message);
@@ -797,7 +801,9 @@ final class Expectation
         }
 
         foreach ($this->value as $k => $item) {
-            $this->and($k)->toBeCamelCase($message);
+            if (is_string($k)) {
+                $this->and($k)->toBeCamelCase($message);
+            }
 
             if (is_array($item)) {
                 $this->and($item)->toHaveCamelCaseKeys($message);
@@ -819,7 +825,9 @@ final class Expectation
         }
 
         foreach ($this->value as $k => $item) {
-            $this->and($k)->toBeStudlyCase($message);
+            if (is_string($k)) {
+                $this->and($k)->toBeStudlyCase($message);
+            }
 
             if (is_array($item)) {
                 $this->and($item)->toHaveStudlyCaseKeys($message);

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -784,4 +784,26 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the given expectation is iterable and contains camelCase keys.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveCamelCaseKeys(string $message = ''): self
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        foreach ($this->value as $k => $item) {
+            $this->and($k)->toBeCamelCase($message);
+
+            if (is_array($item)) {
+                $this->and($item)->toHaveCamelCaseKeys($message);
+            }
+        }
+
+        return $this;
+    }
 }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -740,4 +740,26 @@ final class Expectation
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
         );
     }
+
+    /**
+     * Asserts that the given expectation is iterable and contains snake_case keys.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveSnakeCaseKeys(string $message = ''): self
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        foreach ($this->value as $k => $item) {
+            $this->and($k)->toBeSnakeCase($message);
+
+            if (is_array($item)) {
+                $this->and($item)->toHaveSnakeCaseKeys($message);
+            }
+        }
+
+        return $this;
+    }
 }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -806,4 +806,26 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the given expectation is iterable and contains StudlyCase keys.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveStudlyCaseKeys(string $message = ''): self
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        foreach ($this->value as $k => $item) {
+            $this->and($k)->toBeStudlyCase($message);
+
+            if (is_array($item)) {
+                $this->and($item)->toHaveStudlyCaseKeys($message);
+            }
+        }
+
+        return $this;
+    }
 }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1045,4 +1045,16 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is StudlyCase.
+     *
+     * @return self<TValue>
+     */
+    public function toBeStudlyCase(string $message = ''): self
+    {
+        Assert::assertTrue((bool) preg_match('/^\p{Lu}+\p{Ll}[\p{Ll}\p{Lu}]+$/u', (string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1009,4 +1009,16 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is snake_case.
+     *
+     * @return self<TValue>
+     */
+    public function toBeSnakeCase(string $message = ''): self
+    {
+        Assert::assertTrue((bool) preg_match('/^[\p{Ll}_]+$/u', (string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1033,4 +1033,16 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is camelCase.
+     *
+     * @return self<TValue>
+     */
+    public function toBeCamelCase(string $message = ''): self
+    {
+        Assert::assertTrue((bool) preg_match('/^\p{Ll}[\p{Ll}\p{Lu}]+$/u', (string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1017,7 +1017,13 @@ final class Expectation
      */
     public function toBeSnakeCase(string $message = ''): self
     {
-        Assert::assertTrue((bool) preg_match('/^[\p{Ll}_]+$/u', (string) $this->value), $message);
+        $value = (string) $this->value;
+
+        if ($message === '') {
+            $message = "Failed asserting that {$value} is snake_case.";
+        }
+
+        Assert::assertTrue((bool) preg_match('/^[\p{Ll}_]+$/u', $value), $message);
 
         return $this;
     }
@@ -1029,7 +1035,13 @@ final class Expectation
      */
     public function toBeKebabCase(string $message = ''): self
     {
-        Assert::assertTrue((bool) preg_match('/^[\p{Ll}-]+$/u', (string) $this->value), $message);
+        $value = (string) $this->value;
+
+        if ($message === '') {
+            $message = "Failed asserting that {$value} is kebab-case.";
+        }
+
+        Assert::assertTrue((bool) preg_match('/^[\p{Ll}-]+$/u', $value), $message);
 
         return $this;
     }
@@ -1041,7 +1053,13 @@ final class Expectation
      */
     public function toBeCamelCase(string $message = ''): self
     {
-        Assert::assertTrue((bool) preg_match('/^\p{Ll}[\p{Ll}\p{Lu}]+$/u', (string) $this->value), $message);
+        $value = (string) $this->value;
+
+        if ($message === '') {
+            $message = "Failed asserting that {$value} is camelCase.";
+        }
+
+        Assert::assertTrue((bool) preg_match('/^\p{Ll}[\p{Ll}\p{Lu}]+$/u', $value), $message);
 
         return $this;
     }
@@ -1053,7 +1071,13 @@ final class Expectation
      */
     public function toBeStudlyCase(string $message = ''): self
     {
-        Assert::assertTrue((bool) preg_match('/^\p{Lu}+\p{Ll}[\p{Ll}\p{Lu}]+$/u', (string) $this->value), $message);
+        $value = (string) $this->value;
+
+        if ($message === '') {
+            $message = "Failed asserting that {$value} is StudlyCase.";
+        }
+
+        Assert::assertTrue((bool) preg_match('/^\p{Lu}+\p{Ll}[\p{Ll}\p{Lu}]+$/u', $value), $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1021,4 +1021,16 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is kebab-case.
+     *
+     * @return self<TValue>
+     */
+    public function toBeKebabCase(string $message = ''): self
+    {
+        Assert::assertTrue((bool) preg_match('/^[\p{Ll}-]+$/u', (string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/tests/Features/Expect/toBeCamelCase.php
+++ b/tests/Features/Expect/toBeCamelCase.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('abc')->toBeCamelCase();
+    expect('abcDef')->toBeCamelCase();
+    expect('abc-def')->not->toBeCamelCase();
+    expect('abc-def')->not->toBeCamelCase();
+    expect('AbcDef')->not->toBeCamelCase();
+});
+
+test('failures', function () {
+    expect('Abc')->toBeCamelCase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('Abc')->toBeCamelCase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('abcDef')->not->toBeCamelCase();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeKebabCase.php
+++ b/tests/Features/Expect/toBeKebabCase.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('abc')->toBeKebabCase();
+    expect('abc-def')->toBeKebabCase();
+    expect('abc_def')->not->toBeKebabCase();
+    expect('abcDef')->not->toBeKebabCase();
+    expect('AbcDef')->not->toBeKebabCase();
+});
+
+test('failures', function () {
+    expect('Abc')->toBeKebabCase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('Abc')->toBeKebabCase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('abc-def')->not->toBeKebabCase();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeSnakeCase.php
+++ b/tests/Features/Expect/toBeSnakeCase.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('abc')->toBeSnakeCase();
+    expect('abc_def')->toBeSnakeCase();
+    expect('abc-def')->not->toBeSnakeCase();
+    expect('abcDef')->not->toBeSnakeCase();
+    expect('AbcDef')->not->toBeSnakeCase();
+});
+
+test('failures', function () {
+    expect('Abc')->toBeSnakeCase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('Abc')->toBeSnakeCase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('abc_def')->not->toBeSnakeCase();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeStudlyCase.php
+++ b/tests/Features/Expect/toBeStudlyCase.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('Abc')->toBeStudlyCase();
+    expect('AbcDef')->toBeStudlyCase();
+    expect('abc-def')->not->toBeStudlyCase();
+    expect('abc-def')->not->toBeStudlyCase();
+    expect('abc')->not->toBeStudlyCase();
+});
+
+test('failures', function () {
+    expect('abc')->toBeStudlyCase();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('abc')->toBeStudlyCase('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('AbcDef')->not->toBeStudlyCase();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveCamelCaseKeys.php
+++ b/tests/Features/Expect/toHaveCamelCaseKeys.php
@@ -11,6 +11,11 @@ $array = [
             'camel' => true,
             'camelCase' => true,
         ],
+        'list' => [
+            'abc',
+            'def',
+            'ghi',
+        ],
     ],
 ];
 

--- a/tests/Features/Expect/toHaveCamelCaseKeys.php
+++ b/tests/Features/Expect/toHaveCamelCaseKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+$array = [
+    'camel' => true,
+    'camelCase' => [
+        'camel' => true,
+        'camelCase' => [
+            'camel' => true,
+            'camelCase' => true,
+        ],
+    ],
+];
+
+test('pass', function () use ($array) {
+    expect($array)->toHaveCamelCaseKeys();
+});
+
+test('failures', function () {
+    expect('not-an-array')->toHaveCamelCaseKeys();
+})->throws(InvalidExpectationValue::class);
+
+test('failures with message', function () use ($array) {
+    expect($array)->not->toHaveCamelCaseKeys('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () use ($array) {
+    expect($array)->not->toHaveCamelCaseKeys();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveKebabCaseKeys.php
+++ b/tests/Features/Expect/toHaveKebabCaseKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+$array = [
+    'kebab' => true,
+    'kebab-case' => [
+        'kebab' => true,
+        'kebab-case' => [
+            'kebab' => true,
+            'kebab-case' => true,
+        ],
+    ],
+];
+
+test('pass', function () use ($array) {
+    expect($array)->toHaveKebabCaseKeys();
+});
+
+test('failures', function () {
+    expect('not-an-array')->toHaveKebabCaseKeys();
+})->throws(InvalidExpectationValue::class);
+
+test('failures with message', function () use ($array) {
+    expect($array)->not->toHaveKebabCaseKeys('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () use ($array) {
+    expect($array)->not->toHaveKebabCaseKeys();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveKebabCaseKeys.php
+++ b/tests/Features/Expect/toHaveKebabCaseKeys.php
@@ -11,6 +11,11 @@ $array = [
             'kebab' => true,
             'kebab-case' => true,
         ],
+        'list' => [
+            'abc',
+            'def',
+            'ghi',
+        ],
     ],
 ];
 

--- a/tests/Features/Expect/toHaveSnakeCaseKeys.php
+++ b/tests/Features/Expect/toHaveSnakeCaseKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+$array = [
+    'snake' => true,
+    'snake_case' => [
+        'snake' => true,
+        'snake_case' => [
+            'snake' => true,
+            'snake_case' => true,
+        ],
+    ],
+];
+
+test('pass', function () use ($array) {
+    expect($array)->toHaveSnakeCaseKeys();
+});
+
+test('failures', function () {
+    expect('not-an-array')->toHaveSnakeCaseKeys();
+})->throws(InvalidExpectationValue::class);
+
+test('failures with message', function () use ($array) {
+    expect($array)->not->toHaveSnakeCaseKeys('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () use ($array) {
+    expect($array)->not->toHaveSnakeCaseKeys();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveSnakeCaseKeys.php
+++ b/tests/Features/Expect/toHaveSnakeCaseKeys.php
@@ -11,6 +11,11 @@ $array = [
             'snake' => true,
             'snake_case' => true,
         ],
+        'list' => [
+            'abc',
+            'def',
+            'ghi',
+        ],
     ],
 ];
 

--- a/tests/Features/Expect/toHaveStudlyCaseKeys.php
+++ b/tests/Features/Expect/toHaveStudlyCaseKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+$array = [
+    'Studly' => true,
+    'StudlyCase' => [
+        'Studly' => true,
+        'StudlyCase' => [
+            'Studly' => true,
+            'StudlyCase' => true,
+        ],
+    ],
+];
+
+test('pass', function () use ($array) {
+    expect($array)->toHaveStudlyCaseKeys();
+});
+
+test('failures', function () {
+    expect('not-an-array')->toHaveStudlyCaseKeys();
+})->throws(InvalidExpectationValue::class);
+
+test('failures with message', function () use ($array) {
+    expect($array)->not->toHaveStudlyCaseKeys('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () use ($array) {
+    expect($array)->not->toHaveStudlyCaseKeys();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveStudlyCaseKeys.php
+++ b/tests/Features/Expect/toHaveStudlyCaseKeys.php
@@ -11,6 +11,11 @@ $array = [
             'Studly' => true,
             'StudlyCase' => true,
         ],
+        'List' => [
+            'abc',
+            'def',
+            'ghi',
+        ],
     ],
 ];
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Hi @nunomaduro,
and thanks for your efforts on PHP community.

This is my little contribution to Pest. 
With this PR I will introduce 8 new expectations for checking string case and array key case.

**string case**
- `toBeSnakeCase`
- `toBeKebabCase`
- `toBeCamelCase`
- `toBeStudlyCase`

**array key case**
- `toHaveSnakeCaseKeys`
- `toHaveKebabCaseKeys`
- `toHaveCamelCaseKeys`
- `toHaveStudlyCaseKeys`

### Related:
Documentation PR: https://github.com/pestphp/docs/pull/214

I've discussed about those expectations on X (former Twitter) recently https://twitter.com/lemaurdev/status/1691117815158198272 and based on the users reaction I think they could be helpful.

Plus, as proposed by [David Heremans](https://twitter.com/dHeremans/status/1690708270107770880) I also explored the idea to use Architecture Test but without any success for now. Anyway, I plan to explore Arch test more in depth to find a solution.