### PR TITLE
[2.x] Inconsistent type have count exception

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -264,7 +264,7 @@ final class Expectation
     public function toHaveCount(int $count, string $message = ''): self
     {
         if (! is_countable($this->value) && ! is_iterable($this->value)) {
-            InvalidExpectationValue::expected('string');
+            InvalidExpectationValue::expected('countable|iterable');
         }
 
         Assert::assertCount($count, $this->value, $message);

--- a/tests/Features/Expect/toHaveCount.php
+++ b/tests/Features/Expect/toHaveCount.php
@@ -1,10 +1,15 @@
 <?php
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
     expect([1, 2, 3])->toHaveCount(3);
 });
+
+test('failures with invalid type', function () {
+    expect('foo')->toHaveCount(3);
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [countable|iterable]');
 
 test('failures', function () {
     expect([1, 2, 3])->toHaveCount(4);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Correct  type in exception message at `toHaveCount` expectation

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
