### PR TITLE
[2.x] Add `toHaveSameSize` expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest\Mixins;
 
 use BadMethodCallException;
 use Closure;
+use Countable;
 use DateTimeInterface;
 use Error;
 use InvalidArgumentException;
@@ -268,6 +269,22 @@ final class Expectation
         }
 
         Assert::assertCount($count, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the size of the value and $expected are the same.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveSameSize(Countable|iterable $expected, string $message = ''): self
+    {
+        if (! is_countable($this->value) && ! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('countable|iterable');
+        }
+
+        Assert::assertSameSize($expected, $this->value, $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -6,7 +6,6 @@ namespace Pest\Mixins;
 
 use BadMethodCallException;
 use Closure;
-use Countable;
 use DateTimeInterface;
 use Error;
 use InvalidArgumentException;
@@ -276,9 +275,10 @@ final class Expectation
     /**
      * Asserts that the size of the value and $expected are the same.
      *
+     * @param  array<int|string, mixed>  $expected
      * @return self<TValue>
      */
-    public function toHaveSameSize(Countable|iterable $expected, string $message = ''): self
+    public function toHaveSameSize(iterable $expected, string $message = ''): self
     {
         if (! is_countable($this->value) && ! is_iterable($this->value)) {
             InvalidExpectationValue::expected('countable|iterable');

--- a/tests/Features/Expect/toHaveSameSize.php
+++ b/tests/Features/Expect/toHaveSameSize.php
@@ -1,0 +1,24 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('failures with wrong type', function () {
+    expect('foo')->toHaveSameSize([1]);
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [countable|iterable].');
+
+test('pass', function () {
+    expect([1, 2, 3])->toHaveSameSize([4, 5, 6]);
+});
+
+test('failures', function () {
+    expect([1, 2, 3])->toHaveSameSize([1]);
+})->throws(ExpectationFailedException::class);
+
+test('failures with message', function () {
+    expect([1, 2, 3])->toHaveSameSize([1], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect([1, 2, 3])->not->toHaveSameSize([1]);
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Add `toHaveSameSize` expectation

```php
expect([1, 2, 3])->toHaveSameSize([4, 5, 6]);
expect([1, 2, 3])->not->toHaveSameSize([4]);
```
