### PR TITLE
[2.x] chore: resolve `toHaveSameSize` parameter

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest\Mixins;
 
 use BadMethodCallException;
 use Closure;
+use Countable;
 use DateTimeInterface;
 use Error;
 use InvalidArgumentException;
@@ -275,10 +276,10 @@ final class Expectation
     /**
      * Asserts that the size of the value and $expected are the same.
      *
-     * @param  array<int|string, mixed>  $expected
+     * @param  Countable|iterable<mixed>  $expected
      * @return self<TValue>
      */
-    public function toHaveSameSize(iterable $expected, string $message = ''): self
+    public function toHaveSameSize(Countable|iterable $expected, string $message = ''): self
     {
         if (! is_countable($this->value) && ! is_iterable($this->value)) {
             InvalidExpectationValue::expected('countable|iterable');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

This resolves an incorrect type for the `toHaveSameSize()` expectation.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

See: https://github.com/pestphp/pest/pull/924#discussion_r1302806210