### PR TITLE
[2.x] Suggestion: Fluent `and` Method

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -69,12 +69,12 @@ final class Expectation
      *
      * @template TAndValue
      *
-     * @param  TAndValue  $value
+     * @param  TAndValue|null  $value
      * @return self<TAndValue>
      */
-    public function and(mixed $value): Expectation
+    public function and(mixed $value = null): Expectation
     {
-        return $value instanceof self ? $value : new self($value);
+        return $value instanceof self ? $value : (is_null($value) ? $this : new self($value));
     }
 
     /**

--- a/tests/Features/Expect/fluent.php
+++ b/tests/Features/Expect/fluent.php
@@ -1,0 +1,22 @@
+<?php
+
+it('can run as fluent', function () {
+    $foo = 'foO';
+
+    expect($foo)
+        ->toBe('foO')
+        ->and()
+        ->toContain('O')
+        ->and()
+        ->not
+        ->toBe('Bar');
+});
+
+it('can run with parameter', function () {
+    $foo = 'foO';
+
+    expect($foo)
+        ->toBe('foO')
+        ->and($foo .= 'Bar')
+        ->toContain('Bar');
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

**This PR is part of one suggestion.** 

One of Pest's main proposals is to bring "fluency" when writing tests. With Pest we can do something like:

```php
test('We love PHP 🐘', function () {
    $php = 'PHP 🐘';

    expect($php)
        ->toContain('🐘')
        ->and($php)
        ->not
        ->toBe('Laravel');
});
```

But why do we need `and($php)` if for cases like this, I keep interacting with the value of `$php`? This PR aims to introduce the concept of fluency for the `and()` method so that the parameter is issued (null), enabling the following scenario:

```diff
test('We love PHP 🐘', function () {
    $php = 'PHP 🐘';

    expect($php)
        ->toContain('🐘')
-        ->and($php)
+        ->and()
        ->not
        ->toBe('Laravel');
});
```

With that, we create more fluency in the Pest expectation API.