### PR TITLE
[2.x] Add `toBeEnumeration` Expectation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
             "Tests\\Fixtures\\Covers\\": "tests/Fixtures/Covers",
             "Tests\\Fixtures\\Inheritance\\": "tests/Fixtures/Inheritance",
             "Tests\\Fixtures\\Arch\\": "tests/Fixtures/Arch",
+            "Tests\\Fixtures\\Features\\": "tests/Fixtures/Features",
             "Tests\\": "tests/PHPUnit/"
         },
         "files": [

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -448,6 +448,10 @@ final class Expectation
             throw new InvalidArgumentException("The enum class '$enum' does not exist or does not have any cases.");
         }
 
+        if ($this->value instanceof $enum) {
+            return $this;
+        }
+
         $resolve = $enum::tryFrom($this->value);
 
         Assert::assertNotNull($resolve, $message);

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -437,6 +437,26 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is an instance of enumeration $enum.
+     *
+     * @param  class-string  $enum
+     * @return self<TValue>
+     */
+    public function toBeEnumeration(string $enum, string $message = ''): self
+    {
+        if (! enum_exists($enum) || $enum::cases() === []) {
+            throw new InvalidArgumentException("The enum class '$enum' does not exist or does not have any cases.");
+        }
+
+        $resolve = $enum::tryFrom($this->value);
+
+        Assert::assertNotNull($resolve, $message);
+        Assert::assertInstanceOf($enum, $resolve, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is an array.
      *
      * @return self<TValue>

--- a/tests/Features/Expect/toBeEnumeration.php
+++ b/tests/Features/Expect/toBeEnumeration.php
@@ -7,6 +7,7 @@ test('pass', function () {
     expect(2)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
     expect('foo')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
     expect('bar')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
+    expect('bar')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
 });
 
 test('failures', function () {

--- a/tests/Features/Expect/toBeEnumeration.php
+++ b/tests/Features/Expect/toBeEnumeration.php
@@ -1,29 +1,27 @@
 <?php
 
 use PHPUnit\Framework\ExpectationFailedException;
-use Tests\Fixtures\Features\BackedIntEnumeration;
-use Tests\Fixtures\Features\BackedStringEnumeration;
 
 test('pass', function () {
-    expect(1)->toBeEnumeration(BackedIntEnumeration::class);
-    expect(2)->toBeEnumeration(BackedIntEnumeration::class);
-    expect('foo')->toBeEnumeration(BackedStringEnumeration::class);
-    expect('bar')->toBeEnumeration(BackedStringEnumeration::class);
+    expect(1)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
+    expect(2)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
+    expect('foo')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
+    expect('bar')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
 });
 
 test('failures', function () {
-    expect('baz')->toBeEnumeration(BackedStringEnumeration::class);
-    expect('bar')->toBeEnumeration(BackedStringEnumeration::class);
-    expect(3)->toBeEnumeration(BackedIntEnumeration::class);
-    expect(4)->toBeEnumeration(BackedIntEnumeration::class);
+    expect('baz')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
+    expect('bar')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
+    expect(3)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
+    expect(4)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
 })->throws(ExpectationFailedException::class);
 
 test('failures with custom message', function () {
-    expect('baz')->toBeEnumeration(BackedStringEnumeration::class, 'oh no!');
-    expect(3)->toBeEnumeration(BackedIntEnumeration::class, 'oh no!');
+    expect('baz')->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration', 'oh no!');
+    expect(3)->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
 })->throws(ExpectationFailedException::class, 'oh no!');
 
 test('not failures', function () {
-    expect(1)->not->toBeEnumeration(BackedIntEnumeration::class);
-    expect('bar')->not->toBeEnumeration(BackedStringEnumeration::class);
+    expect(1)->not->toBeEnumeration('Tests\\Fixtures\\Features\\BackedIntEnumeration');
+    expect('bar')->not->toBeEnumeration('Tests\\Fixtures\\Features\\BackedStringEnumeration');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeEnumeration.php
+++ b/tests/Features/Expect/toBeEnumeration.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Fixtures\Features\BackedIntEnumeration;
+use Tests\Fixtures\Features\BackedStringEnumeration;
+
+test('pass', function () {
+    expect(1)->toBeEnumeration(BackedIntEnumeration::class);
+    expect(2)->toBeEnumeration(BackedIntEnumeration::class);
+    expect('foo')->toBeEnumeration(BackedStringEnumeration::class);
+    expect('bar')->toBeEnumeration(BackedStringEnumeration::class);
+});
+
+test('failures', function () {
+    expect('baz')->toBeEnumeration(BackedStringEnumeration::class);
+    expect('bar')->toBeEnumeration(BackedStringEnumeration::class);
+    expect(3)->toBeEnumeration(BackedIntEnumeration::class);
+    expect(4)->toBeEnumeration(BackedIntEnumeration::class);
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('baz')->toBeEnumeration(BackedStringEnumeration::class, 'oh no!');
+    expect(3)->toBeEnumeration(BackedIntEnumeration::class, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect(1)->not->toBeEnumeration(BackedIntEnumeration::class);
+    expect('bar')->not->toBeEnumeration(BackedStringEnumeration::class);
+})->throws(ExpectationFailedException::class);

--- a/tests/Fixtures/Features/BackedIntEnumeration.php
+++ b/tests/Fixtures/Features/BackedIntEnumeration.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Tests\Fixtures\Features;
+
 enum BackedIntEnumeration: int
 {
     case Foo = 1;

--- a/tests/Fixtures/Features/BackedIntEnumeration.php
+++ b/tests/Fixtures/Features/BackedIntEnumeration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Features;
+enum BackedIntEnumeration: int
+{
+    case Foo = 1;
+    case Bar = 2;
+}

--- a/tests/Fixtures/Features/BackedStringEnumeration.php
+++ b/tests/Fixtures/Features/BackedStringEnumeration.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures\Features;
+
+enum BackedStringEnumeration: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}
+
+enum BackedIntEnumeration: int
+{
+    case Foo = 1;
+    case Bar = 2;
+}

--- a/tests/Fixtures/Features/BackedStringEnumeration.php
+++ b/tests/Fixtures/Features/BackedStringEnumeration.php
@@ -7,9 +7,3 @@ enum BackedStringEnumeration: string
     case Foo = 'foo';
     case Bar = 'bar';
 }
-
-enum BackedIntEnumeration: int
-{
-    case Foo = 1;
-    case Bar = 2;
-}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Focusing on PHP 8.1, we have [Enumerations](https://www.php.net/manual/en/language.types.enumerations.php), something that is increasingly part of the ecosystem of well-built applications nowadays. This PR aims to introduce the `toBeEnumeration` expectation, allowing something like that:

```php
enum FooBar: string
{
    case Foo = 'foo';
    case Bar = 'bar';
}

expect('foo')->toBeEnumeration(FooBar::class); // ✅ 
expect(FooBar::Foo)->toBeEnumeration(FooBar::class); // ✅ 
expect('baz')->toBeEnumeration(FooBar::class); // ❌  
```

Behind the scenes, the `toBeEnumeration` will use the `tryFrom` from Enumerations combined with `assertNotNull` and `assertInstanceOf` to ensure that the value is part of the Enumeration.