### PR TITLE
[2.x] Add `throwsUnless`

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -105,7 +105,7 @@ final class TestCall
     }
 
     /**
-     * Asserts that the test throws the given `$exceptionClass` when called if the given condition is falsy.
+     * Asserts that the test throws the given `$exceptionClass` when called if the given condition is false.
      *
      * @param  (callable(): bool)|bool  $condition
      */

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -105,6 +105,24 @@ final class TestCall
     }
 
     /**
+     * Asserts that the test throws the given `$exceptionClass` when called if the given condition is falsy.
+     *
+     * @param  (callable(): bool)|bool  $condition
+     */
+    public function throwsUnless(callable|bool $condition, string|int $exception, string $exceptionMessage = null, int $exceptionCode = null): self
+    {
+        $condition = is_callable($condition)
+            ? $condition
+            : static fn (): bool => $condition;
+
+        if (! $condition()) {
+            return $this->throws($exception, $exceptionMessage, $exceptionCode);
+        }
+
+        return $this;
+    }
+
+    /**
      * Runs the current test multiple times with
      * each item of the given `iterable`.
      *

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -59,3 +59,37 @@ it('can just define the message if given condition is 1', function () {
 it('can just define the code if given condition is 1', function () {
     throw new Exception('Something bad happened', 1);
 })->throwsIf(1, 1);
+
+it('not catch exceptions if given condition is true', function () {
+    $this->assertTrue(true);
+})->throwsUnless(true, Exception::class);
+
+it('catch exceptions if given condition is falsy', function () {
+    throw new Exception('Something bad happened');
+})->throwsUnless(function () {
+    return false;
+}, Exception::class);
+
+it('catch exceptions and messages if given condition is falsy', function () {
+    throw new Exception('Something bad happened');
+})->throwsUnless(false, Exception::class, 'Something bad happened');
+
+it('catch exceptions, messages and code if given condition is falsy', function () {
+    throw new Exception('Something bad happened', 1);
+})->throwsUnless(false, Exception::class, 'Something bad happened', 1);
+
+it('can just define the message if given condition is falsy', function () {
+    throw new Exception('Something bad happened');
+})->throwsUnless(false, 'Something bad happened');
+
+it('can just define the code if given condition is falsy', function () {
+    throw new Exception('Something bad happened', 1);
+})->throwsUnless(false, 1);
+
+it('can just define the message if given condition is 0', function () {
+    throw new Exception('Something bad happened');
+})->throwsUnless(0, 'Something bad happened');
+
+it('can just define the code if given condition is 0', function () {
+    throw new Exception('Something bad happened', 1);
+})->throwsUnless(0, 1);

--- a/tests/Features/Exceptions.php
+++ b/tests/Features/Exceptions.php
@@ -64,25 +64,25 @@ it('not catch exceptions if given condition is true', function () {
     $this->assertTrue(true);
 })->throwsUnless(true, Exception::class);
 
-it('catch exceptions if given condition is falsy', function () {
+it('catch exceptions if given condition is false', function () {
     throw new Exception('Something bad happened');
 })->throwsUnless(function () {
     return false;
 }, Exception::class);
 
-it('catch exceptions and messages if given condition is falsy', function () {
+it('catch exceptions and messages if given condition is false', function () {
     throw new Exception('Something bad happened');
 })->throwsUnless(false, Exception::class, 'Something bad happened');
 
-it('catch exceptions, messages and code if given condition is falsy', function () {
+it('catch exceptions, messages and code if given condition is false', function () {
     throw new Exception('Something bad happened', 1);
 })->throwsUnless(false, Exception::class, 'Something bad happened', 1);
 
-it('can just define the message if given condition is falsy', function () {
+it('can just define the message if given condition is false', function () {
     throw new Exception('Something bad happened');
 })->throwsUnless(false, 'Something bad happened');
 
-it('can just define the code if given condition is falsy', function () {
+it('can just define the code if given condition is false', function () {
     throw new Exception('Something bad happened', 1);
 })->throwsUnless(false, 1);
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds `throwsUnless`  method to conditionally verify an exception if a given boolean expression evaluates to falsy.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
