### PR TITLE
[2.x] Add `toHaveAttribute` expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest;
 
+use Attribute;
 use BadMethodCallException;
 use Closure;
 use InvalidArgumentException;
@@ -837,7 +838,7 @@ final class Expectation
     /**
      * Asserts that the given expectation target to have the given attribute.
      *
-     * @param  class-string  $attribute
+     * @param  class-string<Attribute>  $attribute
      */
     public function toHaveAttribute(string $attribute): ArchExpectation
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -833,4 +833,19 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the given expectation target to have the given attribute.
+     *
+     * @param  class-string  $attribute
+     */
+    public function toHaveAttribute(string $attribute): ArchExpectation
+    {
+        return Targeted::make(
+            $this,
+            fn (ObjectDescription $object): bool => $object->reflectionClass->getAttributes($attribute) !== [],
+            "to have attribute '{$attribute}'",
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
+    }
 }

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Expectations;
 
+use Attribute;
 use Pest\Arch\Contracts\ArchExpectation;
 use Pest\Arch\Expectations\Targeted;
 use Pest\Arch\Expectations\ToBeUsedIn;
@@ -381,7 +382,7 @@ final class OppositeExpectation
     /**
      * Asserts that the given expectation target not to have the given attribute.
      *
-     * @param  class-string  $attribute
+     * @param  class-string<Attribute>  $attribute
      */
     public function toHaveAttribute(string $attribute): ArchExpectation
     {

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -379,6 +379,21 @@ final class OppositeExpectation
     }
 
     /**
+     * Asserts that the given expectation target not to have the given attribute.
+     *
+     * @param  class-string  $attribute
+     */
+    public function toHaveAttribute(string $attribute): ArchExpectation
+    {
+        return Targeted::make(
+            $this->original,
+            fn (ObjectDescription $object): bool => $object->reflectionClass->getAttributes($attribute) === [],
+            "to not have attribute '{$attribute}'",
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
+        );
+    }
+
+    /**
      * Handle dynamic method calls into the original expectation.
      *
      * @param  array<int, mixed>  $arguments

--- a/tests/Features/Expect/toHaveAttribute.php
+++ b/tests/Features/Expect/toHaveAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('class has attribute')
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveAttribute\\HaveAttribute')
+    ->toHaveAttribute('Tests\\Fixtures\\Arch\\ToHaveAttribute\\Attributes\\AsAttribute');
+
+test('opposite class has attribute')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveAttribute\\HaveAttribute')
+    ->not
+    ->toHaveAttribute('Tests\\Fixtures\\Arch\\ToHaveAttribute\\Attributes\\AsAttribute');
+
+test('class not has attribute')
+    ->expect('Tests\\Fixtures\\Arch\\ToHaveAttribute\\NotHaveAttribute')
+    ->not
+    ->toHaveAttribute('Tests\\Fixtures\\Arch\\ToHaveAttribute\\Attributes\\AsAttribute');

--- a/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
@@ -9,5 +9,4 @@ use Attribute;
 #[Attribute()]
 class AsAttribute
 {
-
 }

--- a/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveAttribute\Attributes;
+
+use Attribute;
+
+#[Attribute()]
+class AsAttribute
+{
+
+}

--- a/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
@@ -9,5 +9,4 @@ use Tests\Fixtures\Arch\ToHaveAttribute\Attributes\AsAttribute;
 #[AsAttribute]
 class HaveAttributeClass
 {
-
 }

--- a/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveAttribute\HaveAttribute;
+
+use Tests\Fixtures\Arch\ToHaveAttribute\Attributes\AsAttribute;
+
+#[AsAttribute]
+class HaveAttributeClass
+{
+
+}

--- a/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
@@ -6,5 +6,4 @@ namespace Tests\Fixtures\Arch\ToHaveAttribute\NotHaveAttribute;
 
 class NotHaveAttributeClass
 {
-
 }

--- a/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveAttribute\NotHaveAttribute;
+
+class NotHaveAttributeClass
+{
+
+}


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->
This PR adds `toHaveAttribute` expectation

Usage:

```php
test('commands must have AsCommand attribute')
    ->expect('App\Console\Commands')
    ->toHaveAttribute('Symfony\Component\Console\Attribute\AsCommand');
```

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
