### PR TITLE
[fix] missing datasets when defined in Pest.php file

### DIFF
--- a/src/Pest.php
+++ b/src/Pest.php
@@ -11,5 +11,5 @@ function version(): string
 
 function testDirectory(string $file = ''): string
 {
-    return TestSuite::getInstance()->testPath.'/'.$file;
+    return TestSuite::getInstance()->testPath.DIRECTORY_SEPARATOR.$file;
 }

--- a/src/Support/DatasetInfo.php
+++ b/src/Support/DatasetInfo.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Support;
 
+use function Pest\testDirectory;
+
 /**
  * @internal
  */
@@ -25,6 +27,10 @@ final class DatasetInfo
 
     public static function scope(string $file): string
     {
+        if (Str::endsWith($file, testDirectory('Pest.php'))) {
+            return dirname($file);
+        }
+
         if (self::isInsideADatasetsDirectory($file)) {
             return dirname($file, 2);
         }

--- a/tests/Features/ScopedDatasets/TestFileOutOfScope.php
+++ b/tests/Features/ScopedDatasets/TestFileOutOfScope.php
@@ -10,3 +10,12 @@ test('uses dataset', function ($value) use ($state) {
 test('the right dataset is taken', function () use ($state) {
     expect($state->text)->toBe('12');
 });
+
+it('can see datasets defined in Pest.php file', function (string $value) use ($state) {
+    $state->text .= $value;
+    expect(true)->toBe(true);
+})->with('dataset_in_pest_file');
+
+test('Pest.php dataset is taken', function () use ($state) {
+    expect($state->text)->toBe('12AB');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -37,3 +37,5 @@ function helper_returns_string()
 {
     return 'string';
 }
+
+dataset('dataset_in_pest_file', ['A', 'B']);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

This PR will allow datasets defined in main Pest.php file