### PR TITLE
fix directory separator for windows

### DIFF
--- a/src/Pest.php
+++ b/src/Pest.php
@@ -11,5 +11,5 @@ function version(): string
 
 function testDirectory(string $file = ''): string
 {
-    return TestSuite::getInstance()->testPath.'/'.$file;
+    return TestSuite::getInstance()->testPath.DIRECTORY_SEPARATOR.$file;
 }


### PR DESCRIPTION
This PR will fix directory separator when using `testDirectory` method in a windows environment

```diff
function testDirectory(string $file = ''): string
{
    -return TestSuite::getInstance()->testPath.'/'.$file;
    +return TestSuite::getInstance()->testPath.DIRECTORY_SEPARATOR.$file;
}
```