### PR TITLE
[2.x] Fix the Usage of `depends` With `describe`

### DIFF
--- a/overrides/Runner/TestSuiteLoader.php
+++ b/overrides/Runner/TestSuiteLoader.php
@@ -132,7 +132,7 @@ final class TestSuiteLoader
                     continue;
                 }
 
-                if ($class->isAbstract() || ($class->getFileName() !== $suiteClassFile)) {
+                if ($class->isAbstract() || ($suiteClassFile !== $class->getFileName())) {
                     if (! str_contains($class->getFileName(), 'TestCaseFactory.php')) {
                         continue;
                     }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -239,7 +239,7 @@ final class Expectation
             $index = isset($callbacks[$index + 1]) ? $index + 1 : 0;
         }
 
-        if (count($callbacks) > $valuesCount) {
+        if ($valuesCount < count($callbacks)) {
             throw new OutOfRangeException('Sequence expectations are more than the iterable items.');
         }
 

--- a/src/Factories/Annotations/Depends.php
+++ b/src/Factories/Annotations/Depends.php
@@ -19,7 +19,7 @@ final class Depends implements AddsAnnotations
     public function __invoke(TestCaseMethodFactory $method, array $annotations): array
     {
         foreach ($method->depends as $depend) {
-            $depend = Str::evaluable($depend);
+            $depend = Str::evaluable($method->describing !== null ? Str::describe($method->describing, $depend) : $depend);
 
             $annotations[] = "@depends $depend";
         }

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -241,7 +241,7 @@ final class TestCaseFactory
                 throw ShouldNotHappen::fromMessage('The test description may not be empty.');
             }
 
-            if (Str::evaluable($method->description) === $methodName) {
+            if ($methodName === Str::evaluable($method->description)) {
                 return true;
             }
         }
@@ -259,7 +259,7 @@ final class TestCaseFactory
                 throw ShouldNotHappen::fromMessage('The test description may not be empty.');
             }
 
-            if (Str::evaluable($method->description) === $methodName) {
+            if ($methodName === Str::evaluable($method->description)) {
                 return $method;
             }
         }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -950,7 +950,7 @@ final class Expectation
             }
 
             if (! class_exists($exception)) {
-                if ($e instanceof Error && $e->getMessage() === "Class \"$exception\" not found") {
+                if ($e instanceof Error && "Class \"$exception\" not found" === $e->getMessage()) {
                     Assert::assertTrue(true);
 
                     throw $e;

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -16,6 +16,7 @@ use Pest\Support\Backtrace;
 use Pest\Support\Exporter;
 use Pest\Support\HigherOrderCallables;
 use Pest\Support\NullClosure;
+use Pest\Support\Str;
 use Pest\TestSuite;
 use PHPUnit\Framework\TestCase;
 
@@ -209,7 +210,7 @@ final class TestCall
      */
     private function skipOn(string $osFamily, string $message): self
     {
-        return PHP_OS_FAMILY === $osFamily
+        return $osFamily === PHP_OS_FAMILY
             ? $this->skip($message)
             : $this;
     }
@@ -361,7 +362,7 @@ final class TestCall
     {
         if (! is_null($this->describing)) {
             $this->testCaseMethod->describing = $this->describing;
-            $this->testCaseMethod->description = sprintf('`%s` → %s', $this->describing, $this->testCaseMethod->description);
+            $this->testCaseMethod->description = Str::describe($this->describing, $this->testCaseMethod->description); // @phpstan-ignore-line
         }
 
         $this->testSuite->tests->set($this->testCaseMethod);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -51,7 +51,7 @@ final class Str
             return true;
         }
 
-        return substr($target, -$length) === $search;
+        return $search === substr($target, -$length);
     }
 
     /**
@@ -91,5 +91,13 @@ final class Str
     public static function after(string $subject, string $search): string
     {
         return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+    }
+
+    /**
+     * Creates a describe block as `$right` → `$left` format.
+     */
+    public static function describe(string $right, string $left): string
+    {
+        return sprintf('`%s` → %s', $right, $left);
     }
 }

--- a/tests/Features/Describe.php
+++ b/tests/Features/Describe.php
@@ -76,3 +76,23 @@ describe('with on describe', function () {
         expect($foo)->toBe(3);
     });
 })->with([3]);
+
+describe('depends on describe', function () {
+    test('foo', function () {
+        expect('foo')->toBe('foo');
+    });
+
+    test('bar', function () {
+        expect('bar')->toBe('bar');
+    })->depends('foo');
+});
+
+describe('depends on describe using with', function () {
+    test('foo', function ($foo) {
+        expect($foo)->toBe(3);
+    });
+
+    test('bar', function ($foo) {
+        expect($foo + $foo)->toBe(6);
+    })->depends('foo');
+})->with([3]);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR aims to introduce the ability to use `describe` with `depends`:

```php
describe('depends on describe', function () {
    test('foo', function () {
        expect('foo')->toBe('foo');
    });

    test('bar', function () {
        expect('bar')->toBe('bar');
    })->depends('foo');
});
```

### Related:

https://github.com/pestphp/pest/issues/936
