### PR TITLE
[2.x] Update phpunit.xml stub file

### DIFF
--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-    </coverage>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+    <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+    <env name="MAIL_MAILER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="TELESCOPE_ENABLED" value="false"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
-  <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
-    </testsuite>
-    <testsuite name="Feature">
-      <directory suffix="Test.php">./tests/Feature</directory>
-    </testsuite>
-  </testsuites>
-  <coverage/>
-  <php>
-    <env name="APP_ENV" value="testing"/>
-    <env name="BCRYPT_ROUNDS" value="4"/>
-    <env name="CACHE_DRIVER" value="array"/>
-    <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-    <!-- <env name="DB_DATABASE" value=":memory:"/> -->
-    <env name="MAIL_MAILER" value="array"/>
-    <env name="QUEUE_CONNECTION" value="sync"/>
-    <env name="SESSION_DRIVER" value="array"/>
-    <env name="TELESCOPE_ENABLED" value="false"/>
-  </php>
-  <source>
-    <include>
-      <directory suffix=".php">./app</directory>
-    </include>
-  </source>
+  	<testsuites>
+    	<testsuite name="Unit">
+      		<directory suffix="Test.php">./tests/Unit</directory>
+    	</testsuite>
+    	<testsuite name="Feature">
+      		<directory suffix="Test.php">./tests/Feature</directory>
+    	</testsuite>
+  	</testsuites>
+  	<coverage/>
+  	<php>
+    	<env name="APP_ENV" value="testing"/>
+    	<env name="BCRYPT_ROUNDS" value="4"/>
+    	<env name="CACHE_DRIVER" value="array"/>
+    	<!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+    	<!-- <env name="DB_DATABASE" value=":memory:"/> -->
+    	<env name="MAIL_MAILER" value="array"/>
+    	<env name="QUEUE_CONNECTION" value="sync"/>
+    	<env name="SESSION_DRIVER" value="array"/>
+    	<env name="TELESCOPE_ENABLED" value="false"/>
+  	</php>
+  	<source>
+    	<include>
+      		<directory suffix=".php">./app</directory>
+    	</include>
+  	</source>
 </phpunit>

--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -12,7 +12,6 @@
       		<directory suffix="Test.php">./tests/Feature</directory>
     	</testsuite>
   	</testsuites>
-  	<coverage/>
   	<php>
     	<env name="APP_ENV" value="testing"/>
     	<env name="BCRYPT_ROUNDS" value="4"/>

--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
   	<testsuites>
     	<testsuite name="Unit">
       		<directory suffix="Test.php">./tests/Unit</directory>

--- a/stubs/init/phpunit.xml.stub
+++ b/stubs/init/phpunit.xml.stub
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <coverage/>
+    <source>
         <include>
             <directory suffix=".php">./app</directory>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/stubs/init/phpunit.xml.stub
+++ b/stubs/init/phpunit.xml.stub
@@ -9,7 +9,6 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage/>
     <source>
         <include>
             <directory suffix=".php">./app</directory>

--- a/stubs/init/phpunit.xml.stub
+++ b/stubs/init/phpunit.xml.stub
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests</directory>


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

When `pest --init` in PHP project, `phpunit.xml` was not up to date, So the Warning message was always visible : 

```
Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
``` 

### Related:

Related to [Issue #955](https://github.com/pestphp/pest/issues/955)
