### PR TITLE
Switch mixed indentation to spaces only in Laravel stub for `phpunit.xml.stub`

### DIFF
--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
 >

--- a/stubs/init-laravel/phpunit.xml.stub
+++ b/stubs/init-laravel/phpunit.xml.stub
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd
          bootstrap="vendor/autoload.php"
          colors="true"
 >
-  	<testsuites>
-    	<testsuite name="Unit">
-      		<directory suffix="Test.php">./tests/Unit</directory>
-    	</testsuite>
-    	<testsuite name="Feature">
-      		<directory suffix="Test.php">./tests/Feature</directory>
-    	</testsuite>
-  	</testsuites>
-  	<php>
-    	<env name="APP_ENV" value="testing"/>
-    	<env name="BCRYPT_ROUNDS" value="4"/>
-    	<env name="CACHE_DRIVER" value="array"/>
-    	<!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-    	<!-- <env name="DB_DATABASE" value=":memory:"/> -->
-    	<env name="MAIL_MAILER" value="array"/>
-    	<env name="QUEUE_CONNECTION" value="sync"/>
-    	<env name="SESSION_DRIVER" value="array"/>
-    	<env name="TELESCOPE_ENABLED" value="false"/>
-  	</php>
-  	<source>
-    	<include>
-      		<directory suffix=".php">./app</directory>
-    	</include>
-  	</source>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

PR #956 switched to using a mix of spaces and tabs for the indentation. This PR fixes the indentation to spaces only.

### Related:

#956 