### PR TITLE
[2.x] Added `toUseTrait` arch expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -753,6 +753,19 @@ final class Expectation
     }
 
     /**
+     * Asserts that the given expectation dependency uses the given trait.
+     */
+    public function toUseTrait(string $trait): ArchExpectation
+    {
+        return Targeted::make(
+            $this,
+            fn (ObjectDescription $object): bool => array_key_exists($trait, $object->reflectionClass->getTraits()),
+            sprintf("to use trait '%s'", $trait),
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
+        );
+    }
+
+    /**
      * Asserts that the given expectation is iterable and contains snake_case keys.
      *
      * @return self<TValue>

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -755,7 +755,7 @@ final class Expectation
     /**
      * Asserts that the given expectation dependency uses the given trait.
      *
-     * @param array<int, string>|string $traits
+     * @param  array<int, string>|string  $traits
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {
@@ -773,7 +773,7 @@ final class Expectation
                         $allTraits = [...$allTraits, ...class_uses($parent)];
                     }
 
-                    if (!array_key_exists($trait, $allTraits)) {
+                    if (! array_key_exists($trait, $allTraits)) {
                         return false;
                     }
                 }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -759,6 +759,7 @@ final class Expectation
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {
+        /** @var string[] $traits */
         $traits = is_array($traits) ? $traits : [$traits];
 
         return Targeted::make(

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -754,6 +754,8 @@ final class Expectation
 
     /**
      * Asserts that the given expectation dependency uses the given trait.
+     *
+     * @param array<int, string>|string $traits
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -759,30 +759,19 @@ final class Expectation
     {
         return Targeted::make(
             $this,
-            fn (ObjectDescription $object): bool => $this->objectUsesTrait($object, $trait),
+            function (ObjectDescription $object) use ($trait): bool {
+                $allTraits = $object->reflectionClass->getTraits();
+
+                // Find the traits used by all the parent classes.
+                foreach (class_parents($object->name) as $parent) {
+                    $allTraits = [...$allTraits, ...class_uses($parent)];
+                }
+
+                return array_key_exists($trait, $allTraits);
+            },
             sprintf("to use trait '%s'", $trait),
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
         );
-    }
-
-    /**
-     * Determine whether the given object uses the given trait. The trait may
-     * be used in the object itself or in one of its parent classes.
-     *
-     * @param ObjectDescription $object
-     * @param string $trait
-     * @return bool
-     */
-    private function objectUsesTrait(ObjectDescription $object, string $trait): bool
-    {
-        $allTraits = $object->reflectionClass->getTraits();
-
-        // Find the traits used by all the parent classes.
-        foreach (class_parents($object->name) as $parent) {
-            $allTraits = [...$allTraits, ...class_uses($parent)];
-        }
-
-        return array_key_exists($trait, $allTraits);
     }
 
     /**

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -394,6 +394,8 @@ final class OppositeExpectation
 
     /**
      * Asserts that the given expectation dependency does not use the given trait.
+     *
+     * @param array<int, string>|string $traits
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -393,6 +393,28 @@ final class OppositeExpectation
     }
 
     /**
+     * Asserts that the given expectation dependency does not use the given trait.
+     */
+    public function toUseTrait(string $trait): ArchExpectation
+    {
+        return Targeted::make(
+            $this->original,
+            function (ObjectDescription $object) use ($trait): bool {
+                $allTraits = $object->reflectionClass->getTraits();
+
+                // Find the traits used by all the parent classes.
+                foreach (class_parents($object->name) as $parent) {
+                    $allTraits = [...$allTraits, ...class_uses($parent)];
+                }
+
+                return !array_key_exists($trait, $allTraits);
+            },
+            sprintf("to not use trait '%s'", $trait),
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
+        );
+    }
+
+    /**
      * Asserts that the given expectation target not to have the given attribute.
      *
      * @param  class-string<Attribute>  $attribute

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -399,6 +399,7 @@ final class OppositeExpectation
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {
+        /** @var string[] $traits */
         $traits = is_array($traits) ? $traits : [$traits];
 
         return Targeted::make(

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -395,7 +395,7 @@ final class OppositeExpectation
     /**
      * Asserts that the given expectation dependency does not use the given trait.
      *
-     * @param array<int, string>|string $traits
+     * @param  array<int, string>|string  $traits
      */
     public function toUseTrait(array|string $traits): ArchExpectation
     {

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -395,21 +395,29 @@ final class OppositeExpectation
     /**
      * Asserts that the given expectation dependency does not use the given trait.
      */
-    public function toUseTrait(string $trait): ArchExpectation
+    public function toUseTrait(array|string $traits): ArchExpectation
     {
+        $traits = is_array($traits) ? $traits : [$traits];
+
         return Targeted::make(
             $this->original,
-            function (ObjectDescription $object) use ($trait): bool {
-                $allTraits = $object->reflectionClass->getTraits();
+            function (ObjectDescription $object) use ($traits): bool {
+                foreach ($traits as $trait) {
+                    $allTraits = $object->reflectionClass->getTraits();
 
-                // Find the traits used by all the parent classes.
-                foreach (class_parents($object->name) as $parent) {
-                    $allTraits = [...$allTraits, ...class_uses($parent)];
+                    // Find the traits used by all the parent classes.
+                    foreach (class_parents($object->name) as $parent) {
+                        $allTraits = [...$allTraits, ...class_uses($parent)];
+                    }
+
+                    if (array_key_exists($trait, $allTraits)) {
+                        return false;
+                    }
                 }
 
-                return !array_key_exists($trait, $allTraits);
+                return true;
             },
-            sprintf("to not use trait '%s'", $trait),
+            "to not use traits '".implode("', '", $traits)."'",
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
         );
     }

--- a/tests/Features/Expect/toUseTrait.php
+++ b/tests/Features/Expect/toUseTrait.php
@@ -29,6 +29,13 @@ describe('toUseTrait', function () {
         ->toUseTrait(TraitOne::class)
         ->toUseTrait(TraitTwo::class);
 
+    test('check class uses multiple traits in array format')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
+        ->toUseTrait([
+            TraitOne::class,
+            TraitTwo::class,
+        ]);
+
     test('failure when the class does not use a trait')
         ->throws(ArchExpectationFailedException::class)
         ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')

--- a/tests/Features/Expect/toUseTrait.php
+++ b/tests/Features/Expect/toUseTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+use Tests\Fixtures\Arch\ToUseTrait\TraitOne;
+use Tests\Fixtures\Arch\ToUseTrait\TraitTwo;
+
+
+test('class uses trait')
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+    ->toUseTrait(TraitOne::class);
+
+test('opposite class does not use trait')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+    ->not->toUseTrait(TraitOne::class);
+
+test('class uses a trait via a parent class')
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneViaParent')
+    ->toUseTrait(TraitOne::class);
+
+test('class uses multiple traits')
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
+    ->toUseTrait(TraitOne::class)
+    ->toUseTrait(TraitTwo::class);
+
+test('check class uses multiple traits using array')
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
+    ->toUseTrait([
+        TraitOne::class,
+        TraitTwo::class,
+    ]);
+
+test('failure when the class does not use a trait')
+    ->throws(ArchExpectationFailedException::class)
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+    ->toUseTrait(TraitTwo::class);
+
+test('class does not use a trait')
+    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+    ->not->toUseTrait(TraitTwo::class);

--- a/tests/Features/Expect/toUseTrait.php
+++ b/tests/Features/Expect/toUseTrait.php
@@ -6,37 +6,35 @@ use Pest\Arch\Exceptions\ArchExpectationFailedException;
 use Tests\Fixtures\Arch\ToUseTrait\TraitOne;
 use Tests\Fixtures\Arch\ToUseTrait\TraitTwo;
 
+describe('toUseTrait', function () {
+    test('class uses trait')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+        ->toUseTrait(TraitOne::class);
 
-test('class uses trait')
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
-    ->toUseTrait(TraitOne::class);
+    test('opposite class does not use trait')
+        ->throws(ArchExpectationFailedException::class)
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+        ->not->toUseTrait(TraitOne::class);
 
-test('opposite class does not use trait')
-    ->throws(ArchExpectationFailedException::class)
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
-    ->not->toUseTrait(TraitOne::class);
+    test('class uses a trait via a parent class')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneViaParent')
+        ->toUseTrait(TraitOne::class);
 
-test('class uses a trait via a parent class')
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneViaParent')
-    ->toUseTrait(TraitOne::class);
+    test('class uses a trait via a parents parent class')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneViaParentsParent')
+        ->toUseTrait(TraitOne::class);
 
-test('class uses multiple traits')
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
-    ->toUseTrait(TraitOne::class)
-    ->toUseTrait(TraitTwo::class);
+    test('class uses multiple traits')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
+        ->toUseTrait(TraitOne::class)
+        ->toUseTrait(TraitTwo::class);
 
-test('check class uses multiple traits using array')
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOneAndTwo')
-    ->toUseTrait([
-        TraitOne::class,
-        TraitTwo::class,
-    ]);
+    test('failure when the class does not use a trait')
+        ->throws(ArchExpectationFailedException::class)
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+        ->toUseTrait(TraitTwo::class);
 
-test('failure when the class does not use a trait')
-    ->throws(ArchExpectationFailedException::class)
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
-    ->toUseTrait(TraitTwo::class);
-
-test('class does not use a trait')
-    ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
-    ->not->toUseTrait(TraitTwo::class);
+    test('class does not use a trait')
+        ->expect('Tests\\Fixtures\\Arch\\ToUseTrait\\UsesTraitOne')
+        ->not->toUseTrait(TraitTwo::class);
+});

--- a/tests/Fixtures/Arch/ToUseTrait/EmptyParentClass.php
+++ b/tests/Fixtures/Arch/ToUseTrait/EmptyParentClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+class EmptyParentClass extends ParentClassUsingTrait
+{
+    //
+}

--- a/tests/Fixtures/Arch/ToUseTrait/ParentClassUsingTrait.php
+++ b/tests/Fixtures/Arch/ToUseTrait/ParentClassUsingTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+class ParentClassUsingTrait
+{
+    use TraitOne;
+}

--- a/tests/Fixtures/Arch/ToUseTrait/TraitOne.php
+++ b/tests/Fixtures/Arch/ToUseTrait/TraitOne.php
@@ -6,5 +6,4 @@ namespace Tests\Fixtures\Arch\ToUseTrait;
 
 trait TraitOne
 {
-
 }

--- a/tests/Fixtures/Arch/ToUseTrait/TraitOne.php
+++ b/tests/Fixtures/Arch/ToUseTrait/TraitOne.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+trait TraitOne
+{
+
+}

--- a/tests/Fixtures/Arch/ToUseTrait/TraitTwo.php
+++ b/tests/Fixtures/Arch/ToUseTrait/TraitTwo.php
@@ -6,5 +6,4 @@ namespace Tests\Fixtures\Arch\ToUseTrait;
 
 trait TraitTwo
 {
-
 }

--- a/tests/Fixtures/Arch/ToUseTrait/TraitTwo.php
+++ b/tests/Fixtures/Arch/ToUseTrait/TraitTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+trait TraitTwo
+{
+
+}

--- a/tests/Fixtures/Arch/ToUseTrait/UsesTraitOne.php
+++ b/tests/Fixtures/Arch/ToUseTrait/UsesTraitOne.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+class UsesTraitOne
+{
+    use TraitOne;
+}

--- a/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneAndTwo.php
+++ b/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneAndTwo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+/**
+ * This class uses TraitTwo in this class itself, and uses TraitTwo
+ * via the parent class that we're extending from.
+ */
+class UsesTraitOneAndTwo extends ParentClassUsingTrait
+{
+    use TraitTwo;
+}

--- a/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneViaParent.php
+++ b/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneViaParent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+class UsesTraitOneViaParent extends ParentClassUsingTrait
+{
+    //
+}

--- a/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneViaParentsParent.php
+++ b/tests/Fixtures/Arch/ToUseTrait/UsesTraitOneViaParentsParent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait;
+
+class UsesTraitOneViaParentsParent extends EmptyParentClass
+{
+    //
+}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Hey! This PR proposes a new `toUseTrait` arch expectation. There are times when I want to ensure that classes in a given directory are all using a specific trait.

For example, in my `app/Actions` folder, I might be using the `lorisleiva/laravel-actions` package which allows me to add an `Lorisleiva\Actions\Concerns\AsAction` trait to all my action classes. Example:

```php
namespace App\Actions\Users;

use Lorisleiva\Actions\Concerns\AsAction;

class CreateUser
{
    use AsAction;

    // ...
}
```

In this situation, I'd like be to able to do something like:

```php
test('all actions use AsAction trait')
    ->expect('App\Actions')
    ->toUseTrait(AsAction::class);
```

I've also added support for checking multiple at once. For example:

```php
test('all actions use both traits')
    ->expect('App\Actions')
    ->toUseTrait([
        AsAction::class,
        MyAwesomeTrait::class,
    ]);
```

Running the above would ensure that all the classes in the `app/Actions` folder will use the `AsAction` trait AND the `MyAwesomeTrait`.

There's also the opposite expectation that you can use to make sure a given trait isn't being used:

```php
test('no actions use AsAction trait')
    ->expect('App\Actions')
    ->not->toUseTrait(AsAction::class);
```

This expectation will bubble up and check all the given class' traits too. So if a class has access to a trait, but via a parent class, this _should_ detect that and pass the expectation.

### Caveats

I think the main caveat to what I've done so far is that it's not detecting traits used by other traits. For example, say we have a trait called `BaseActionTrait` and this trait uses the `AsAction` trait:

```php
trait BaseActionTrait {
    use AsAction;

    // ...
}
```

Then let's say you have a class that uses the `BaseActionTrait`:

```php
class MyAction {
    use BaseActionTrait;

    // ...
}
```

If you were to run the following test, it would fail:

```php
test('all actions use AsAction trait')
    ->expect('App\Actions')
    ->toUseTrait(AsAction::class);
```

I don't know if this is an issue or not. But I didn't want to spend too much time working on it just in case it's something that might not be needed or wanted. I'm happy to have a crack at adding it though 🙂

### Related:

N/A

If you think this new `toUseTrait` expectation would be useful, please give me a shout if there's anything you'd like me to update.

I've tried my best to test this out, but I might have missed some edges. Apologies if so! 😄
