### PR TITLE
[2.x] Allow define multiple hooks per directory

### DIFF
--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -25,7 +25,7 @@ final class TestRepository
     private array $testCases = [];
 
     /**
-     * @var array<string, array{0: array<int, string>, 1: array<int, string>, 2: array<int, string|Closure>}>
+     * @var array<string, array{0: array<int, string>, 1: array<int, string>, 2: array<int, array<int, string|Closure>>}>
      */
     private array $uses = [];
 
@@ -77,12 +77,17 @@ final class TestRepository
             throw new TestCaseClassOrTraitNotFound($classOrTrait);
         }
 
+        $hooks = array_map(fn (Closure $hook): array => [$hook], $hooks);
+
         foreach ($paths as $path) {
             if (array_key_exists($path, $this->uses)) {
                 $this->uses[$path] = [
                     [...$this->uses[$path][0], ...$classOrTraits],
                     [...$this->uses[$path][1], ...$groups],
-                    $this->uses[$path][2] + $hooks,
+                    array_map(
+                        fn (int $index): array => [...$this->uses[$path][2][$index] ?? [], ...($hooks[$index] ?? [])],
+                        range(0, 3),
+                    ),
                 ];
             } else {
                 $this->uses[$path] = [$classOrTraits, $groups, $hooks];
@@ -189,10 +194,11 @@ final class TestRepository
                     $method->groups = [...$groups, ...$method->groups];
                 }
 
-                $testCase->factoryProxies->add($testCase->filename, 0, '__addBeforeAll', [$hooks[0] ?? null]);
-                $testCase->factoryProxies->add($testCase->filename, 0, '__addBeforeEach', [$hooks[1] ?? null]);
-                $testCase->factoryProxies->add($testCase->filename, 0, '__addAfterEach', [$hooks[2] ?? null]);
-                $testCase->factoryProxies->add($testCase->filename, 0, '__addAfterAll', [$hooks[3] ?? null]);
+                foreach (['__addBeforeAll', '__addBeforeEach', '__addAfterEach', '__addAfterAll'] as $index => $name) {
+                    foreach ($hooks[$index] ?? [null] as $hook) {
+                        $testCase->factoryProxies->add($testCase->filename, 0, $name, [$hook]);
+                    }
+                }
             }
         }
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1377,4 +1377,5 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 978 passed (2304 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 953 passed (2323 assertions)
+

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -154,6 +154,10 @@
   ✓ it can correctly resolve a bound dataset that returns an array with (Closure)
   ✓ it can correctly resolve a bound dataset that returns an array but wants to be spread with (Closure)
   ↓ forbids to define tests in Datasets dirs and Datasets.php files
+  ✓ it may be used with high order with dataset "formal"
+  ✓ it may be used with high order with dataset "informal"
+  ✓ it may be used with high order even when bound with dataset "formal"
+  ✓ it may be used with high order even when bound with dataset "informal"
 
    PASS  Tests\Features\Depends
   ✓ first
@@ -1134,8 +1138,16 @@
    PASS  Tests\Helpers\TestInHelpers
   ✓ it executes tests in the Helpers directory
 
+   PASS  Tests\Hooks\AfterAllTest
+  ✓ global afterAll execution order
+  ✓ it only gets called once per file
+
    PASS  Tests\Hooks\AfterEachTest
   ✓ global afterEach execution order
+
+   PASS  Tests\Hooks\BeforeAllTest
+  ✓ global beforeAll execution order
+  ✓ it only gets called once per file
 
    PASS  Tests\Hooks\BeforeEachTest
   ✓ global beforeEach execution order
@@ -1377,5 +1389,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 953 passed (2323 assertions)
-
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 986 passed (2372 assertions)

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -1,0 +1,45 @@
+<?php
+
+uses()->afterAll(function () {
+    expect($_SERVER['globalHook'])
+        ->toHaveProperty('afterAll')
+        ->and($_SERVER['globalHook']->afterAll)
+        ->toBe(1)
+        ->and($_SERVER['globalHook']->calls)
+        ->afterAll
+        ->toBe(1);
+
+    $_SERVER['globalHook']->afterAll = 2;
+    $_SERVER['globalHook']->calls->afterAll++;
+});
+
+afterAll(function () {
+    expect($_SERVER['globalHook'])
+        ->toHaveProperty('afterAll')
+        ->and($_SERVER['globalHook']->afterAll)
+        ->toBe(1)
+        ->and($_SERVER['globalHook']->calls)
+        ->afterAll
+        ->toBe(2);
+
+    $_SERVER['globalHook']->afterAll = 2;
+    $_SERVER['globalHook']->calls->afterAll++;
+});
+
+test('global afterAll execution order', function () {
+    expect($_SERVER['globalHook'])
+        ->not()
+        ->toHaveProperty('afterAll')
+        ->and($_SERVER['globalHook']->calls)
+        ->afterAll
+        ->toBe(0);
+});
+
+it('only gets called once per file', function () {
+    expect($_SERVER['globalHook'])
+        ->not()
+        ->toHaveProperty('afterAll')
+        ->and($_SERVER['globalHook']->calls)
+        ->afterAll
+        ->toBe(0);
+});

--- a/tests/Hooks/AfterEachTest.php
+++ b/tests/Hooks/AfterEachTest.php
@@ -4,16 +4,16 @@ uses()->afterEach(function () {
     expect($this)
         ->toHaveProperty('ith')
         ->and($this->ith)
-        ->toBe(0);
+        ->toBe(1);
 
-    $this->ith = 1;
+    $this->ith = 2;
 });
 
 afterEach(function () {
     expect($this)
         ->toHaveProperty('ith')
         ->and($this->ith)
-        ->toBe(1);
+        ->toBe(2);
 });
 
 test('global afterEach execution order', function () {

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Pest\Plugins\Parallel;
+use Pest\Support\Str;
+
+// HACK: we have to determine our $_SERVER['globalHook-]>calls baseline. This is because
+// two other tests are executed before this one due to filename ordering.
+$args = $_SERVER['argv'] ?? [];
+$single = (isset($args[1]) && Str::endsWith(__FILE__, $args[1])) || Parallel::isWorker();
+$offset = $single ? 0 : 2;
+
+uses()->beforeAll(function () use ($offset) {
+    expect($_SERVER['globalHook'])
+        ->toHaveProperty('beforeAll')
+        ->and($_SERVER['globalHook']->beforeAll)
+        ->toBe(1)
+        ->and($_SERVER['globalHook']->calls)
+        ->beforeAll
+        ->toBe(1 + $offset);
+
+    $_SERVER['globalHook']->beforeAll = 2;
+    $_SERVER['globalHook']->calls->beforeAll++;
+});
+
+beforeAll(function () use ($offset) {
+    expect($_SERVER['globalHook'])
+        ->toHaveProperty('beforeAll')
+        ->and($_SERVER['globalHook']->beforeAll)
+        ->toBe(2)
+        ->and($_SERVER['globalHook']->calls)
+        ->beforeAll
+        ->toBe(2 + $offset);
+
+    $_SERVER['globalHook']->beforeAll = 3;
+    $_SERVER['globalHook']->calls->beforeAll++;
+});
+
+test('global beforeAll execution order', function () use ($offset) {
+    expect($_SERVER['globalHook'])
+        ->toHaveProperty('beforeAll')
+        ->and($_SERVER['globalHook']->beforeAll)
+        ->toBe(3)
+        ->and($_SERVER['globalHook']->calls)
+        ->beforeAll
+        ->toBe(3 + $offset);
+});
+
+it('only gets called once per file', function () use ($offset) {
+    expect($_SERVER['globalHook'])
+        ->beforeAll
+        ->toBe(3)
+        ->and($_SERVER['globalHook']->calls)
+        ->beforeAll
+        ->toBe(3 + $offset);
+});

--- a/tests/Hooks/BeforeEachTest.php
+++ b/tests/Hooks/BeforeEachTest.php
@@ -4,23 +4,23 @@ uses()->beforeEach(function () {
     expect($this)
         ->toHaveProperty('baz')
         ->and($this->baz)
-        ->toBe(0);
+        ->toBe(1);
 
-    $this->baz = 1;
+    $this->baz = 2;
 });
 
 beforeEach(function () {
     expect($this)
         ->toHaveProperty('baz')
         ->and($this->baz)
-        ->toBe(1);
+        ->toBe(2);
 
-    $this->baz = 2;
+    $this->baz = 3;
 });
 
 test('global beforeEach execution order', function () {
     expect($this)
         ->toHaveProperty('baz')
         ->and($this->baz)
-        ->toBe(2);
+        ->toBe(3);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -33,6 +33,41 @@ uses()
     })
     ->in('Hooks');
 
+uses()
+    ->beforeEach(function () {
+        expect($this)
+            ->toHaveProperty('baz')
+            ->and($this->baz)
+            ->toBe(0);
+
+        $this->baz = 1;
+    })
+    ->beforeAll(function () {
+        expect($_SERVER['globalHook'])
+            ->toHaveProperty('beforeAll')
+            ->and($_SERVER['globalHook']->beforeAll)
+            ->toBe(0);
+
+        $_SERVER['globalHook']->beforeAll = 1;
+    })
+    ->afterEach(function () {
+        expect($this)
+            ->toHaveProperty('ith')
+            ->and($this->ith)
+            ->toBe(0);
+
+        $this->ith = 1;
+    })
+    ->afterAll(function () {
+        expect($_SERVER['globalHook'])
+            ->toHaveProperty('afterAll')
+            ->and($_SERVER['globalHook']->afterAll)
+            ->toBe(0);
+
+        $_SERVER['globalHook']->afterAll = 1;
+    })
+    ->in('Hooks');
+
 function helper_returns_string()
 {
     return 'string';

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 965 passed (2285 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 973 passed (2353 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR allows to define multiple beforeAll/beforeEach/efterEach/afterAll hooks in the `Pest.php` file for the same directory. 

#### Why

When I develop Laravel applications, I often create contract tests (in `Contracts`). The `beforeEach` is really similar to the one I use in the folder `Feature`.

```php
uses()->beforeEach(function (): void {
    $this->withoutExceptionHandling([
        AuthenticationException::class,
        AuthorizationException::class,
        BackedEnumCaseNotFoundException::class,
        HttpException::class,
        HttpResponseException::class,
        ModelNotFoundException::class,
        ValidationException::class,
    ]);

    $this->withoutDeprecationHandling();
})->in('Feature');

uses()->beforeEach(function (): void {
    $this->withoutExceptionHandling([
        AuthenticationException::class,
        AuthorizationException::class,
        BackedEnumCaseNotFoundException::class,
        HttpException::class,
        HttpResponseException::class,
        ModelNotFoundException::class,
        ValidationException::class,
    ]);

    $this->withoutDeprecationHandling();

    Spectator::using('project.openapi.yaml');
})->in('Contact');
```

This would be awesome to be able to simplify the setup with 
```php
uses()->beforeEach(function (): void {
    $this->withoutExceptionHandling([
        AuthenticationException::class,
        AuthorizationException::class,
        BackedEnumCaseNotFoundException::class,
        HttpException::class,
        HttpResponseException::class,
        ModelNotFoundException::class,
        ValidationException::class,
    ]);

    $this->withoutDeprecationHandling();
})->in('Contact', 'Feature');

uses()->beforeEach(function (): void {
    Spectator::using('project.openapi.yaml');
})->in('Contact');
```

This is actually not possible because the second `beforeEach` is not executed.

I think this could be a useful addition.

Note: the hooks are executed in the order they are defined in the `Pest.php` file

