### PR TITLE
add toHaveConstructor() and toHaveDestructor() expectations

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -862,4 +862,20 @@ final class Expectation
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
         );
     }
+
+    /**
+     * Asserts that the given expectation target has a constructor method.
+     */
+    public function toHaveConstructor(): ArchExpectation
+    {
+        return $this->toHaveMethod('__construct');
+    }
+
+    /**
+     * Asserts that the given expectation target has a destructor method.
+     */
+    public function toHaveDestructor(): ArchExpectation
+    {
+        return $this->toHaveMethod('__destruct');
+    }
 }

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -469,4 +469,20 @@ final class OppositeExpectation
             implode(' ', array_map(fn (mixed $argument): string => $toString($argument), $arguments)),
         ));
     }
+
+    /**
+     * Asserts that the given expectation target does not have a constructor method.
+     */
+    public function toHaveConstructor(): ArchExpectation
+    {
+        return $this->toHaveMethod('__construct');
+    }
+
+    /**
+     * Asserts that the given expectation target does not have a destructor method.
+     */
+    public function toHaveDestructor(): ArchExpectation
+    {
+        return $this->toHaveMethod('__destruct');
+    }
 }

--- a/tests/Features/Expect/toHaveConstructor.php
+++ b/tests/Features/Expect/toHaveConstructor.php
@@ -1,0 +1,9 @@
+<?php
+
+test('class has constructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveConstructor\HasConstructor\HasConstructor')
+    ->toHaveConstructor();
+
+test('class has no constructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveConstructor\HasNoConstructor\HasNoConstructor')
+    ->not->toHaveConstructor();

--- a/tests/Features/Expect/toHaveDestructor.php
+++ b/tests/Features/Expect/toHaveDestructor.php
@@ -1,0 +1,9 @@
+<?php
+
+test('class has destructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveDestructor\HasDestructor\HasDestructor')
+    ->toHaveDestructor();
+
+test('class has no destructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveDestructor\HasNoDestructor\HasNoDestructor')
+    ->not->toHaveDestructor();

--- a/tests/Fixtures/Arch/ToHaveConstructor/HasConstructor/HasConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveConstructor/HasConstructor/HasConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveConstructor\HasConstructor;
+
+class HasConstructor
+{
+    public function __construct()
+    {
+
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveConstructor\HasNoConstructor;
+
+class HasNoConstructor
+{
+
+}

--- a/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
@@ -6,5 +6,4 @@ namespace Tests\Fixtures\Arch\ToHaveConstructor\HasNoConstructor;
 
 class HasNoConstructor
 {
-
 }

--- a/tests/Fixtures/Arch/ToHaveDestructor/HasDestructor/HasDestructor.php
+++ b/tests/Fixtures/Arch/ToHaveDestructor/HasDestructor/HasDestructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveDestructor\HasDestructor;
+
+class HasDestructor
+{
+    public function __destruct()
+    {
+
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
+++ b/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
@@ -6,5 +6,4 @@ namespace Tests\Fixtures\Arch\ToHaveDestructor\HasNoDestructor;
 
 class HasNoDestructor
 {
-
 }

--- a/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
+++ b/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveDestructor\HasNoDestructor;
+
+class HasNoDestructor
+{
+
+}


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Adds a more fluent way to be able to check that classes have a constructor and/or destructor. Currently, you'd do something like:

```php
test('classes have a constructor and destructor')
    ->expect('App\Http\Example')
    ->toHaveMethod('__construct');
    ->toHaveMethod('__destruct');
```

with this PR, you can instead do:

```php
test('classes have a constructor and destructor')
    ->expect('App\Http\Example')
    ->toHaveConstructor()
    ->toHaveDestructor();
```

If you need to check to see if classes _don't_ have a constructor and/or destructor, then you can do:

```php
test('classes do not have a constructor and destructor')
    ->expect('App\Http\Example')
    ->not->toHaveConstructor()
    ->not->toHaveDestructor();
```