### PR TITLE
[2.x] Add `toBeBetween` expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1128,4 +1128,17 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is between 2 specified values
+     *
+     * @return self<TValue>
+     */
+    public function toBeBetween(int|float|DateTimeInterface $lowestValue, int|float|DateTimeInterface $highestValue, string $message = ''): self
+    {
+        Assert::assertGreaterThanOrEqual($lowestValue, $this->value, $message);
+        Assert::assertLessThanOrEqual($highestValue, $this->value, $message);
+
+        return $this;
+    }
 }

--- a/tests/Features/Expect/toBeBetween.php
+++ b/tests/Features/Expect/toBeBetween.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with int', function () {
+    expect(2)->toBeBetween(1, 3);
+});
+
+test('passes with float', function () {
+    expect(1.5)->toBeBetween(1.25, 1.75);
+});
+
+test('passes with float and int', function () {
+    expect(1.5)->toBeBetween(1, 2);
+});
+
+test('passes with DateTime', function () {
+    expect(new DateTime('2023-09-22'))->toBeBetween(new DateTime('2023-09-21'), new DateTime('2023-09-23'));
+});
+
+test('failure with int', function () {
+    expect(4)->toBeBetween(1, 3);
+})->throws(ExpectationFailedException::class);
+
+test('failure with float', function () {
+    expect(2)->toBeBetween(1.5, 1.75);
+})->throws(ExpectationFailedException::class);
+
+test('failure with float and int', function () {
+    expect(2.1)->toBeBetween(1, 2);
+})->throws(ExpectationFailedException::class);
+
+test('failure with DateTime', function () {
+    expect(new DateTime('2023-09-20'))->toBeBetween(new DateTime('2023-09-21'), new DateTime('2023-09-23'));
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect(4)->toBeBetween(1, 3, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect(2)->not->toBeBetween(1, 3);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

This PR adds a `toBeBetween()` expectation. You pass in the 2 values you want your value to be between and the expectation will assert whether it's true or not. It works with Int, Float and DateTime types. 

```php
expect(1)->toBeBetween(1, 3);
expect(2)->toBeBetween(1, 3);
expect(1.5)->toBetween(1, 2);
expect(new DateTime('2023-09-22'))->toBeBetween(new DateTime('2023-09-21'), new DateTime('2023-09-23'));

expect(4)->not->toBeBetween(1, 3);
expect(2.1)->not->toBetween(1, 2);
expect(new DateTime('2023-09-20'))->not->toBeBetween(new DateTime('2023-09-21'), new DateTime('2023-09-23'));
```