### PR TITLE
[2.x] Add `toContainEquals` expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -197,6 +197,21 @@ final class Expectation
     }
 
     /**
+     * Asserts that $needle equals an element of the value.
+     * 
+     * @return self<TValue>
+     */
+    public function toContainEquals(mixed ...$needles): self
+    {
+        foreach ($needles as $needle) {
+            if (! is_iterable($this->value)) {
+                InvalidExpectationValue::expected('iterable');
+            }
+            Assert::assertContainsEquals($needle, $this->value);
+        }
+    }
+
+    /**
      * Asserts that the value starts with $expected.
      *
      * @param  non-empty-string  $expected

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -197,18 +197,21 @@ final class Expectation
     }
 
     /**
-     * Asserts that $needle equals an element of the value.
-     * 
+     * Asserts that $needle equal an element of the value.
+     *
      * @return self<TValue>
      */
-    public function toContainEquals(mixed ...$needles): self
+    public function toContainEqual(mixed ...$needles): self
     {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
         foreach ($needles as $needle) {
-            if (! is_iterable($this->value)) {
-                InvalidExpectationValue::expected('iterable');
-            }
             Assert::assertContainsEquals($needle, $this->value);
         }
+
+        return $this;
     }
 
     /**

--- a/tests/Features/Expect/toContainEqual.php
+++ b/tests/Features/Expect/toContainEqual.php
@@ -4,33 +4,33 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 
 test('passes arrays', function () {
-    expect([1, 2, 42])->toContainEquals('42');
+    expect([1, 2, 42])->toContainEqual('42');
 });
 
 test('passes arrays with multiple needles', function () {
-    expect([1, 2, 42])->toContainEquals('42', '2');
+    expect([1, 2, 42])->toContainEqual('42', '2');
 });
 
 test('failures', function () {
-    expect([1, 2, 42])->toContainEquals('3');
+    expect([1, 2, 42])->toContainEqual('3');
 })->throws(ExpectationFailedException::class);
 
 test('failures with multiple needles (all failing)', function () {
-    expect([1, 2, 42])->toContainEquals('3', '4');
+    expect([1, 2, 42])->toContainEqual('3', '4');
 })->throws(ExpectationFailedException::class);
 
 test('failures with multiple needles (some failing)', function () {
-    expect([1, 2, 42])->toContainEquals('1', '3', '4');
+    expect([1, 2, 42])->toContainEqual('1', '3', '4');
 })->throws(ExpectationFailedException::class);
 
 test('not failures', function () {
-    expect([1, 2, 42])->not->toContainEquals('42');
+    expect([1, 2, 42])->not->toContainEqual('42');
 })->throws(ExpectationFailedException::class);
 
 test('not failures with multiple needles (all failing)', function () {
-    expect([1, 2, 42])->not->toContainEquals('42', '2');
+    expect([1, 2, 42])->not->toContainEqual('42', '2');
 })->throws(ExpectationFailedException::class);
 
 test('not failures with multiple needles (some failing)', function () {
-    expect([1, 2, 42])->not->toContainEquals('42', '1');
+    expect([1, 2, 42])->not->toContainEqual('42', '1');
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainEquals.php
+++ b/tests/Features/Expect/toContainEquals.php
@@ -1,0 +1,36 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+
+test('passes arrays', function () {
+    expect([1, 2, 42])->toContain('42');
+});
+
+test('passes arrays with multiple needles', function () {
+    expect([1, 2, 42])->toContain('42', '2');
+});
+
+test('failures', function () {
+    expect([1, 2, 42])->toContain('3');
+})->throws(ExpectationFailedException::class);
+
+test('failures with multiple needles (all failing)', function () {
+    expect([1, 2, 42])->toContainEquals('3', '4');
+})->throws(ExpectationFailedException::class);
+
+test('failures with multiple needles (some failing)', function () {
+    expect([1, 2, 42])->toContainEquals('1', '3', '4');
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect([1, 2, 42])->not->toContainEquals('42');
+})->throws(ExpectationFailedException::class);
+
+test('not failures with multiple needles (all failing)', function () {
+    expect([1, 2, 42])->not->toContainEquals('42', '2');
+})->throws(ExpectationFailedException::class);
+
+test('not failures with multiple needles (some failing)', function () {
+    expect([1, 2, 42])->not->toContainEquals('42', '1');
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainEquals.php
+++ b/tests/Features/Expect/toContainEquals.php
@@ -4,15 +4,15 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 
 test('passes arrays', function () {
-    expect([1, 2, 42])->toContain('42');
+    expect([1, 2, 42])->toContainEquals('42');
 });
 
 test('passes arrays with multiple needles', function () {
-    expect([1, 2, 42])->toContain('42', '2');
+    expect([1, 2, 42])->toContainEquals('42', '2');
 });
 
 test('failures', function () {
-    expect([1, 2, 42])->toContain('3');
+    expect([1, 2, 42])->toContainEquals('3');
 })->throws(ExpectationFailedException::class);
 
 test('failures with multiple needles (all failing)', function () {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->

Adds an expectation `toContainEquals` which is analogous to `Assert::assertContainsEquals` from PHPUnit.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
