### PR TITLE
[3.x] Sharing `repeat` iteration as `dataset` variable

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -262,8 +262,9 @@ trait Testable
     {
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
 
-        if ($method->repetitions > 1 && $method->datasets !== []) {
-            array_shift($arguments);
+        if ($method->repetitions > 1) {
+            $firstArgument = array_shift($arguments);
+            $arguments[] = $firstArgument;
         }
 
         $underlyingTest = Reflection::getFunctionVariable($this->__test, 'closure');

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -262,7 +262,7 @@ trait Testable
     {
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
 
-        if ($method->repetitions > 1) {
+        if ($method->repetitions > 1 && $method->datasets !== []) {
             array_shift($arguments);
         }
 

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -263,6 +263,10 @@ trait Testable
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
 
         if ($method->repetitions > 1) {
+            // If the test is repeated, the first argument is the iteration number
+            // we need to move it to the end of the arguments list
+            // so that the datasets are the first n arguments
+            // and the iteration number is the last argument
             $firstArgument = array_shift($arguments);
             $arguments[] = $firstArgument;
         }

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -116,7 +116,7 @@ final class TestCaseMethodFactory
      */
     public function receivesArguments(): bool
     {
-        return $this->datasets !== [] || $this->depends !== [];
+        return $this->datasets !== [] || $this->depends !== [] || $this->repetitions > 1;
     }
 
     /**

--- a/tests/Features/Repeat.php
+++ b/tests/Features/Repeat.php
@@ -17,6 +17,29 @@ test('multiple times with multiple dataset', function (int $numberA, int $number
         ->and([4, 5, 6])->toContain($numberB);
 })->repeat(times: 7)->with(['a' => 1, 'b' => 2, 'c' => 3], [4, 5, 6]);
 
-test('multiple times with iterator as argument', function (int $iteration) {
-    expect($iteration)->toBeGreaterThan(0);
-})->repeat(times: 8);
+test('multiple times with iterator', function (int $iteration) {
+    expect($iteration)
+        ->toBeNumeric()
+        ->toBeGreaterThan(0);
+})->repeat(times: 2);
+
+test('multiple times with repeat iterator with single dataset', function (string $letter, int $iteration) {
+    expect($letter)
+        ->toBeString()
+        ->toBeIn(['a', 'b', 'c'])
+        ->and($iteration)
+        ->toBeNumeric()
+        ->toBeGreaterThan(0);
+})->repeat(times: 2)->with(['a', 'b', 'c']);
+
+test('multiple times with repeat iterator with multiple dataset', function (string $letterA, string $letterB, int $iteration) {
+    expect($letterA)
+        ->toBeString()
+        ->toBeIn(['a', 'b', 'c'])
+        ->and($letterB)
+        ->toBeString()
+        ->toBeIn(['d', 'e', 'f'])
+        ->and($iteration)
+        ->toBeNumeric()
+        ->toBeGreaterThan(0);
+})->repeat(times: 2)->with(['a', 'b', 'c'], ['d', 'e', 'f']);

--- a/tests/Features/Repeat.php
+++ b/tests/Features/Repeat.php
@@ -16,3 +16,7 @@ test('multiple times with multiple dataset', function (int $numberA, int $number
     expect([1, 2, 3])->toContain($numberA)
         ->and([4, 5, 6])->toContain($numberB);
 })->repeat(times: 7)->with(['a' => 1, 'b' => 2, 'c' => 3], [4, 5, 6]);
+
+test('multiple times with iterator as argument', function (int $iteration) {
+    expect($iteration)->toBeGreaterThan(0);
+})->repeat(times: 8);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Improvement

### Description:

- Essentially, what was previously in [Issue #908](https://github.com/pestphp/pest/issues/908) requested
- When no dataset is provided, but the repetitions are above 1, the current iteration should be passed to the closure of the test

### Related:
[Issue #908](https://github.com/pestphp/pest/issues/908)