### PR TITLE
[2.x] Adds `toBeUrl()` Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1142,4 +1142,20 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is a url
+     *
+     * @return self<TValue>
+     */
+    public function toBeUrl(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is a url.";
+        }
+
+        Assert::assertTrue(Str::isUrl((string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -108,4 +108,12 @@ final class Str
     {
         return sprintf('`%s` → %s', $describeDescription, $testDescription);
     }
+
+    /**
+     * Determine if a given value is a valid URL.
+     */
+    public static function isUrl(string $value): bool
+    {
+        return (bool) filter_var($value, FILTER_VALIDATE_URL);
+    }
 }

--- a/tests/Features/Expect/toBeUrl.php
+++ b/tests/Features/Expect/toBeUrl.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('https://pestphp.com')->toBeUrl()
+        ->and('pestphp.com')->not->toBeUrl();
+});
+
+test('failures', function () {
+    expect('pestphp.com')->toBeUrl();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('pestphp.com')->toBeUrl('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with default message', function () {
+    expect('pestphp.com')->toBeUrl();
+})->throws(ExpectationFailedException::class, 'Failed asserting that pestphp.com is a url.');
+
+test('not failures', function () {
+    expect('https://pestphp.com')->not->toBeUrl();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds a `toBeUrl()` expectation, to validate whether a value is a valid URL. This uses the same `isUrl()` method that Laravel has.

Example Usage:
```php
expect('https://pestphp.com')->toBeUrl();
expect('test')->not->toBeUrl();
```