### PR TITLE
[2.x] Refactor: Extract ANSI Escape Sequence Removal to a Function

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -194,3 +194,16 @@ if (! function_exists('afterAll')) {
         TestSuite::getInstance()->afterAll->set($closure);
     }
 }
+
+if (! function_exists('removeAnsiEscapeSequences')) {
+    /**
+     * Remove ANSI escape sequences from a given string.
+     *
+     * @param  string  $input The string containing ANSI escape sequences.
+     * @return string|null A new string with all ANSI escape sequences removed.
+     */
+    function removeAnsiEscapeSequences(string $input): ?string
+    {
+        return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $input);
+    }
+}

--- a/tests/Visual/Collision.php
+++ b/tests/Visual/Collision.php
@@ -10,7 +10,7 @@ test('collision', function (array $arguments) {
 
         $process->run();
 
-        return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
+        return removeAnsiEscapeSequences($process->getOutput());
     };
 
     $outputContent = explode("\n", $output());

--- a/tests/Visual/Help.php
+++ b/tests/Visual/Help.php
@@ -6,7 +6,7 @@ test('visual snapshot of help command output', function () {
 
         $process->run();
 
-        return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
+        return removeAnsiEscapeSequences($process->getOutput());
     };
 
     expect($output())->toMatchSnapshot();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -11,7 +11,7 @@ $run = function () {
 
     $process->run();
 
-    return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
+    return removeAnsiEscapeSequences($process->getOutput());
 };
 
 test('parallel', function () use ($run) {

--- a/tests/Visual/SingleTestOrDirectory.php
+++ b/tests/Visual/SingleTestOrDirectory.php
@@ -9,7 +9,7 @@ $run = function (string $target, $decorated = false) {
 
     $process->run();
 
-    return $decorated ? $process->getOutput() : preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
+    return $decorated ? $process->getOutput() : removeAnsiEscapeSequences($process->getOutput());
 };
 
 $snapshot = function ($name) {

--- a/tests/Visual/Todo.php
+++ b/tests/Visual/Todo.php
@@ -11,9 +11,7 @@ $run = function (string $target, bool $parallel) {
 
     expect($process->getExitCode())->toBe(0);
 
-    $outputContent = preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
-
-    return $outputContent;
+    return removeAnsiEscapeSequences($process->getOutput());
 };
 
 $snapshot = function ($name) {

--- a/tests/Visual/Version.php
+++ b/tests/Visual/Version.php
@@ -6,7 +6,7 @@ test('visual snapshot of help command output', function () {
 
         $process->run();
 
-        return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $process->getOutput());
+        return removeAnsiEscapeSequences($process->getOutput());
     };
 
     expect($output())->toMatchSnapshot();


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Introduces a function `removeAnsiEscapeSequences` to replace multiple instances of the same regular expression used to remove ANSI escape sequences from strings.
