### PR TITLE
[2.x] add `toBeEmailAddress()` expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1158,4 +1158,20 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is a valid email address
+     *
+     * @return self<TValue>
+     */
+    public function toBeEmailAddress(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is an email address.";
+        }
+
+        Assert::assertTrue(Str::isEmailAddress((string) $this->value), $message);
+
+        return $this;
+    }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -116,4 +116,12 @@ final class Str
     {
         return (bool) filter_var($value, FILTER_VALIDATE_URL);
     }
+
+    /**
+     * Determine if a given value is a valid email address.
+     */
+    public static function isEmailAddress(string $value): bool
+    {
+        return (bool) filter_var($value, FILTER_VALIDATE_EMAIL);
+    }
 }

--- a/tests/Features/Expect/toBeEmailAddress.php
+++ b/tests/Features/Expect/toBeEmailAddress.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('hello@pest.com')->toBeEmailAddress()
+        ->and('pestphp.com')->not->toBeEmailAddress();
+});
+
+test('failures', function () {
+    expect('pestphp.com')->toBeEmailAddress();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('pestphp.com')->toBeEmailAddress('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with default message', function () {
+    expect('pestphp.com')->toBeEmailAddress();
+})->throws(ExpectationFailedException::class, 'Failed asserting that pestphp.com is an email address.');
+
+test('not failures', function () {
+    expect('hello@pest.com')->not->toBeEmailAddress();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds a `toBeEmailAddress()` Expectation, to validate a value is an email address. 

```php
<?php

it ('ensures the email of the user is actually an email', function () {
    expect($user->email)->toBeEmailAddress();
});
````