### PR TITLE
Polishing Up "TestDox.php' PHPDoc Blocks for Clarity

### DIFF
--- a/src/Factories/Annotations/TestDox.php
+++ b/src/Factories/Annotations/TestDox.php
@@ -14,13 +14,12 @@ final class TestDox implements AddsAnnotations
      */
     public function __invoke(TestCaseMethodFactory $method, array $annotations): array
     {
-        /*
-       * escapes docblock according to
+      /*
+       * Escapes docblock according to
        * https://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.desc
        *
-       * note: '@' escaping is not needed as it cannot be the first character of the line (it always starts with @testdox
+       * note: '@' escaping is not needed as it cannot be the first character of the line (it always starts with @testdox).
        */
-
         assert($method->description !== null);
         $methodDescription = str_replace('*/', '{@*}', $method->description);
 

--- a/src/Factories/Annotations/TestDox.php
+++ b/src/Factories/Annotations/TestDox.php
@@ -18,7 +18,7 @@ final class TestDox implements AddsAnnotations
        * Escapes docblock according to
        * https://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.desc
        *
-       * note: '@' escaping is not needed as it cannot be the first character of the line (it always starts with @testdox).
+       * Note: '@' escaping is not needed as it cannot be the first character of the line (it always starts with @testdox).
        */
         assert($method->description !== null);
         $methodDescription = str_replace('*/', '{@*}', $method->description);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Improvment of 'TestDox.php' PHPDoc Blocks

### Description:

Added the missing parenthesis and period for proper punctuation and formatted the doc block to meet PHPDocumentor standards.
