### PR TITLE
Fix toHaveProperty with dynamics properties (magically accessible)

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -301,7 +301,7 @@ final class Expectation
         $this->toBeObject();
 
         // @phpstan-ignore-next-line
-        Assert::assertTrue(property_exists($this->value, $name), $message);
+        Assert::assertTrue(property_exists($this->value, $name) || isset($this->value->$name), $message);
 
         if (! $value instanceof Any) {
             /* @phpstan-ignore-next-line */

--- a/tests/Features/Expect/toHaveProperty.php
+++ b/tests/Features/Expect/toHaveProperty.php
@@ -13,6 +13,21 @@ test('pass', function () use ($obj) {
     expect($obj)->toHaveProperty('fooNull', null);
 });
 
+test('dynamic properties', function () {
+    $object = new class {
+        public function __isset(string $name): bool {
+            if ($name === 'foo') {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
+
+    expect($object)->toHaveProperty('foo');
+    expect($object)->not->toHaveProperty('bar');
+});
+
 test('failures', function () use ($obj) {
     expect($obj)->toHaveProperty('bar');
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Fix toHaveProperty() with dynamics properties that are magically accessible using the [__get](https://www.php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members) magic method.

### Related:

Fix #987 


