### PR TITLE
Fix typo in toHaveProperties() PHPDoc block

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -314,7 +314,7 @@ final class Expectation
     /**
      * Asserts that the value contains the provided properties $names.
      *
-     * @param  iterable<array-key, string>  $names
+     * @param  iterable<array-key, mixed>  $names
      * @return self<TValue>
      */
     public function toHaveProperties(iterable $names, string $message = ''): self


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Changed incorrect PHPDoc block for toHaveProperties().
