### PR TITLE
[2.x] Fix typo in `toHaveProperties` PHPDoc block

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -314,7 +314,7 @@ final class Expectation
     /**
      * Asserts that the value contains the provided properties $names.
      *
-     * @param  iterable<array-key, string>  $names
+     * @param  iterable<array-key, mixed>  $names
      * @return self<TValue>
      */
     public function toHaveProperties(iterable $names, string $message = ''): self

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -314,7 +314,7 @@ final class Expectation
     /**
      * Asserts that the value contains the provided properties $names.
      *
-     * @param  iterable<array-key, mixed>  $names
+     * @param  iterable<string, mixed>|iterable<int, string>  $names
      * @return self<TValue>
      */
     public function toHaveProperties(iterable $names, string $message = ''): self


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR fixes an incorrect phpDoc parameter type for toHaveProperties() Expectation. Currently allows only strings. Expectation  toHaveProperty() accepts Any value.

![image](https://github.com/pestphp/pest/assets/5038647/ff27e18a-08dd-400a-b460-f7c67174202e)


