### PR TITLE
Create PHPStan extension and add `HigherOrderTapProxy` to `universalObjectCratesClasses`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,11 @@
                 "Pest\\Plugins\\Version",
                 "Pest\\Plugins\\Parallel"
             ]
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,3 @@
+parameters:
+    universalObjectCratesClasses:
+        - Pest\Support\HigherOrderTapProxy

--- a/extension.neon
+++ b/extension.neon
@@ -1,3 +1,4 @@
 parameters:
     universalObjectCratesClasses:
         - Pest\Support\HigherOrderTapProxy
+        - Pest\Expectation


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->


### What:

- [x] New Feature

### Description:
Hello!

With the release of PHP 8.2, dynamic property creation is deprecated unless the class uses the `AllowDynamicProperties` attribute or defines the `__get`/`__set` magic methods. However, PHPStan still reports the dynamic properties as being undefined unless the class is added to the `universalObjectCratesClasses` config.

Because of this, PHPStan is throwing errors for the below example even though the `HigherOrderTapProxy` (returned by empty `test()` call) does implement the `__get`/`__set` magic methods:

```php
beforeEach(function () {
    test()->dateFormat = 'Y-m-d';
});

it('...', function () {
    // ...
    now()->format(test()->dateFormat);
});

// yields
Access to an undefined property Pest\PendingCalls\TestCall|Pest\Support\HigherOrderTapProxy::$dateFormat.
```

This PR creates an auto-registerable PHPStan extension that adds the `HigherOrderTapProxy` to the `universalObjectCratesClasses` config to fix these errors.

Thanks!