### PR TITLE
[2.x] Improve "not" modifier in order to accept condition

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -180,10 +180,14 @@ final class Expectation
     /**
      * Creates the opposite expectation for the value.
      *
-     * @return OppositeExpectation<TValue>
+     * @return OppositeExpectation<TValue>|self<TValue>
      */
-    public function not(): OppositeExpectation
+    public function not(bool $condition = true): OppositeExpectation|self
     {
+        if (! $condition) {
+            return $this;
+        }
+
         return new OppositeExpectation($this);
     }
 

--- a/tests/Features/Expect/not.php
+++ b/tests/Features/Expect/not.php
@@ -5,6 +5,8 @@ test('not property calls', function () {
         ->toBeTrue()
         ->not()->toBeFalse()
         ->not->toBeFalse
+        ->not(true)->toBeFalse()
+        ->not(false)->toBeTrue()
         ->and(false)
         ->toBeFalse();
 });


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

New Feature

### Description:

With this PR, this test:
```
it('example (before)', function (bool $hasMedia, int $mediaId) {

    $media = Media::find($mediaId);

    if ($hasMedia) {
        expect($media)->not->toBeNull();
    } else {
        expect($media)->toBeNull();
    }
})->with([
    [true, 1],
    [false, 2],
]);
```

Could be refactorized like that:
```
it('example (after)', function (bool $hasMedia, int $mediaId) {

    $media = Media::find($mediaId);

    expect($media)->not($hasMedia)->toBeNull();
})->with([
    [true, 1],
    [false, 2],
]);
```