### PR TITLE
[2.x] fix: allow flags combination with --watch

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -21,12 +21,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
     foreach ($args as $key => $value) {
         if ($value === '--compact') {
             $_SERVER['COLLISION_PRINTER_COMPACT'] = 'true';
-            unset($args[$key]);
         }
 
         if ($value === '--profile') {
             $_SERVER['COLLISION_PRINTER_PROFILE'] = 'true';
-            unset($args[$key]);
         }
 
         if (str_contains($value, '--test-directory')) {
@@ -35,12 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
         if ($value === '--dirty') {
             $dirty = true;
-            unset($args[$key]);
         }
 
         if ($value === '--todos') {
             $todo = true;
-            unset($args[$key]);
         }
 
         if (str_contains($value, '--teamcity')) {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -87,6 +87,24 @@ final class Kernel
     {
         $args = CallsHandleArguments::execute($args);
 
+        foreach ($args as $key => $value) {
+            $optionsToRemove = [
+                '--compact',
+                '--profile',
+                '--dirty',
+                '--todos',
+            ];
+
+            $shouldRemoveOption = (bool) count(array_filter(
+                $optionsToRemove,
+                fn ($option) => str_contains($value, $option)
+            ));
+
+            if ($shouldRemoveOption) {
+                unset($args[$key]);
+            }
+        }
+
         try {
             $this->application->run($args);
         } catch (NoDirtyTestsFound) {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR introduce the ability to use the `--watch` flag with other pest flags

### Related:

#738
