### PR TITLE
[2.x] Add contain with count methods

### DIFF
--- a/src/Exceptions/InvalidMethod.php
+++ b/src/Exceptions/InvalidMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use Exception;
+
+/**
+ * @internal
+ */
+final class InvalidMethod extends Exception
+{
+    /**
+     * Creates a new InvalidMethod instance from the given name.
+     */
+    public static function fromName(string $name): InvalidMethod
+    {
+        return new self("Method [$name] does not exist.");
+    }
+}

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -208,6 +208,7 @@ final class Expectation
         if (is_string($this->value)) {
             // @phpstan-ignore-next-line
             Assert::assertStringContainsString((string) $needle, $this->value);
+            // @phpstan-ignore-next-line
             Assert::$method($count, substr_count($this->value, $needle), $message);
         } else {
             if (! is_iterable($this->value)) {
@@ -220,6 +221,7 @@ final class Expectation
                     $found++;
                 }
             }
+            // @phpstan-ignore-next-line
             Assert::$method($count, $found, $message);
         }
 

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -214,13 +214,16 @@ final class Expectation
             if (! is_iterable($this->value)) {
                 InvalidExpectationValue::expected('iterable');
             }
+
             Assert::assertContains($needle, $this->value);
+
             $found = 0;
             foreach ($this->value as $val) {
                 if ($val === $needle) {
                     $found++;
                 }
             }
+
             // @phpstan-ignore-next-line
             Assert::$method($count, $found, $message);
         }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -209,7 +209,7 @@ final class Expectation
             // @phpstan-ignore-next-line
             Assert::assertStringContainsString((string) $needle, $this->value);
             // @phpstan-ignore-next-line
-            Assert::$method($count, substr_count($this->value, $needle), $message);
+            Assert::$method($count, substr_count($this->value, (string) $needle), $message);
         } else {
             if (! is_iterable($this->value)) {
                 InvalidExpectationValue::expected('iterable');

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -241,6 +241,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that $needle exists in the value at most $count times.
+     *
+     * @return self<TValue>
+     */
+    public function toContainAtMost(int $count, mixed $needle, string $message = ''): self
+    {
+        $this->toContainOp('less than or equal', $count, $needle, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that $needle exists in the value exactly $count times.
      *
      * @return self<TValue>

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -650,6 +650,17 @@
   ✓ failures when count is zero
   ✓ failures when count is negative
 
+   PASS  Tests\Features\Expect\toContainAtMost
+  ✓ passes strings
+  ✓ passes arrays
+  ✓ passes with array needles
+  ✓ not success
+  ✓ passes when exact
+  ✓ failures
+  ✓ not failures
+  ✓ failures when count is zero
+  ✓ failures when count is negative
+
    PASS  Tests\Features\Expect\toContainExact
   ✓ passes strings
   ✓ passes arrays
@@ -1390,4 +1401,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 994 passed (3432 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 1003 passed (3476 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -669,8 +669,14 @@
 
    PASS  Tests\Features\Expect\toContainOp
   ✓ passes strings
+  ✓ not success with greater than
+  ✓ passes with greater than
   ✓ not success with greater than or equal
   ✓ passes with greater than or equal
+  ✓ not success with less than
+  ✓ passes with less than
+  ✓ not success with less than or equal
+  ✓ passes with less than or equal
   ✓ not success with equals
   ✓ passes with equals
   ✓ failures
@@ -1384,4 +1390,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 988 passed (3406 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 994 passed (3432 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -639,10 +639,41 @@
   ✓ not failures with multiple needles (all failing)
   ✓ not failures with multiple needles (some failing)
 
+   PASS  Tests\Features\Expect\toContainAtLeast
+  ✓ passes strings
+  ✓ passes arrays
+  ✓ passes with array needles
+  ✓ not success
+  ✓ passes when exact
+  ✓ failures
+  ✓ not failures
+  ✓ failures when count is zero
+  ✓ failures when count is negative
+
+   PASS  Tests\Features\Expect\toContainExact
+  ✓ passes strings
+  ✓ passes arrays
+  ✓ passes with array needles
+  ✓ not success
+  ✓ failures when not exact
+  ✓ failures
+  ✓ not failures
+  ✓ failures when count is zero
+  ✓ failures when count is negative
+
    PASS  Tests\Features\Expect\toContainOnlyInstancesOf
   ✓ pass
   ✓ failures
   ✓ failures with custom message
+  ✓ not failures
+
+   PASS  Tests\Features\Expect\toContainOp
+  ✓ passes strings
+  ✓ not success with greater than or equal
+  ✓ passes with greater than or equal
+  ✓ not success with equals
+  ✓ passes with equals
+  ✓ failures
   ✓ not failures
 
    PASS  Tests\Features\Expect\toEndWith
@@ -1353,4 +1384,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 963 passed (2281 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 988 passed (3406 assertions)

--- a/tests/Features/Expect/toContainAtLeast.php
+++ b/tests/Features/Expect/toContainAtLeast.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes strings', function () {
+    expect('Nuno')->toContainAtLeast(1, 'Nu');
+});
+
+test('passes arrays', function () {
+    expect([1, 42, 2, 42, 31, 42])->toContainAtLeast(2, 42);
+});
+
+test('passes with array needles', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainAtLeast(1, [1, 2, 3]);
+});
+
+test('not success', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainAtLeast(2, 31);
+});
+
+test('passes when exact', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtLeast(3, 2);
+});
+
+test('failures', function () {
+    expect([1, 2, 42, 2])->toContainAtLeast(3, 2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainAtLeast(2, 2);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is zero', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtLeast(0, 3);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is negative', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtLeast(-1, 2);
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainAtMost.php
+++ b/tests/Features/Expect/toContainAtMost.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes strings', function () {
+    expect('Nuno')->toContainAtMost(1, 'Nu');
+});
+
+test('passes arrays', function () {
+    expect([1, 42, 2, 42, 31, 42])->toContainAtMost(3, 42);
+});
+
+test('passes with array needles', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainAtMost(2, [1, 2, 3]);
+});
+
+test('not success', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainAtMost(1, 2);
+});
+
+test('passes when exact', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtMost(3, 2);
+});
+
+test('failures', function () {
+    expect([1, 2, 42, 2])->toContainAtMost(1, 2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect([1, 42, 97, 31, 2])->not->toContainAtMost(2, 2);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is zero', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtMost(0, 3);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is negative', function () {
+    expect([1, 2, 42, 2, 2])->toContainAtMost(-1, 2);
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainExact.php
+++ b/tests/Features/Expect/toContainExact.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes strings', function () {
+    expect('Nuno')->toContainExact(1, 'Nu');
+});
+
+test('passes arrays', function () {
+    expect([1, 42, 2, 42])->toContainExact(2, 42);
+});
+
+test('passes with array needles', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainExact(2, [1, 2, 3]);
+});
+
+test('not success', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainExact(3, 97);
+});
+
+test('failures when not exact', function () {
+    expect([1, 2, 42, 2, 2])->toContainExact(1, 2);
+})->throws(ExpectationFailedException::class);
+
+test('failures', function () {
+    expect([1, 2, 42, 2])->toContainExact(3, 2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainExact(3, 2);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is zero', function () {
+    expect([1, 2, 42, 2, 2])->toContainExact(0, 3);
+})->throws(ExpectationFailedException::class);
+
+test('failures when count is negative', function () {
+    expect([1, 2, 42, 2, 2])->toContainExact(-1, 2);
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainOp.php
+++ b/tests/Features/Expect/toContainOp.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Pest\Exceptions\InvalidMethod;
+
+test('passes strings', function () {
+    expect('Nuno')->toContainOp('greater than or equal', 1, 'Nu');
+});
+
+test('not success with greater than or equal', function () {
+    expect([1, 42, 2, 42, 31, 42])->not->toContainOp('greater than or equal', 2, 31);
+});
+
+test('passes with greater than or equal', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainOp('greater than or equal', 1, [1, 2, 3]);
+});
+
+test('not success with equals', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainOp('equals', 2, 31);
+});
+
+test('passes with equals', function () {
+    expect([1, 2, 42, 2, 2])->toContainOp('equals', 3, 2);
+});
+
+test('failures', function () {
+    expect([1, 2, 42, 2])->toContainOp('not exist', 3, 2);
+})->throws(InvalidMethod::class);
+
+test('not failures', function () {
+    expect([1, 2, 42, 2, 97, 31, 2])->not->toContainOp('not exist', 2, 2);
+})->throws(InvalidMethod::class);

--- a/tests/Features/Expect/toContainOp.php
+++ b/tests/Features/Expect/toContainOp.php
@@ -7,12 +7,36 @@ test('passes strings', function () {
     expect('Nuno')->toContainOp('greater than or equal', 1, 'Nu');
 });
 
+test('not success with greater than', function () {
+    expect([1, 42, 2, 42, 31, 42])->not->toContainOp('greater than', 2, 31);
+});
+
+test('passes with greater than', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainOp('greater than', 1, [1, 2, 3]);
+});
+
 test('not success with greater than or equal', function () {
     expect([1, 42, 2, 42, 31, 42])->not->toContainOp('greater than or equal', 2, 31);
 });
 
 test('passes with greater than or equal', function () {
     expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainOp('greater than or equal', 1, [1, 2, 3]);
+});
+
+test('not success with less than', function () {
+    expect([1, 42, 2, 42, 31, 42])->not->toContainOp('less than', 2, 42);
+});
+
+test('passes with less than', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainOp('less than', 3, [1, 2, 3]);
+});
+
+test('not success with less than or equal', function () {
+    expect([1, 42, 2, 42, 31, 42])->not->toContainOp('less than or equal', 2, 42);
+});
+
+test('passes with less than or equal', function () {
+    expect([[1, 2, 3], 2, 42, [1, 2, 3]])->toContainOp('less than or equal', 2, [1, 2, 3]);
 });
 
 test('not success with equals', function () {

--- a/tests/Features/Expect/toContainOp.php
+++ b/tests/Features/Expect/toContainOp.php
@@ -1,6 +1,5 @@
 <?php
 
-use PHPUnit\Framework\ExpectationFailedException;
 use Pest\Exceptions\InvalidMethod;
 
 test('passes strings', function () {

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 977 passed (3359 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 983 passed (3385 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 983 passed (3385 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 992 passed (3429 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 952 passed (2266 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 977 passed (3359 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:
In this PR I have added contain with count methods `toContainAtLeast` , `toContainAtMost` and `toContainExact`  which asserts that a substring exists in a string for a number of times (exact or at least) same thing for iterables it asserts that it contains an element exatly or at least a number of times.

PS: We can use `toContainOp` too which can be controlled by the operator passed. (`greater than or equal`, `greater than`, `less than or equal`, `less than` ...).

### Examples:
```php
it('to have count', function() {
    expect([[1, 2, 3], 2, 42])->toContain(42, [1, 2, 3]);
    expect([[1, 2, 3], 2, 42, 42])->toContainAtLeast(1, 42);
    expect([1, 42, 2, 42, 31, 42])->toContainAtMost(3, 42);
    expect([[1, 2, 3], 2, 42])->toContainExact(1, [1, 2, 3]);
    expect("pest is the best.")->toContain('pest');
    expect(["pest", "is", "the", "best", "pest"])->toContain('pest');
    expect("pest is the best")->toContainAtLeast(1, 'pest');
    expect(["pest", "is", "the", "best", "pest"])->toContainExact(2, 'pest');
})->only();
```