### PR TITLE
[2.x] Implementation to the `at` method

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -66,6 +66,20 @@ final class Expectation
     }
 
     /**
+     * Allows you to target a value in a table
+     *
+     * @return self<TAndValue>
+     */
+    public function at(string|int $key): Expectation
+    {
+        if (! is_iterable($this->value)) {
+            InvalidExpectationValue::expected('iterable');
+        }
+
+        return new self($this->value[$key]);
+    }
+
+    /**
      * Creates a new expectation.
      *
      * @template TAndValue

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -76,6 +76,31 @@ final class Expectation
             InvalidExpectationValue::expected('iterable');
         }
 
+        if(gettype($key) === 'string') {
+            if(strpos($key, '.') !== false) {
+                $keys = explode('.', $key);
+                $value = $this->value;
+                foreach($keys as $nestedKey) {
+                    if(!isset($value[$nestedKey])) {
+                        throw new OutOfRangeException(sprintf(
+                            'Key "%s" does not exist in %s.',
+                            $nestedKey,
+                            gettype($value)
+                        ));
+                    }
+                    $value = $value[$nestedKey];
+                }
+                return new self($value);
+            }
+        }
+
+        if (! isset($this->value[$key])) {
+            throw new OutOfRangeException(sprintf(
+                'Index out of range: %s.',
+                $key
+            ));
+        }
+
         return new self($this->value[$key]);
     }
 

--- a/tests/Features/Expect/at.php
+++ b/tests/Features/Expect/at.php
@@ -34,8 +34,40 @@ it('ensures it work with nested array', function () {
     expect($nestedArray)
         ->at(0)->at(1)->toBe(2)
         ->and($nestedArray)
-        ->at(1)->foo->toBe('bar');
+        ->at(1)->at('foo')->toBe('bar');
 });
+
+it('ensures it work with nested dictionary', function () {
+    $nestedDictionary = [
+        'foo' => [
+            'bar' => [
+                'john' => 'doe',
+            ],
+        ],
+    ];
+
+    expect($nestedDictionary)
+        ->foo->at('bar')->at('john')->toBe('doe');
+});
+
+it('ensures it work with dot notation', function () {
+    $nestedDictionary = [
+        'foo' => [
+            'bar' => [
+                'john' => 'doe',
+            ],
+        ],
+    ];
+
+    expect($nestedDictionary)
+        ->at('foo.bar.john')->toBe('doe');
+});
+
+it('ensures it return an out of range exception', function () {
+    $array = [1, 2, 3, 4];
+
+    expect($array)->at(4);
+})->throws('Index out of range: 4');
 
 it('ensures it throw an invalid expectation value', function () {
     $boolean = false;

--- a/tests/Features/Expect/at.php
+++ b/tests/Features/Expect/at.php
@@ -1,0 +1,44 @@
+<?php
+
+it('ensures that the values returned for the index are correct', function () {
+    $array = [1, 2, 3, 4];
+
+    expect($array)
+        ->at(0)->toBe(1)
+        ->and($array)
+        ->at(1)->toBe(2)
+        ->and($array)
+        ->at(2)->toBe(3)
+        ->and($array)
+        ->at(3)->toBe(4);
+});
+
+it('ensures that the values returned for the key are correct', function () {
+    $dictionary = [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+    ];
+
+    expect($dictionary)
+        ->at('first_name')->toBe('John')
+        ->and($dictionary)
+        ->at('last_name')->toBe('Doe');
+});
+
+it('ensures it work with nested array', function () {
+    $nestedArray = [
+        [1, 2, 3],
+        ['foo' => 'bar', 'john' => 'doe'],
+    ];
+
+    expect($nestedArray)
+        ->at(0)->at(1)->toBe(2)
+        ->and($nestedArray)
+        ->at(1)->foo->toBe('bar');
+});
+
+it('ensures it throw an invalid expectation value', function () {
+    $boolean = false;
+
+    expect($boolean)->at(1);
+})->throws('Invalid expectation value type. Expected [iterable].');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Implementation of the `at` method. This will allow you to target an index or key on an iterable and apply other expectation methods to the value. It provides better readability and works on nested arrays.

Example below:

```php
it('ensures it work with nested array', function () {
    $nestedArray = [
        [1, 2, 3],
        ['foo' => 'bar', 'john' => 'doe'],
    ];

    expect($nestedArray)
        ->at(0)->at(1)->toBe(2)
        ->and($nestedArray)
        ->at(1)->foo->toBe('bar');
});
```
