### PR TITLE
[2.x] Add `toBeStringBackedEnum()` and `toBeIntBackedEnum()` Architecture Expectations

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -878,4 +878,50 @@ final class Expectation
     {
         return $this->toHaveMethod('__destruct');
     }
+
+    /**
+     * Asserts that the given expectation target is a backed enum of given type.
+     */
+    private function toBeBackedEnum(string $backingType): ArchExpectation
+    {
+        return Targeted::make(
+            $this,
+            fn (ObjectDescription $object): bool => (new \ReflectionEnum($object->name))->isBacked()
+                && (string)(new \ReflectionEnum($object->name))->getBackingType() === $backingType,
+            'to be ' . $backingType . ' backed enum',
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
+    }
+
+    /**
+     * Asserts that the given expectation targets are string backed enums.
+     */
+    public function toBeStringBackedEnums(): ArchExpectation
+    {
+        return $this->toBeStringBackedEnum();
+    }
+
+    /**
+     * Asserts that the given expectation targets are int backed enums.
+     */
+    public function toBeIntBackedEnums(): ArchExpectation
+    {
+        return $this->toBeIntBackedEnum();
+    }
+
+    /**
+     * Asserts that the given expectation target is a string backed enum.
+     */
+    public function toBeStringBackedEnum(): ArchExpectation
+    {
+        return $this->toBeBackedEnum('string');
+    }
+
+    /**
+     * Asserts that the given expectation target is an int backed enum.
+     */
+    public function toBeIntBackedEnum(): ArchExpectation
+    {
+        return $this->toBeBackedEnum('int');
+    }
 }

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -485,4 +485,50 @@ final class OppositeExpectation
     {
         return $this->toHaveMethod('__destruct');
     }
+
+    /**
+     * Asserts that the given expectation target is not a backed enum of given type.
+     */
+    private function toBeBackedEnum(string $backingType): ArchExpectation
+    {
+        return Targeted::make(
+            $this->original,
+            fn (ObjectDescription $object): bool => (new \ReflectionEnum($object->name))->isBacked()
+                && (string)(new \ReflectionEnum($object->name))->getBackingType() !== $backingType,
+            'not to be ' . $backingType . ' backed enum',
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
+    }
+
+    /**
+     * Asserts that the given expectation targets are not string backed enums.
+     */
+    public function toBeStringBackedEnums(): ArchExpectation
+    {
+        return $this->toBeStringBackedEnum();
+    }
+
+    /**
+     * Asserts that the given expectation targets are not int backed enums.
+     */
+    public function toBeIntBackedEnums(): ArchExpectation
+    {
+        return $this->toBeIntBackedEnum();
+    }
+
+    /**
+     * Asserts that the given expectation target is not a string backed enum.
+     */
+    public function toBeStringBackedEnum(): ArchExpectation
+    {
+        return $this->toBeBackedEnum('string');
+    }
+
+    /**
+     * Asserts that the given expectation target is not an int backed enum.
+     */
+    public function toBeIntBackedEnum(): ArchExpectation
+    {
+        return $this->toBeBackedEnum('int');
+    }
 }

--- a/tests/Features/Expect/toBeIntBackedEnum.php
+++ b/tests/Features/Expect/toBeIntBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+test('enum is backed by int')
+    ->expect('Tests\Fixtures\Arch\ToBeIntBackedEnum\HasIntBacking')
+    ->toBeIntBackedEnum();
+
+test('enum is not backed by int')
+    ->expect('Tests\Fixtures\Arch\ToBeIntBackedEnum\HasStringBacking')
+    ->not->toBeIntBackedEnum();

--- a/tests/Features/Expect/toBeStringBackedEnum.php
+++ b/tests/Features/Expect/toBeStringBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+test('enum is backed by string')
+    ->expect('Tests\Fixtures\Arch\ToBeStringBackedEnum\HasStringBacking')
+    ->toBeStringBackedEnum();
+
+test('enum is not backed by string')
+    ->expect('Tests\Fixtures\Arch\ToBeStringBackedEnum\HasIntBacking')
+    ->not->toBeStringBackedEnum();

--- a/tests/Fixtures/Arch/ToBeIntBackedEnum/HasIntBacking/HasIntBackingEnum.php
+++ b/tests/Fixtures/Arch/ToBeIntBackedEnum/HasIntBacking/HasIntBackingEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeIntBackedEnum\HasIntBacking;
+
+enum HasIntBackingEnum: int
+{
+    case IntBacked = 1;
+}

--- a/tests/Fixtures/Arch/ToBeIntBackedEnum/HasStringBacking/HasStringBackingEnum.php
+++ b/tests/Fixtures/Arch/ToBeIntBackedEnum/HasStringBacking/HasStringBackingEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeIntBackedEnum\HasStringBacking;
+
+enum HasStringBackingEnum: string
+{
+    case StringBacked = 'Testing';
+}

--- a/tests/Fixtures/Arch/ToBeStringBackedEnum/HasIntBacking/HasIntBackingEnum.php
+++ b/tests/Fixtures/Arch/ToBeStringBackedEnum/HasIntBacking/HasIntBackingEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeStringBackedEnum\HasIntBacking;
+
+enum HasIntBackingEnum: int
+{
+    case IntBacked = 1;
+}

--- a/tests/Fixtures/Arch/ToBeStringBackedEnum/HasStringBacking/HasStringBackingEnum.php
+++ b/tests/Fixtures/Arch/ToBeStringBackedEnum/HasStringBacking/HasStringBackingEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToBeStringBackedEnum\HasStringBacking;
+
+enum HasStringBackingEnum: string
+{
+    case StringBacked = 'Testing';
+}


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

We already have the very handy `toBeEnum()` Arch Expectation, which is useful for Pure Enums. This PR adds 2 similar Expectations, specifically for Backed Enums:

- `toBeStringBackedEnum()`
- `toBeIntBackedEnum()`

```php
<?php

namespace App\Enums;

enum TestEnum: string
{
    case Test = 'Test';
}
```

By writing the following test, we can ensure that it is actually a String Backed Enum.

```php
test('enum is backed by string')
    ->expect('app\Enums')
    ->toBeStringBackedEnums();
```

We could also change the test if the Enum returned an Int:

```php
test('enum is backed by int')
    ->expect('app\Enums')
    ->toBeIntBackedEnums();
```

Docs: https://github.com/pestphp/docs/pull/247
