### PR TITLE
[2.x] Added onlyOn* methods to run the test only on a specific OS

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -224,6 +224,30 @@ final class TestCall
     }
 
     /**
+     * Runs the current test only if the given test is running on Windows.
+     */
+    public function onlyOnWindows(): self
+    {
+        return $this->skipOnLinux()->skipOnMac();
+    }
+
+    /**
+     * Runs the current test only if the given test is running on Mac.
+     */
+    public function onlyOnMac(): self
+    {
+        return $this->skipOnWindows()->skipOnLinux();
+    }
+
+    /**
+     * Run the current test only if the given test is running on Linux.
+     */
+    public function onlyOnLinux(): self
+    {
+        return $this->skipOnWindows()->skipOnMac();
+    }
+
+    /**
      * Skips the current test if the given test is running on the given operating systems.
      */
     private function skipOn(string $osFamily, string $message): self

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -224,35 +224,45 @@ final class TestCall
     }
 
     /**
-     * Runs the current test only if the given test is running on Windows.
-     */
-    public function onlyOnWindows(): self
-    {
-        return $this->skipOnLinux()->skipOnMac();
-    }
-
-    /**
-     * Runs the current test only if the given test is running on Mac.
-     */
-    public function onlyOnMac(): self
-    {
-        return $this->skipOnWindows()->skipOnLinux();
-    }
-
-    /**
-     * Run the current test only if the given test is running on Linux.
-     */
-    public function onlyOnLinux(): self
-    {
-        return $this->skipOnWindows()->skipOnMac();
-    }
-
-    /**
      * Skips the current test if the given test is running on the given operating systems.
      */
     private function skipOn(string $osFamily, string $message): self
     {
         return $osFamily === PHP_OS_FAMILY
+            ? $this->skip($message)
+            : $this;
+    }
+
+    /**
+     * Skips the current test unless the given test is running on Windows.
+     */
+    public function onlyOnWindows(): self
+    {
+        return $this->onlyOn('Windows', 'This test is skipped unless on [Windows].');
+    }
+
+    /**
+     * Skips the current test unless the given test is running on Mac.
+     */
+    public function onlyOnMac(): self
+    {
+        return $this->onlyOn('Darwin', 'This test is skipped unless on [Mac].');
+    }
+
+    /**
+     * Skips the current test unless the given test is running on Linux.
+     */
+    public function onlyOnLinux(): self
+    {
+        return $this->onlyOn('Linux', 'This test is skipped unless on [Linux].');
+    }
+
+    /**
+     * Skips the current test unless the given test is running on the given operating system.
+     */
+    private function onlyOn(string $osFamily, string $message): self
+    {
+        return $osFamily !== PHP_OS_FAMILY
             ? $this->skip($message)
             : $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -238,7 +238,7 @@ final class TestCall
      */
     public function onlyOnWindows(): self
     {
-        return $this->onlyOn('Windows', 'This test is skipped unless on [Windows].');
+        return $this->skipOnMac()->skipOnLinux();
     }
 
     /**
@@ -246,7 +246,7 @@ final class TestCall
      */
     public function onlyOnMac(): self
     {
-        return $this->onlyOn('Darwin', 'This test is skipped unless on [Mac].');
+        return $this->skipOnWindows()->skipOnLinux();
     }
 
     /**
@@ -254,17 +254,7 @@ final class TestCall
      */
     public function onlyOnLinux(): self
     {
-        return $this->onlyOn('Linux', 'This test is skipped unless on [Linux].');
-    }
-
-    /**
-     * Skips the current test unless the given test is running on the given operating system.
-     */
-    private function onlyOn(string $osFamily, string $message): self
-    {
-        return $osFamily !== PHP_OS_FAMILY
-            ? $this->skip($message)
-            : $this;
+        return $this->skipOnWindows()->skipOnMac();
     }
 
     /**


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

Sometimes a test should run only on one explicit OS. It's easier to use onlyOn{OS}, rather than skipping all other OSes.
This PR introduces:

- onlyOnWindows()
- onlyOnMac()
- onlyOnLinux()

### Related:

Related to the issue/improvement https://github.com/pestphp/pest/issues/1011
