### PR TITLE
[2.x] Add `toSnapshot` early return

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -844,6 +844,7 @@ final class Expectation
 
         $string = match (true) {
             is_string($this->value) => $this->value,
+            is_object($this->value) && method_exists($this->value, 'toSnapshot') => $this->value->toSnapshot(),
             is_object($this->value) && method_exists($this->value, '__toString') => $this->value->__toString(),
             is_object($this->value) && method_exists($this->value, 'toString') => $this->value->toString(),
             $this->value instanceof \Illuminate\Testing\TestResponse => $this->value->getContent(), // @phpstan-ignore-line

--- a/tests/.pest/snapshots/Features/Expect/toMatchSnapshot/pass_with__toSnapshot_.snap
+++ b/tests/.pest/snapshots/Features/Expect/toMatchSnapshot/pass_with__toSnapshot_.snap
@@ -1,0 +1,3 @@
+{
+    "key": "    <div class=\"container\">\n        <div class=\"row\">\n            <div class=\"col-md-12\">\n                <h1>Snapshot<\/h1>\n            <\/div>\n        <\/div>\n    <\/div>"
+}

--- a/tests/Features/Expect/toMatchSnapshot.php
+++ b/tests/Features/Expect/toMatchSnapshot.php
@@ -103,6 +103,26 @@ test('pass with array', function () {
     ])->toMatchSnapshot();
 });
 
+test('pass with `toSnapshot`', function () {
+    TestSuite::getInstance()->snapshots->save(json_encode(['key' => $this->snapshotable], JSON_PRETTY_PRINT));
+
+    $object = new class($this->snapshotable)
+    {
+        public function __construct(protected string $snapshotable)
+        {
+        }
+
+        public function toSnapshot()
+        {
+            return json_encode([
+                'key' => $this->snapshotable,
+            ], JSON_PRETTY_PRINT);
+        }
+    };
+
+    expect($object)->toMatchSnapshot();
+});
+
 test('failures', function () {
     TestSuite::getInstance()->snapshots->save($this->snapshotable);
 


### PR DESCRIPTION
Sometimes objects need native toString() and toArray() methods that are different from what you want to snapshot.

This adds an explicit toSnapshot() method that will be called first (when set) allowing for better snapshot values than the generic methods offer.

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

I have a number of objects in my project that already contain `toString()` and `toArray()` methods for different reasons than snapshotting. For example a user object that may downcast to a string by rendering the full name or to an array by returning the raw DB attributes.

But for snapshotting I want a mixture of both. I want the attributes with some computed fields and even some hidden fields. I'd like to include a user's "token" field in the snapshot, even though it's hidden from API responses so I can have confidence that the token logic isn't changing.

This adds an explicit `->toSnapshot()` method call above the more abstract methods allowing consumers to customize exactly what data is snapshotted.