### PR TITLE
Update Expectation.php

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -34,8 +34,6 @@ use PHPUnit\Architecture\Elements\ObjectDescription;
 use PHPUnit\Framework\ExpectationFailedException;
 
 /**
- * @internal
- *
  * @template TValue
  *
  * @property OppositeExpectation $not Creates the opposite expectation.


### PR DESCRIPTION
Removed @internal phpdoc

<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`@internal` PHPdoc was causing some wrong warnings on some methods from PEST that pass a Expectation instance like in `each` method. This PR solve this problem.

### Related:

As mentioned on #1018 @nunomaduro requested this pull request
