### PR TITLE
[2.x] Introduce Reminder When Filtering Using `only`

### DIFF
--- a/src/Plugins/Only.php
+++ b/src/Plugins/Only.php
@@ -34,7 +34,7 @@ final class Only implements Shutdownable
             unlink($lockFile);
         }
 
-        echo "The tests executed were tests filtered using <href=https://pestphp.com/docs/filtering-tests#content-only>only</>";
+        echo 'The tests executed were tests filtered using <href=https://pestphp.com/docs/filtering-tests#content-only>only</>';
     }
 
     /**

--- a/src/Plugins/Only.php
+++ b/src/Plugins/Only.php
@@ -33,6 +33,8 @@ final class Only implements Shutdownable
         if (file_exists($lockFile)) {
             unlink($lockFile);
         }
+
+        echo "The tests executed were tests filtered using <href=https://pestphp.com/docs/filtering-tests#content-only>only</>";
     }
 
     /**


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancements

### Description:

This PR is intended to introduce a warning as a reminder when you are filtering tests using `->only()`, because without something like this, we can filter the tests but forget to remove the `->only()` filter.

![CleanShot 2023-11-24 at 14 24 23](https://github.com/pestphp/pest/assets/60591772/ced52aa5-52ea-4d34-9661-393f2e8fd66d)