### PR TITLE
[2.x] Allow `--todo` argument.

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
             unset($args[$key]);
         }
 
-        if ($value === '--todos') {
+        if (str_contains($value, '--todo')) {
             $todo = true;
             unset($args[$key]);
         }

--- a/bin/pest
+++ b/bin/pest
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
             unset($args[$key]);
         }
 
-        if (str_contains($value, '--todo')) {
+        if (in_array($value, ['--todo', '--todos'], true)) {
             $todo = true;
             unset($args[$key]);
         }

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -34,7 +34,7 @@ final class Parallel implements HandlesArguments
     /**
      * @var string[]
      */
-    private const UNSUPPORTED_ARGUMENTS = ['--todos', '--retry'];
+    private const UNSUPPORTED_ARGUMENTS = ['--todo', '--todos', '--retry'];
 
     /**
      * Whether the given command line arguments indicate that the test suite should be run in parallel.

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1348,10 +1348,12 @@
   - visual snapshot of team city with ('SuccessOnly.php')
 
    PASS  Tests\Visual\Todo
+  ✓ todos
+  ✓ todos in parallel
   ✓ todo
   ✓ todo in parallel
 
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 964 passed (2282 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 966 passed (2286 assertions)

--- a/tests/.snapshots/todos.txt
+++ b/tests/.snapshots/todos.txt
@@ -1,0 +1,31 @@
+   TODO  Tests\Features\BeforeEachProxiesToTestCallWithTodo - 4 todos
+  ↓ is marked as todo 1
+  ↓ is marked as todo 2
+  ↓ is marked as todo 3
+  ↓ shouldBeMarkedAsTodo
+
+   TODO  Tests\Features\DatasetsTests - 1 todo
+  ↓ forbids to define tests in Datasets dirs and Datasets.php files
+
+   TODO  Tests\Features\Describe - 5 todos
+  ↓ todo
+  ↓ todo on hook → should not fail
+  ↓ todo on hook → should run
+  ↓ todo on describe → should not fail
+  ↓ todo on describe → should run
+
+   TODO  Tests\Features\Todo - 3 todos
+  ↓ something todo later
+  ↓ something todo later chained
+  ↓ something todo later chained and with function body
+
+   PASS  Tests\CustomTestCase\ChildTest
+  ✓ override method
+
+   PASS  Tests\CustomTestCase\ExecutedTest
+  ✓ that gets executed
+
+   PASS  Tests\CustomTestCase\ParentTest
+  ✓ override method
+
+  Tests:    13 todos, 3 passed (3 assertions)

--- a/tests/Visual/Todo.php
+++ b/tests/Visual/Todo.php
@@ -26,10 +26,18 @@ $snapshot = function ($name) {
     ]));
 };
 
+test('todos', function () use ($run, $snapshot) {
+    expect($run('--todos', false))->toContain($snapshot('todos'));
+})->skipOnWindows();
+
+test('todos in parallel', function () use ($run, $snapshot) {
+    expect($run('--todos', true))->toContain($snapshot('todos'));
+})->skipOnWindows();
+
 test('todo', function () use ($run, $snapshot) {
-    expect($run('--todos', false))->toContain($snapshot('todo'));
+    expect($run('--todo', false))->toContain($snapshot('todo'));
 })->skipOnWindows();
 
 test('todo in parallel', function () use ($run, $snapshot) {
-    expect($run('--todos', true))->toContain($snapshot('todo'));
+    expect($run('--todo', true))->toContain($snapshot('todo'));
 })->skipOnWindows();


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This allows `--todo` argument to be used as an alias for `--todos`.

I find myself running `pest --todo` all the time, and I figured that could be a good alias to have.

Cheers.