### PR TITLE
Fix typo in `toBeClass`

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -535,7 +535,7 @@ final class Expectation
     }
 
     /**
-     * Asserts that the given expectation targets is an class.
+     * Asserts that the given expectation target is a class.
      */
     public function toBeClass(): ArchExpectation
     {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fix small grammar problem/typo in the `toBeClass` DocBlock
