### PR TITLE
Fix cache directory config override

### DIFF
--- a/src/Plugins/Cache.php
+++ b/src/Plugins/Cache.php
@@ -30,10 +30,12 @@ final class Cache implements HandlesArguments
      */
     public function handleArguments(array $arguments): array
     {
-        $arguments = $this->pushArgument(
-            sprintf('--cache-directory=%s', realpath(self::TEMPORARY_FOLDER)),
-            $arguments
-        );
+        if (! $this->hasArgument('--cache-directory', $arguments)) {
+            $arguments = $this->pushArgument(
+                sprintf('--cache-directory=%s', realpath(self::TEMPORARY_FOLDER)),
+                $arguments
+            );
+        }
 
         if (! $this->hasArgument('--parallel', $arguments)) {
             return $this->pushArgument('--cache-result', $arguments);

--- a/src/Plugins/Concerns/HandleArguments.php
+++ b/src/Plugins/Concerns/HandleArguments.php
@@ -16,7 +16,17 @@ trait HandleArguments
      */
     public function hasArgument(string $argument, array $arguments): bool
     {
-        return in_array($argument, $arguments, true);
+        foreach ($arguments as $arg) {
+            if ($arg === $argument) {
+                return true;
+            }
+
+            if (str_starts_with($arg, "$argument=")) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1212,6 +1212,14 @@
    PASS  Tests\Unit\Overrides\ThrowableBuilder
   ✓ collision editor can be added to the stack trace
 
+   PASS  Tests\Unit\Plugins\Concerns\HandleArguments
+  ✓ method hasArgument with ('--long-argument', true)
+  ✓ method hasArgument with ('-a', true)
+  ✓ method hasArgument with ('--with-equal-sign', true)
+  ✓ method hasArgument with ('someValue', true)
+  ✓ method hasArgument with ('--a', false)
+  ✓ method hasArgument with ('--undefined-argument', false)
+
    PASS  Tests\Unit\Plugins\Environment
   ✓ environment is set to CI when --ci option is used
   ✓ environment is set to Local when --ci option is not used
@@ -1364,4 +1372,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 970 passed (2296 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 976 passed (2302 assertions)

--- a/tests/Unit/Plugins/Concerns/HandleArguments.php
+++ b/tests/Unit/Plugins/Concerns/HandleArguments.php
@@ -1,0 +1,26 @@
+<?php
+
+use Pest\Plugins\Concerns\HandleArguments;
+
+test('method hasArgument', function (string $argument, bool $expectedResult) {
+    $obj = new class
+    {
+        use HandleArguments;
+    };
+
+    $arguments = [
+        '--long-argument',
+        'someValue',
+        '-a',
+        '--with-equal-sign=1337',
+    ];
+
+    expect($obj->hasArgument($argument, $arguments))->toBe($expectedResult);
+})->with([
+    ['--long-argument', true],
+    ['-a', true],
+    ['--with-equal-sign', true],
+    ['someValue', true],
+    ['--a', false],
+    ['--undefined-argument', false],
+]);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 957 passed (2277 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 963 passed (2283 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- Bug Fix

### Description:

Fixing overriding CLI argument --cache-directory by plugin Cache

### Related:

https://github.com/pestphp/pest/issues/1050
