### PR TITLE
[2.x] Allow string type in greaterThan/lessThan expectations

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -131,7 +131,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThan(int|float|DateTimeInterface $expected, string $message = ''): self
+    public function toBeGreaterThan(int|float|string|DateTimeInterface $expected, string $message = ''): self
     {
         Assert::assertGreaterThan($expected, $this->value, $message);
 
@@ -143,7 +143,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeGreaterThanOrEqual(int|float|DateTimeInterface $expected, string $message = ''): self
+    public function toBeGreaterThanOrEqual(int|float|string|DateTimeInterface $expected, string $message = ''): self
     {
         Assert::assertGreaterThanOrEqual($expected, $this->value, $message);
 
@@ -155,7 +155,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThan(int|float|DateTimeInterface $expected, string $message = ''): self
+    public function toBeLessThan(int|float|string|DateTimeInterface $expected, string $message = ''): self
     {
         Assert::assertLessThan($expected, $this->value, $message);
 
@@ -167,7 +167,7 @@ final class Expectation
      *
      * @return self<TValue>
      */
-    public function toBeLessThanOrEqual(int|float|DateTimeInterface $expected, string $message = ''): self
+    public function toBeLessThanOrEqual(int|float|string|DateTimeInterface $expected, string $message = ''): self
     {
         Assert::assertLessThanOrEqual($expected, $this->value, $message);
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -426,6 +426,7 @@
    PASS  Tests\Features\Expect\toBeGreaterThan
   ✓ passes
   ✓ passes with DateTime and DateTimeImmutable
+  ✓ passes with strings
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
@@ -433,6 +434,7 @@
    PASS  Tests\Features\Expect\toBeGreaterThanOrEqual
   ✓ passes
   ✓ passes with DateTime and DateTimeImmutable
+  ✓ passes with strings
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
@@ -490,6 +492,7 @@
    PASS  Tests\Features\Expect\toBeLessThan
   ✓ passes
   ✓ passes with DateTime and DateTimeImmutable
+  ✓ passes with strings
   ✓ failures
   ✓ failures with custom message
   ✓ not failures
@@ -497,6 +500,7 @@
    PASS  Tests\Features\Expect\toBeLessThanOrEqual
   ✓ passes
   ✓ passes with DateTime and DateTimeImmutable
+  ✓ passes with strings
   ✓ failures
   ✓ failures with custom message
   ✓ not failures

--- a/tests/Features/Expect/toBeGreaterThan.php
+++ b/tests/Features/Expect/toBeGreaterThan.php
@@ -16,6 +16,11 @@ test('passes with DateTime and DateTimeImmutable', function () {
     expect($past)->not->toBeGreaterThan($now);
 });
 
+test('passes with strings', function () {
+    expect('b')->toBeGreaterThan('a');
+    expect('a')->not->toBeGreaterThan('a');
+});
+
 test('failures', function () {
     expect(4)->toBeGreaterThan(4);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeGreaterThanOrEqual.php
+++ b/tests/Features/Expect/toBeGreaterThanOrEqual.php
@@ -18,6 +18,11 @@ test('passes with DateTime and DateTimeImmutable', function () {
     expect($past)->not->toBeGreaterThanOrEqual($now);
 });
 
+test('passes with strings', function () {
+    expect('b')->toBeGreaterThanOrEqual('a');
+    expect('a')->toBeGreaterThanOrEqual('a');
+});
+
 test('failures', function () {
     expect(4)->toBeGreaterThanOrEqual(4.1);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThan.php
+++ b/tests/Features/Expect/toBeLessThan.php
@@ -16,6 +16,11 @@ test('passes with DateTime and DateTimeImmutable', function () {
     expect($now)->not->toBeLessThan($now);
 });
 
+test('passes with strings', function () {
+    expect('a')->toBeLessThan('b');
+    expect('a')->not->toBeLessThan('a');
+});
+
 test('failures', function () {
     expect(4)->toBeLessThan(4);
 })->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeLessThanOrEqual.php
+++ b/tests/Features/Expect/toBeLessThanOrEqual.php
@@ -18,6 +18,11 @@ test('passes with DateTime and DateTimeImmutable', function () {
     expect($now)->not->toBeLessThanOrEqual($past);
 });
 
+test('passes with strings', function () {
+    expect('a')->toBeLessThanOrEqual('b');
+    expect('a')->toBeLessThanOrEqual('a');
+});
+
 test('failures', function () {
     expect(4)->toBeLessThanOrEqual(3.9);
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Since the time type annotations were added to these assertions:

- `toBeLessThan`
- `toBeLessThanOrEqual`
- `toBeGreaterThan`
- `toBeGreaterThanOrEqual`

they only allowed `int|float` (and more recently `DateTimeInterface`) values as the comparators. However, PHP also has semantics for string comparison which were not taken into account.

This PR adds the appropriate annotation to the expectation so that strings can also be compared among themselves.

Please feel free to adjust the PR to your liking or request changes. Thanks!