### PR TITLE
Skip on php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^8.1.0",
         "brianium/paratest": "^7.3.1",
+        "composer/semver": "^3.4",
         "nunomaduro/collision": "^7.10.0|^8.0.1",
         "nunomaduro/termwind": "^1.15.1|^2.0.0",
         "pestphp/pest-plugin": "^2.1.1",

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\PendingCalls;
 
 use Closure;
+use Composer\Semver\Semver;
 use Pest\Exceptions\InvalidArgumentException;
 use Pest\Factories\Covers\CoversClass;
 use Pest\Factories\Covers\CoversFunction;
@@ -269,9 +270,9 @@ final class TestCall
     /**
      * Skips the current test if the given test is running on the given php version.
      */
-    public function skipOnPhp(string $version, string $operator = '=', string $message = ''): self
+    public function skipOnPhp(string $version, string $message = ''): self
     {
-        return version_compare(PHP_VERSION, $version, $operator)
+        return Semver::satisfies(PHP_VERSION, $version)
             ? $this->skip($message)
             : $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -267,6 +267,16 @@ final class TestCall
     }
 
     /**
+     * Skips the current test if the given test is running on the given php version.
+     */
+    public function skipOnPhp(string $version, string $operator = '=', string $message = ''): self
+    {
+        return version_compare(PHP_VERSION, $version, $operator)
+            ? $this->skip($message)
+            : $this;
+    }
+
+    /**
      * Repeats the current test the given number of times.
      */
     public function repeat(int $times): self

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1093,7 +1093,7 @@
   - it can use something in the test case as a condition → This test was skipped
   - it can user higher order callables and skip
   - it can skip on specific php version
-  - it can skip on php versions greater than
+  - it can skip on php versions depending on operator
 
    PASS  Tests\Features\Test
   ✓ a test

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1093,7 +1093,7 @@
   - it can use something in the test case as a condition → This test was skipped
   - it can user higher order callables and skip
   - it can skip on specific php version
-  - it can skip on php versions depending on operator
+  - it can skip on php versions depending on constraint
 
    PASS  Tests\Features\Test
   ✓ a test

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1092,6 +1092,8 @@
   - it skips when skip after assertion
   - it can use something in the test case as a condition → This test was skipped
   - it can user higher order callables and skip
+  - it can skip on specific php version
+  - it can skip on php versions greater than
 
    PASS  Tests\Features\Test
   ✓ a test
@@ -1372,4 +1374,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 19 skipped, 976 passed (2302 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 21 skipped, 976 passed (2302 assertions)

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -60,5 +60,5 @@ it('can skip on specific php version')
     ->assertTrue(false);
 
 it('can skip on php versions depending on operator')
-    ->skipOnPhp('7.4.0', '>')
+    ->skipOnPhp('>=7.4.0')
     ->assertTrue(false);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -59,6 +59,6 @@ it('can skip on specific php version')
     ->skipOnPhp(PHP_VERSION)
     ->assertTrue(false);
 
-it('can skip on php versions depending on operator')
+it('can skip on php versions depending on constraint')
     ->skipOnPhp('>=7.4.0')
     ->assertTrue(false);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -54,3 +54,11 @@ it('can user higher order callables and skip')
         return $this->shouldSkip;
     })
     ->toBeFalse();
+
+it('can skip on specific php version')
+    ->skipOnPhp(PHP_VERSION)
+    ->assertTrue(false);
+
+it('can skip on php versions greater than')
+    ->skipOnPhp("7.4.0", ">")
+    ->assertTrue(false);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -60,5 +60,5 @@ it('can skip on specific php version')
     ->assertTrue(false);
 
 it('can skip on php versions greater than')
-    ->skipOnPhp("7.4.0", ">")
+    ->skipOnPhp('7.4.0', '>')
     ->assertTrue(false);

--- a/tests/Features/Skip.php
+++ b/tests/Features/Skip.php
@@ -59,6 +59,6 @@ it('can skip on specific php version')
     ->skipOnPhp(PHP_VERSION)
     ->assertTrue(false);
 
-it('can skip on php versions greater than')
+it('can skip on php versions depending on operator')
     ->skipOnPhp('7.4.0', '>')
     ->assertTrue(false);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 15 skipped, 963 passed (2283 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 17 skipped, 963 passed (2283 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

In this PR I have added the ability to skip tests on php versions.

```php
    it('skips specific php version')->skipOnPhp("8.3.0");
    it('skips multiple php versions depending on constraint')->skipOnPhp("<=7.4.0");
````