### PR TITLE
[2.x] Support test dependencies across different classes

### DIFF
--- a/src/Factories/Annotations/Depends.php
+++ b/src/Factories/Annotations/Depends.php
@@ -19,8 +19,18 @@ final class Depends implements AddsAnnotations
     public function __invoke(TestCaseMethodFactory $method, array $annotations): array
     {
         foreach ($method->depends as $depend) {
+            // Split class and method name
+            $class = null;
+            if (str_contains($depend, '::')) {
+                [$class, $depend] = explode('::', $depend);
+            }
+
             $depend = Str::evaluable($method->describing !== null ? Str::describe($method->describing, $depend) : $depend);
 
+            // Add class name to method name and add annotation
+            if ($class !== null) {
+                $depend = "$class::$depend";
+            }
             $annotations[] = "@depends $depend";
         }
 

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -149,10 +149,25 @@ final class TestCall
 
     /**
      * Sets the test depends.
+     *
+     * @param  array<string|array<string, string>>  $depends
      */
-    public function depends(string ...$depends): self
+    public function depends(string|array ...$depends): self
     {
         foreach ($depends as $depend) {
+            // Unpack and format class reference as array
+            if (is_array($depend)) {
+                if (count($depend) !== 2) {
+                    throw new InvalidArgumentException('Depends array must have 2 elements.');
+                }
+                [$file, $test] = $depend;
+                if (! is_string($file) || ! is_string($test)) {
+                    throw new InvalidArgumentException('Depends array must have 2 string elements.');
+                }
+                $file = ltrim($file, '\\');
+                $depend = 'P\\'.$file.'::'.$test;
+            }
+
             $this->testCaseMethod->depends[] = $depend;
         }
 

--- a/tests/Features/DependsOnOtherFile.php
+++ b/tests/Features/DependsOnOtherFile.php
@@ -1,0 +1,43 @@
+<?php
+
+test('depends on other file - first same class', function () use (&$runCounter) {
+    expect(true)->toBeTrue();
+
+    return 'first same class';
+});
+
+test('depends on other file - second same class', function () use (&$runCounter) {
+    expect(true)->toBeTrue();
+
+    return 'second same class';
+});
+
+test('depends on other file - test invoke signature 1', function () {
+    expect(func_get_args())->toBe(['first', 'second']);
+})->depends(
+    ['\Tests\Features\Depends', 'first'],
+    ['\Tests\Features\Depends', 'second'],
+);
+
+test('depends on other file - test invoke signature 2', function ($first, $second) {
+    expect($first)->toBe('first');
+    expect($second)->toBe('second');
+})->depends(
+    ['\Tests\Features\Depends', 'first'],
+    ['\Tests\Features\Depends', 'second'],
+);
+
+test('depends on other file - test mixed parameters 1', function () {
+    expect(func_get_args())->toBe(['first', 'second same class']);
+})->depends(
+    ['\Tests\Features\Depends', 'first'],
+    'depends on other file - second same class',
+);
+
+test('depends on other file - test mixed parameters 2', function ($first, $second) {
+    expect($first)->toBe('first same class');
+    expect($second)->toBe('second');
+})->depends(
+    'depends on other file - first same class',
+    ['\Tests\Features\Depends', 'second'],
+);


### PR DESCRIPTION

<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->

Allow the test()->depends(...) method to reference methods from other file like the underlying https://github.com/Depends annotation from PHPUnit can do.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
Feature Request Issue: #1054 

### Motivation

In of our projects we've been using pest for integration testing on the staging system. These tests include general system requirements tests and some end-to-end feature tests that rely on the general system availability. Till now every test was in one file but this doesn't scale very well across a team so we would like to abstract the general tests into there own test file and reference theme via the `depends` on the feature tests.

### Interface (DX)

``` php
test('test model creation', function() { 
    # [...]
})->depends([ '\Tests\Feature\DbTest', 'successful db migration' ]);
```

### Implementation steps
1. Add class functionality to Pest\PendingCalls\TestCall -> depends
``` php
    /**
     * Sets the test depends.
     */
    public function depends(string|array ...$depends): self
    {
        foreach ($depends as $depend) {
            // Unpack and format class reference as array
            if (is_array($depend)) {
                if (count($depend) !== 2)
                    throw new InvalidArgumentException('Depends array must have 2 elements.');
                [$file, $test] = $depend;
                $file = ltrim($file, '\\');
                $depend = 'P\\'. $file . '::' . $test;
            }
            // Add depends
            $this->testCaseMethod->depends[] = $depend;
        }
        return $this;
    }
```
2. Adjust logic in @depends annotation generator Pest\Factories\Annotations\Depends -> __invoke
``` php
    /**
     * {@inheritdoc}
     */
    public function __invoke(TestCaseMethodFactory $method, array $annotations): array
    {
        foreach ($method->depends as $depend) {
            $method_name = $depend;

            // Split class and method name
            $class = null;
            if (str_contains($depend, '::')) {
                $parts = explode('::', $depend);
                [$class, $method_name] = $parts;
            }

            // Convert method name to evaluable string
            $depend = Str::evaluable($method->describing !== null ? Str::describe($method->describing, $method_name) : $method_name);

            // Add class name to method name and add annotation
            if ($class !== null)
                $depend = "$class::$depend";
            $annotations[] = "@depends $depend";
        }

        return $annotations;
    }
```
3. Added new tests for this feature