### PR TITLE
[2.x] fix: warn if no code coverage driver

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -363,6 +363,15 @@ final class WrapperRunner implements RunnerInterface
             $this->codeCoverageFilterRegistry,
             false,
         );
+        if (! $coverageManager->isActive()) {
+            $this->output->writeln([
+                '',
+                '  <fg=black;bg=yellow;options=bold> WARN </> No code coverage driver is available.</>',
+                '',
+            ]);
+
+            return;
+        }
         $coverageMerger = new CoverageMerger($coverageManager->codeCoverage());
         foreach ($this->coverageFiles as $coverageFile) {
             $coverageMerger->addCoverageFromFile($coverageFile);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Hello!

An exception is thrown if a coverage report is defined in the `phpunit.xml` but there's no coverage driver available (when running in parallel):

![image](https://github.com/pestphp/pest/assets/4176520/a8a261ac-a709-4030-91e3-42131845fb4e)

This PR updates the runner to check if there's a driver (and warns if there's not) before trying to compile the coverage information:

![image](https://github.com/pestphp/pest/assets/4176520/b0f6a045-ab80-4c55-9fbf-77d747734244)


Thanks!