### PR TITLE
[3.x] Add a `test()->after()` helper to create test-specific teardown callbacks

### DIFF
--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -214,7 +214,7 @@ final class TestCaseMethodFactory
      */
     public function __destruct()
     {
-        if ($this->after !== null) {
+        if ($this->after instanceof Closure) {
             ($this->after)();
         }
     }

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -208,4 +208,14 @@ final class TestCaseMethodFactory
 
         EOF;
     }
+
+    /**
+     * Execute the 'after' callback, if set.
+     */
+    public function __destruct()
+    {
+        if ($this->after !== null) {
+            ($this->after)();
+        }
+    }
 }

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -66,6 +66,11 @@ final class TestCaseMethodFactory
     public array $groups = [];
 
     /**
+     * Callback to run after the test has been executed.
+     */
+    public ?Closure $after = null;
+
+    /**
      * Creates a new test case method factory instance.
      */
     public function __construct(

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -404,6 +404,16 @@ final class TestCall
     }
 
     /**
+     * Registers a closure to be called after the test has been executed.
+     */
+    public function after(Closure $after): self
+    {
+        $this->testCaseMethod->after = $after;
+
+        return $this;
+    }
+
+    /**
      * Saves the property accessors to be used on the target.
      */
     public function __get(string $name): self

--- a/tests/Hooks/AfterTest.php
+++ b/tests/Hooks/AfterTest.php
@@ -1,0 +1,15 @@
+<?php
+
+test('after helper can be chained', function () {
+    expect(true)->toBeTrue();
+})->after(function () {
+    // Example
+});
+
+test('after closure is called', function () use (&$afterWasCalled) {
+    $afterWasCalled = true;
+
+    expect(true)->toBeTrue();
+})->after(function () use (&$afterWasCalled) {
+    expect($afterWasCalled)->toBeTrue();
+});


### PR DESCRIPTION
## Abstract

Adds a chainable helper to add a teardown closure specific to the test function, something that has gotten great response on Twitter so far. https://twitter.com/CodeWithCaen/status/1745752831385055626/photo/1

Targets v3, as requested by Nuno on Twitter.

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This feature makes it really easy to create teardown logic specific to a single test function, by chaining the new `->after()` method to the test setup. 

```php
test('file parsing', function () {
    touch('example.txt');

    expect(Parser::parse('example.txt'))->toBe('foo');
})->after(function () {
    // This closure gets called regardless of the test outcome
    unlink('example.txt');
});
```

This is really useful for cleaning up after an impure test, or to clear a service container, but you only need it for a single test function. Of course these things could be done at the end of a test within its main function body, but if the test fails the cleanup wouldn't be executed. This solves that as the closure gets executed regardless of the test outcome. It also makes the code cleaner by keeping cleanup logic out of the actual test declaration.

### Implementation:

As this is my first PR to Pest, I'm not fully familiar with the internals of the framework, so I opted for what I after looking through the related code found to be the simplest implementation and tried to match the coding style of the related code. Upon code review I'm more than happy to adjust the implementation to fit the codebase better, if necessary.

### Future features:

This could of course be enhanced by allowing things like dependency injection for the `after` closure, but I wanted to keep the initial feature as light as possible. I could also see the use for adding a `before` helper for test setups, however I think the `after` helper has the broadest use case.