### PR TITLE
[2.x] Improve coverage output message on failing minimum requirements

### DIFF
--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -128,9 +128,9 @@ final class Coverage implements AddsOutput, HandlesArguments
 
             if ($exitCode === 1) {
                 $this->output->writeln(sprintf(
-                    "\n  <fg=white;bg=red;options=bold> FAIL </> Code coverage below expected:<fg=red;options=bold> %s %%</>. Minimum:<fg=white;options=bold> %s %%</>.",
-                    number_format($coverage, 1),
-                    number_format($this->coverageMin, 1)
+                    "\n  <fg=white;bg=red;options=bold> FAIL </> Code coverage below expected <fg=white;options=bold> %s %%</>, currently <fg=red;options=bold> %s %%</>.",
+                    number_format($this->coverageMin, 1),
+                    number_format($coverage, 1)
                 ));
             }
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Improvement

### Description:
Improves the readability of the console output when the minimum required percentage is not met. 
As an added benefit, the value that is most important is at the end of the line, making it easier to spot.
