### PR TITLE
fix: build failing to run

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,11 @@ ARG PHP=8.1
 FROM php:${PHP}-cli-alpine
 
 RUN apk update && apk add \
-    zip libzip-dev icu-dev git \
+    zip libzip-dev icu-dev git
 
-RUN docker-php-ext-configure zip intl
 RUN docker-php-ext-install zip intl
-RUN docker-php-ext-enable zip intl
 
-RUN apk add --no-cache linux-headers
+RUN apk add --no-cache linux-headers autoconf build-base
 RUN pecl install xdebug
 RUN docker-php-ext-enable xdebug
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:
<!-- describe what your PR is solving -->
Only made changes in the dockerfile.
Running `make build ARGS="--build-arg PHP=8.2"` would result in an error that made it impossible to run the `docker compose build`.
```
 => ERROR [php stage-0 2/9] RUN apk update && apk add     zip libzip-dev icu-dev git RUN docker-php-ex  0.9s
------
 > [php stage-0 2/9] RUN apk update && apk add     zip libzip-dev icu-dev git RUN docker-php-ext-configure zip intl:
0.127 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/aarch64/APKINDEX.tar.gz
0.251 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/aarch64/APKINDEX.tar.gz
0.576 v3.19.0-341-gfaf9f17e39b [https://dl-cdn.alpinelinux.org/alpine/v3.19/main]
0.576 v3.19.0-347-g603bc9299c4 [https://dl-cdn.alpinelinux.org/alpine/v3.19/community]
0.576 OK: 22843 distinct packages available
0.829 ERROR: unable to select packages:
0.829   docker-php-ext-configure (no such package):
0.829     required by: world[docker-php-ext-configure]
0.829   intl (no such package):
0.829     required by: world[intl]
0.829   RUN (no such package):
0.829     required by: world[RUN]
------
failed to solve: process "/bin/sh -c apk update && apk add     zip libzip-dev icu-dev git RUN docker-php-ext-configure zip intl" did not complete successfully: exit code: 3
make: *** [build] Error 17
```
- Removed an unnecessary character, that was breaking the build.
-  Also removed the `docker-php-ext-configure` and `docker-php-ext-enable` commands on the file because according to [this issue](https://stackoverflow.com/a/61957409) `docker-php-ext-configure` should only be used when configuring extension before `docker-php-ext-install` and this command automatically runs `docker-php-ext-enable` after building the extension.
- Lastly, installed `autoconf` and `build-base` because of the error below.

<img width="1028" alt="image" src="https://github.com/pestphp/pest/assets/13033016/fdc44bf7-309a-4d53-9e34-688e344a9da5">

After these changes running the command `make build ARGS="--build-arg PHP=8.2"` builds the image successfully 👍 