### PR TITLE
fix: updates Only plugin to check for CI environment

### DIFF
--- a/src/Plugins/Only.php
+++ b/src/Plugins/Only.php
@@ -40,6 +40,10 @@ final class Only implements Terminable
      */
     public static function enable(TestCall $testCall): void
     {
+        if (Environment::name() == Environment::CI) {
+            return;
+        }
+
         $testCall->group('__pest_only');
 
         $lockFile = self::TEMPORARY_FOLDER.DIRECTORY_SEPARATOR.'only.lock';


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

**Pest v1** had a `--ci` flag that could be used in CI environments to ignore `->only()` calls that were accidentally checked-in to the code base. 

This feature looks to have been removed around the release of **Pest v2** but it is unlear if it was an intentional choice or simply an omission as a result of a refactor to the `->only()` feature. The [commit](https://github.com/pestphp/pest/commit/a61db76c24ef0b886a13fc9dbc40f0d50dbc0da3) that disabled the feature makes no mention of that intent and remnants of the `--ci` feature remain in the code base (such as the `Environment` plugin).

This PR restores the functionality of the `--ci` flag by updating the `Only` plugin to check the `Environment` plugin when it is invoked.

### Related:

- Original implementation: https://github.com/pestphp/pest/pull/405
- Disabled here: https://github.com/pestphp/pest/commit/a61db76c24ef0b886a13fc9dbc40f0d50dbc0da3
- https://github.com/pestphp/pest/discussions/1077
- https://github.com/pestphp/pest/blob/13f340a74239b2200a89a5825ec68dd72bf371a4/src/Plugins/Environment.php#L35
