### PR TITLE
[2.x] Adds toBeEmail() Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1177,4 +1177,23 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is an email
+     *
+     * @return self<TValue>
+     */
+    public function toBeEmail(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is an email.";
+        }
+
+        Assert::assertTrue(
+            Str::isEmail((string) $this->value),
+            $message
+        );
+
+        return $this;
+    }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -116,4 +116,12 @@ final class Str
     {
         return (bool) filter_var($value, FILTER_VALIDATE_URL);
     }
+
+    /**
+     * Determine if a given value is a valid EMAIL.
+     */
+    public static function isEmail(string $value): bool
+    {
+        return (bool) filter_var($value, FILTER_VALIDATE_EMAIL);
+    }
 }

--- a/tests/Features/Expect/toBeEmail.php
+++ b/tests/Features/Expect/toBeEmail.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+describe(
+    'check the validity of an email',
+    function (): void {
+        test('pass', function () {
+            expect('test@example.com')->toBeEmail();
+        });
+
+        test('failures', function (string $email) {
+            expect($email)->toBeEmail();
+        })
+            ->with([
+                'test',
+                'test.com',
+                'test@localhost',
+            ])
+            ->throws(ExpectationFailedException::class);
+
+        test('failures with custom message', function () {
+            expect('test@localhost')->toBeEmail('oh no!');
+        })
+            ->throws(
+                ExpectationFailedException::class,
+                'oh no!'
+            );
+
+        test('failures with default message', function () {
+            expect('test@localhost')->toBeEmail();
+        })
+            ->throws(
+                ExpectationFailedException::class,
+                'Failed asserting that test@localhost is an email'
+            );
+
+        test('not failures', function () {
+            expect('test@example.com')->not->toBeEmail();
+        })
+            ->throws(ExpectationFailedException::class);
+    }
+);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds a toBeEmail() expectation, to validate whether a value is a valid EMAIL.

### Related:

```php
expect('test@example.com')->toBeEmail();
expect('test@localhost')->not->toBeEmail();
```
