### PR TITLE
[2.x] Adds toBePowerOf() Expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1177,4 +1177,25 @@ final class Expectation
 
         return $this;
     }
+
+    /**
+     * Asserts that the value is power of $expected.
+     *
+     * @return self<TValue>
+     */
+    public function toBePowerOf(int|float $expected, string $message = ''): self
+    {
+        $logarithme = log(
+            (float) $this->value,
+            (float) $expected
+        );
+
+        Assert::assertTrue(
+            $expected === 1
+            || floor($logarithme) === $logarithme,
+            $message
+        );
+
+        return $this;
+    }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -543,6 +543,12 @@
   ✓ failures with custom message
   ✓ not failures
 
+   PASS  Tests\Features\Expect\toBePowerOf
+  ✓ Check whether one number is a power of another → pass
+  ✓ Check whether one number is a power of another → failures
+  ✓ Check whether one number is a power of another → failures with custom message
+  ✓ Check whether one number is a power of another → not failures
+
    PASS  Tests\Features\Expect\toBeReadableDirectory
   ✓ pass
   ✓ failures
@@ -1418,4 +1424,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1009 passed (2395 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1013 passed (2404 assertions)

--- a/tests/Features/Expect/toBePowerOf.php
+++ b/tests/Features/Expect/toBePowerOf.php
@@ -1,0 +1,25 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+describe('Check whether one number is a power of another', function () {
+    test('pass', function () {
+        expect(8)->toBePowerOf(2)
+            ->and(7)->not->toBePowerOf(2);
+    });
+
+    test('failures', function () {
+        expect(7)->toBePowerOf(2);
+    })->throws(ExpectationFailedException::class);
+
+    test('failures with custom message', function () {
+        expect(7)->toBePowerOf(2, 'oh no!');
+    })->throws(
+        ExpectationFailedException::class,
+        'oh no!'
+    );
+
+    test('not failures', function () {
+        expect(8)->not->toBePowerOf(2);
+    })->throws(ExpectationFailedException::class);
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 994 passed (2348 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 998 passed (2357 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds a `toBePowerOf()` expectation, to validate whether a value is a power of another.
If the PR is accepted, I could create one for documentation.

> [!NOTE]
> What's more, if this code is accepted then I could also create expectations for `exponential` and `square root`, for example.

### Related:

```php
expect(8)->toBePowerOf(2);
expect(7)->not->toBePowerOf(2);
```
