### PR TITLE
Fix strict_types check for enhanced compatibility

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -441,7 +441,7 @@ final class Expectation
     {
         return Targeted::make(
             $this,
-            fn (ObjectDescription $object): bool => str_contains((string) file_get_contents($object->path), 'declare(strict_types=1);'),
+            fn (ObjectDescription $object): bool => (bool) preg_match('/^<\?php\s+declare\s*\(\s*strict_types\s*=\s*1\s*\);/', (string) file_get_contents($object->path)),
             'to use strict types',
             FileLineFinder::where(fn (string $line): bool => str_contains($line, '<?php')),
         );

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -84,7 +84,7 @@ final class OppositeExpectation
     {
         return Targeted::make(
             $this->original,
-            fn (ObjectDescription $object): bool => ! str_contains((string) file_get_contents($object->path), 'declare(strict_types=1);'),
+            fn (ObjectDescription $object): bool => ! (bool) preg_match('/^<\?php\s+declare\s*\(\s*strict_types\s*=\s*1\s*\);/', (string) file_get_contents($object->path)),
             'not to use strict types',
             FileLineFinder::where(fn (string $line): bool => str_contains($line, '<?php')),
         );


### PR DESCRIPTION
Enhances strict_types detection in method to accommodate commented declarations via preg_match. Ensures code alignment with PHP CS Fixer's 'single space' rule for improved formatting consistency.

configuration: ['space' => 'single'].
```markdown
--- Original
+++ New
 <?php
-declare(ticks=1);
+declare(ticks = 1);
```

<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
