### PR TITLE
feat: auto-detect CI from environment

### DIFF
--- a/src/Plugins/Environment.php
+++ b/src/Plugins/Environment.php
@@ -39,6 +39,10 @@ final class Environment implements HandlesArguments
             }
         }
 
+        if (getenv('CI') === 'true') {
+            self::$name ??= self::CI;
+        }
+
         return array_values($arguments);
     }
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->

I was looking at [this PR on the docs](https://github.com/pestphp/docs/pull/259) earlier, and thought that it would be quite nice to add auto-detection for CI environments.

The majority of CI services (GitHub, GitLab, Travis, Bitbucket, CircleCI, etc.) provide a `CI` environment variable that is set to `true`, and this would basically allow us to auto-detect based on that.

> [!NOTE]
> My only thought is that this automatically disables the `Only` plugin, which someone may want to use in CI.
>
> I'm not 100% sure about whether people do use it in CI much, but just thought I'd bring it up for discussion.

On the flip side, I do like being explicit, but having this might prevent excessive CI time usage when people forget to include `--ci`. 🤷🏻