### PR TITLE
Fix nested datasets

### DIFF
--- a/src/Support/DatasetInfo.php
+++ b/src/Support/DatasetInfo.php
@@ -20,6 +20,11 @@ final class DatasetInfo
         return basename(dirname($file)) === self::DATASETS_DIR_NAME;
     }
 
+    public static function isNestedInsideADatasetsDirectory(string $file): bool
+    {
+        return str_contains($file, DIRECTORY_SEPARATOR.self::DATASETS_DIR_NAME.DIRECTORY_SEPARATOR);
+    }
+
     public static function isADatasetsFile(string $file): bool
     {
         return basename($file) === self::DATASETS_FILE_NAME;
@@ -33,6 +38,14 @@ final class DatasetInfo
 
         if (self::isInsideADatasetsDirectory($file)) {
             return dirname($file, 2);
+        }
+
+        if (self::isNestedInsideADatasetsDirectory($file)) {
+            $scope = strstr($file, DIRECTORY_SEPARATOR.self::DATASETS_DIR_NAME, true);
+
+            assert(is_string($scope));
+
+            return $scope;
         }
 
         if (self::isADatasetsFile($file)) {

--- a/tests/Datasets/Nested/Letters.php
+++ b/tests/Datasets/Nested/Letters.php
@@ -1,0 +1,3 @@
+<?php
+
+dataset('nested.letters', ['A', 'B']);

--- a/tests/Features/ScopedDatasets/TestFileOutOfScope.php
+++ b/tests/Features/ScopedDatasets/TestFileOutOfScope.php
@@ -14,6 +14,7 @@ test('the right dataset is taken', function () use ($state) {
 it('can see datasets defined in Pest.php file', function (string $value) use ($state) {
     $state->text .= $value;
     expect(true)->toBe(true);
+
 })->with('dataset_in_pest_file');
 
 test('Pest.php dataset is taken', function () use ($state) {
@@ -24,3 +25,7 @@ it('can see datasets in nested Dataset folders', function ($value) use ($state) 
     $state->text .= $value;
     expect(true)->toBeTrue();
 })->with('nested.letters');
+
+test('Nested dataset is taken', function () use ($state) {
+    expect($state->text)->toBe('12ABAB');
+});

--- a/tests/Features/ScopedDatasets/TestFileOutOfScope.php
+++ b/tests/Features/ScopedDatasets/TestFileOutOfScope.php
@@ -19,3 +19,8 @@ it('can see datasets defined in Pest.php file', function (string $value) use ($s
 test('Pest.php dataset is taken', function () use ($state) {
     expect($state->text)->toBe('12AB');
 });
+
+it('can see datasets in nested Dataset folders', function ($value) use ($state) {
+    $state->text .= $value;
+    expect(true)->toBeTrue();
+})->with('nested.letters');


### PR DESCRIPTION
This PR will allow to have nested datasets inside `Datasets` folder

**note**

this solution seems to work in standard mode, but fails with --parallel flag set up, it seems that the nested dataset si found, but the tests are filtered out by Paratest

can't get why, would be great if someone could take a look at this, maybe I'm missing something :(

fixes #1121