### PR TITLE
[2.x] Add `toBeUlid` expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1134,6 +1134,22 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is ULID.
+     *
+     * @return self<TValue>
+     */
+    public function toBeUlid(string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(Str::isUlid($this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is UUID.
      *
      * @return self<TValue>

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -94,6 +94,14 @@ final class Str
     }
 
     /**
+     * Determine if a given value is a valid ULID.
+     */
+    public static function isUlid(string $value): bool
+    {
+        return preg_match('/^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/i', $value) > 0;
+    }
+
+    /**
      * Determine if a given value is a valid UUID.
      */
     public static function isUuid(string $value): bool

--- a/tests/Features/Expect/toBeUlid.php
+++ b/tests/Features/Expect/toBeUlid.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('failures with wrong type', function () {
+    expect([])->toBeUlid();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
+
+test('pass', function () {
+    expect('1wnys2cgs627qaa5m4d69qh346')->toBeUlid(); // Timestamp 4084-06-09T15:09:55.366Z
+    expect('00010nrgs647qae044d69qh346')->toBeUlid(); // Timestamp 1970-01-13T16:36:05.542Z
+    expect('1ze0wnbant7sra7jxtzxna7cmf')->toBeUlid(); // Timestamp 4180-04-29T21:53:22.618Z
+    expect('6a1a12hkfp87dv6jy2yca8aybc')->toBeUlid(); // Timestamp 9009-07-17T20:09:55.958Z
+    expect('53ahvtxfxhbwqbb92725cmv1az')->toBeUlid(); // Timestamp 7660-10-06T00:48:41.393Z
+    expect('0ywgs67kttdzc8yhw4d69qh346')->toBeUlid(); // Timestamp 3046-04-28T14:19:38.714Z
+    expect('01h8nyy2fjea6bxjy3ynmxj546')->toBeUlid(); // Timestamp 2023-08-25T09:03:20.562Z
+    expect('0024h36h2ngsvrh6daqf6dvvqz')->toBeUlid(); // Timestamp 1972-05-01T17:10:29.205Z
+});
+
+test('failures', function () {
+    expect('foo')->toBeUlid();
+})->throws(ExpectationFailedException::class);
+
+test('failures with message', function () {
+    expect('bar')->toBeUlid('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('foo')->not->toBeUlid();
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

This PR adds `toBeUlid` expectation.

Usage:

```php
expect('01h8nyy2fjea6bxjy3ynmxj546')->toBeUlid();
```