### PR TITLE
[2.x] Add `act` higher order method

### DIFF
--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -74,11 +74,11 @@ final class HigherOrderCallables
      *
      * Execute the given callable and return its value.
      *
-     * @param  callable():TValue  $value
+     * @param  callable():TValue  $callable
      * @return TValue
      */
-    public function value(callable $value)
+    public function act(callable $callable)
     {
-        return Reflection::bindCallableWithData($value);
+        return Reflection::bindCallableWithData($callable);
     }
 }

--- a/src/Support/HigherOrderCallables.php
+++ b/src/Support/HigherOrderCallables.php
@@ -68,4 +68,17 @@ final class HigherOrderCallables
 
         return $this->target;
     }
+
+    /**
+     * @template TValue
+     *
+     * Execute the given callable and return its value.
+     *
+     * @param  callable():TValue  $value
+     * @return TValue
+     */
+    public function value(callable $value)
+    {
+        return Reflection::bindCallableWithData($value);
+    }
 }

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -75,7 +75,7 @@ it('can pass shared datasets into callables')
 
 it('can pass datasets into the value callable')
     ->with([[1, 2, 3]])
-    ->value(function (...$numbers) {
+    ->act(function (...$numbers) {
         return $this->assertSame($numbers, [1, 2, 3]);
     })
     ->assertTrue(true)

--- a/tests/Features/HigherOrderTests.php
+++ b/tests/Features/HigherOrderTests.php
@@ -73,4 +73,12 @@ it('can pass shared datasets into callables')
     })
     ->toBeInt();
 
+it('can pass datasets into the value callable')
+    ->with([[1, 2, 3]])
+    ->value(function (...$numbers) {
+        return $this->assertSame($numbers, [1, 2, 3]);
+    })
+    ->assertTrue(true)
+    ->assertFalse(false);
+
 afterEach()->assertTrue(true);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds new `act` higher order method, to be able to use higher order assertion with datasets.

### Example usage:

```php
it('creates new user')
    ->with(['Nuno Maduro', 'Hafez Divandari'])
    ->act(fn ($name) => $this->postJson('/api/user', ['name' => $name]))
    ->assertStatus(201)
    ->assertJson([
        'created' => true,
    ]);
```

```php
it('serves for guest user')
    ->with(['/home', '/login'])
    ->act(fn ($uri) => $this->get($uri))
    ->assertGuest('web')
    ->assertSessionHas('message', 'Welcome!')
```

Even better:

```php
it('restricts access for unauthenticated user')
    ->with('endpoints')
    ->act(jsonAsGuest(...))
    ->assertUnauthorized()
    ->assertExactJson(['message' => 'Unauthenticated.']);

// dataset
dataset('endpoints', [
    'index'   => ['GET', '/api/projects'],
    'store'   => ['POST', '/api/projects'],
    'show'    => ['GET', '/api/projects/1'],
    'update'  => ['PUT', '/api/projects/1'],
    'destroy' => ['DELETE', '/api/projects/1'],
]);

// tests/Pest.php
function jsonAsGuest(...$args): TestResponse
{
    return test()->json(...$args);
}
```

### Naming:

I chose `act` because of Arrange-**Act**-Assert Pattern. Please let me know if you have any better suggestion. e.g `value`, `does`, `exec`, `for`, `after`?
