### PR TITLE
[2.x] Fix JUnit output for mutation testing 

### DIFF
--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -121,7 +121,7 @@ final class JunitXmlLogger
     public function testSuiteStarted(Started $event): void
     {
         $testSuite = $this->document->createElement('testsuite');
-        $testSuite->setAttribute('name', $this->converter->getTestSuiteName($event->testSuite())); // pest-changed
+        $testSuite->setAttribute('name', $event->testSuite()->name());
 
         if ($event->testSuite()->isForTestClass()) {
             $testSuite->setAttribute('file', $this->converter->getTestSuiteLocation($event->testSuite()) ?? ''); // pest-changed
@@ -441,16 +441,15 @@ final class JunitXmlLogger
         $test = $event->test();
         $file = $this->converter->getTestCaseLocation($test); // pest-added
 
-        $testCase->setAttribute('name', $this->converter->getTestCaseMethodName($test)); // pest-changed
+        $testCase->setAttribute('name', $this->name($test));
         $testCase->setAttribute('file', $file); // pest-changed
 
         if ($test->isTestMethod()) {
             assert($test instanceof TestMethod);
 
             //$testCase->setAttribute('line', (string) $test->line()); // pest-removed
-            $className = $this->converter->getTrimmedTestClassName($test); // pest-added
-            $testCase->setAttribute('class', $className); // pest-changed
-            $testCase->setAttribute('classname', str_replace('\\', '.', $className)); // pest-changed
+            $testCase->setAttribute('class', $test->className());
+            $testCase->setAttribute('classname', str_replace('\\', '.', $test->className()));
         }
 
         $this->currentTestCase = $testCase;

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -439,7 +439,9 @@ final class JunitXmlLogger
         $testCase = $this->document->createElement('testcase');
 
         $test = $event->test();
-        $file = $this->converter->getTestCaseLocation($test); // pest-added
+        $location = $this->converter->getTestCaseLocation($test); // pest-added
+        $file = strstr($location, '::', true); // pest-added
+        $file = $file === false ? $location : $file; // pest-added
 
         $testCase->setAttribute('name', $this->name($test));
         $testCase->setAttribute('file', $file); // pest-changed

--- a/tests/Visual/JUnit.php
+++ b/tests/Visual/JUnit.php
@@ -47,7 +47,7 @@ test('junit output', function () use ($normalizedPath, $run) {
 
     expect($result['testsuite']['testcase'][0]['@attributes'])
         ->name->toBe('__pest_evaluable_it_can_pass_with_comparison')
-        ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php::it can pass with comparison'))
+        ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
         ->class->toBe('P\Tests\tests\SuccessOnly')
         ->classname->toBe('P.Tests.tests.SuccessOnly')
         ->assertions->toBe('1')
@@ -71,7 +71,7 @@ test('junit with parallel', function () use ($normalizedPath, $run) {
 
     expect($result['testsuite']['testcase']['@attributes'])
         ->name->toBe('__pest_evaluable_it_can_pass_with_comparison')
-        ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php::it can pass with comparison'))
+        ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
         ->class->toBe('P\Tests\tests\SuccessOnly')
         ->classname->toBe('P.Tests.tests.SuccessOnly')
         ->assertions->toBe('1')

--- a/tests/Visual/JUnit.php
+++ b/tests/Visual/JUnit.php
@@ -34,7 +34,7 @@ test('junit output', function () use ($normalizedPath, $run) {
     $result = $run('tests/.tests/SuccessOnly.php');
 
     expect($result['testsuite']['@attributes'])
-        ->name->toBe('Tests\tests\SuccessOnly')
+        ->name->toBe('P\Tests\tests\SuccessOnly')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
         ->tests->toBe('2')
         ->assertions->toBe('2')
@@ -46,10 +46,10 @@ test('junit output', function () use ($normalizedPath, $run) {
         ->toHaveCount(2);
 
     expect($result['testsuite']['testcase'][0]['@attributes'])
-        ->name->toBe('it can pass with comparison')
+        ->name->toBe('__pest_evaluable_it_can_pass_with_comparison')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php::it can pass with comparison'))
-        ->class->toBe('Tests\tests\SuccessOnly')
-        ->classname->toBe('Tests.tests.SuccessOnly')
+        ->class->toBe('P\Tests\tests\SuccessOnly')
+        ->classname->toBe('P.Tests.tests.SuccessOnly')
         ->assertions->toBe('1')
         ->time->toStartWith('0.0');
 });
@@ -58,7 +58,7 @@ test('junit with parallel', function () use ($normalizedPath, $run) {
     $result = $run('tests/.tests/SuccessOnly.php', '--parallel', '--processes=1', '--filter', 'can pass with comparison');
 
     expect($result['testsuite']['@attributes'])
-        ->name->toBe('Tests\tests\SuccessOnly')
+        ->name->toBe('P\Tests\tests\SuccessOnly')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
         ->tests->toBe('1')
         ->assertions->toBe('1')
@@ -70,10 +70,10 @@ test('junit with parallel', function () use ($normalizedPath, $run) {
         ->toHaveCount(1);
 
     expect($result['testsuite']['testcase']['@attributes'])
-        ->name->toBe('it can pass with comparison')
+        ->name->toBe('__pest_evaluable_it_can_pass_with_comparison')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php::it can pass with comparison'))
-        ->class->toBe('Tests\tests\SuccessOnly')
-        ->classname->toBe('Tests.tests.SuccessOnly')
+        ->class->toBe('P\Tests\tests\SuccessOnly')
+        ->classname->toBe('P.Tests.tests.SuccessOnly')
         ->assertions->toBe('1')
         ->time->toStartWith('0.0');
 });


### PR DESCRIPTION
### What:
- [x] Bug Fix

### Description:
[Mutation testing](https://github.com/infection/infection) relies on real generated phpunit classes under the hood of pest.
(for example `P\Tests\CalculatorTest::__pest_evaluable_it_adds`)

my current junit implementation for pest is printing the "pretty" name `Tests\CalculatorTest::it adds` which is nice for humans not for other libs that try to work with the generated test classes by pest

Im reverting method and class name related changes which should fix it.
We still override the junit logger to get the proper file location

### Test this fix
`composer.json`
```JSON
{
    "require-dev": {
        "pestphp/pest": "dev-junit-revert-naming as v2.35.0"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/nuernbergerA/pest"
        }
    ]
}
```

### Related:
Fixes #1095
