### PR TITLE
Interpolated dataset names

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -194,7 +194,13 @@ trait Testable
 
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
 
-        $description = $this->dataName() ? $method->description.' with '.$this->dataName() : $method->description;
+        $description = $method->description;
+        if ($this->dataName()) {
+            $description = str_contains((string) $description, ':dataset')
+                ? str_replace(':dataset', str_replace('dataset ', '', $this->dataName()), (string) $description)
+                : $description.' with '.$this->dataName();
+        }
+
         $description = htmlspecialchars(html_entity_decode((string) $description), ENT_NOQUOTES);
 
         if ($method->repetitions > 1) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -63,6 +63,8 @@
   ✓ lazy datasets with (1)
   ✓ lazy datasets with (2)
   ✓ lazy datasets did the job right
+  ✓ interpolated (1) lazy datasets
+  ✓ interpolated (2) lazy datasets
   ✓ eager datasets with (1)
   ✓ eager datasets with (2)
   ✓ eager datasets did the job right
@@ -1442,4 +1444,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 21 skipped, 1032 passed (2517 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 21 skipped, 1034 passed (2519 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -77,6 +77,8 @@
   ✓ eager registered wrapped datasets did the job right
   ✓ named datasets with dataset "one"
   ✓ named datasets with dataset "two"
+  ✓ interpolated "one" named datasets
+  ✓ interpolated "two" named datasets
   ✓ named datasets did the job right
   ✓ lazy named datasets with (Bar)
   ✓ it creates unique test case names with ('Name 1', Pest\Plugin Object (), true) #1
@@ -1440,4 +1442,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 21 skipped, 1030 passed (2515 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 21 skipped, 1032 passed (2517 assertions)

--- a/tests/Features/DatasetsTests.php
+++ b/tests/Features/DatasetsTests.php
@@ -109,6 +109,13 @@ test('named datasets', function ($text) use ($state, $datasets) {
     'two' => [2],
 ]);
 
+test('interpolated :dataset named datasets', function ($text) {
+    expect(true)->toBeTrue();
+})->with([
+    'one' => [1],
+    'two' => [2],
+]);
+
 test('named datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('121212121212');
 });

--- a/tests/Features/DatasetsTests.php
+++ b/tests/Features/DatasetsTests.php
@@ -61,6 +61,10 @@ test('lazy datasets did the job right', function () use ($state) {
     expect($state->text)->toBe('12');
 });
 
+test('interpolated :dataset lazy datasets', function ($text) {
+    expect(true)->toBeTrue();
+})->with($datasets);
+
 $state->text = '';
 
 test('eager datasets', function ($text) use ($state, $datasets) {

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 1016 passed (2483 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 1018 passed (2485 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 1018 passed (2485 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 1020 passed (2487 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

<!-- describe what your PR is solving -->

This PR is to add the functionality I described in a [recent discussion thread](https://github.com/pestphp/pest/discussions/1143). 

This PR is solving the problem that though we can name our datasets, we are not able to take a step further and use those dataset names fluently inside of a test name. 

To do this you add `:dataset` into your test name, and the dataset name will be interpolated into the test name string. Similar to [Laravel's `:attribute` inside validation strings](https://laravel.com/docs/11.x/validation#manual-customizing-the-error-messages)

I am very open to any changes! 

I targeted `3.x` because this would be a breaking change, even if `:dataset` is unlikely. 

### Contrived Example
#### Before

**Test**
```php
it('can sort by all fields', function (/* ... */) {
    /* ... */
})->with([
    'name' => [ /* ... */ ],
    'email' => [ /* ... */ ],
    'created_at' => [ /* ... */]
]);
```

**Pest output**
```log
   PASS  Tests\Feature\TableSortTest
  ✓ it can sort by all fields with dataset "name"                                                                                                            
  ✓ it can sort by all fields with dataset "email"
  ✓ it can sort by all fields with dataset "created_at"
```

#### After

**Test**

```php
it('can sort by :dataset field', function (/* ... */) {
    /* ... */
})->with([
    'name' => [ /* ... */ ],
    'email' => [ /* ... */ ],
    'created_at' => [ /* ... */]
]);
```

**Pest output**
```log
   PASS  Tests\Feature\TableSortTest
  ✓ it can sort by "name" field                                                                                                     
  ✓ it can sort by "email" field
  ✓ it can sort by "created_at" field
```

### Questions

I'm not a huge fan of where this functionality is, but I'm not sure where else it could be refactored to. Especially needing to remove the `'dataset '` that is already on the name. However any other approach would require significantly more refactoring I believe. 

- Is this functionality worth pursuing? 
- Should I move this somewhere else? 
- Should I do any other manipulation to the dataset name? Should it have the `"..."`s on named sets and `(...)` on unnamed sets? 
- Should I use some other string than `:dataset`?
