### PR TITLE
[2.x] Add PHPStan `$this` annotation (1.11)

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -53,7 +53,7 @@ if (! function_exists('beforeEach')) {
     /**
      * Runs the given closure before each test in the current file.
      *
-     * @param-closure-this \Tests\TestCase $closure
+     * @param-closure-this TestCase $closure
      * @return HigherOrderTapProxy<Expectable|TestCall|TestCase>|Expectable|TestCall|TestCase|mixed
      */
     function beforeEach(?Closure $closure = null): BeforeEachCall
@@ -115,7 +115,7 @@ if (! function_exists('test')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
-     * @param-closure-this \Tests\TestCase $closure
+     * @param-closure-this TestCase $closure
      * @return Expectable|TestCall|TestCase|mixed
      */
     function test(?string $description = null, ?Closure $closure = null): HigherOrderTapProxy|TestCall
@@ -136,7 +136,7 @@ if (! function_exists('it')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
-     * @param-closure-this \Tests\TestCase $closure
+     * @param-closure-this TestCase $closure
      * @return Expectable|TestCall|TestCase|mixed
      */
     function it(string $description, ?Closure $closure = null): TestCall
@@ -172,7 +172,7 @@ if (! function_exists('afterEach')) {
     /**
      * Runs the given closure after each test in the current file.
      *
-     * @param-closure-this \Tests\TestCase $closure
+     * @param-closure-this TestCase $closure
      * @return Expectable|HigherOrderTapProxy<Expectable|TestCall|TestCase>|TestCall|mixed
      */
     function afterEach(?Closure $closure = null): AfterEachCall

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -53,6 +53,7 @@ if (! function_exists('beforeEach')) {
     /**
      * Runs the given closure before each test in the current file.
      *
+     * @param-closure-this \Tests\TestCase $closure
      * @return HigherOrderTapProxy<Expectable|TestCall|TestCase>|Expectable|TestCall|TestCase|mixed
      */
     function beforeEach(?Closure $closure = null): BeforeEachCall
@@ -114,6 +115,7 @@ if (! function_exists('test')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
+     * @param-closure-this \Tests\TestCase $closure
      * @return Expectable|TestCall|TestCase|mixed
      */
     function test(?string $description = null, ?Closure $closure = null): HigherOrderTapProxy|TestCall
@@ -134,6 +136,7 @@ if (! function_exists('it')) {
      * is the test description; the second argument is
      * a closure that contains the test expectations.
      *
+     * @param-closure-this \Tests\TestCase $closure
      * @return Expectable|TestCall|TestCase|mixed
      */
     function it(string $description, ?Closure $closure = null): TestCall
@@ -169,6 +172,7 @@ if (! function_exists('afterEach')) {
     /**
      * Runs the given closure after each test in the current file.
      *
+     * @param-closure-this \Tests\TestCase $closure
      * @return Expectable|HigherOrderTapProxy<Expectable|TestCall|TestCase>|TestCall|mixed
      */
     function afterEach(?Closure $closure = null): AfterEachCall


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [X] New Feature

### Description:

Is it a bug fix? Is it a feature? Quite frankly, I think a bit of both 😁

One of the biggest frustrations for me when using Pest was the fact that the `$this` keyword is not bound to anything, which causes Phpstan to complain about it like this:

![CleanShot 2024-05-23 at 17 05 09](https://github.com/pestphp/pest/assets/7697/44f31d48-e763-4dff-8f9d-6e328cab0505)

Since [PHPStan 1.11.0](https://github.com/phpstan/phpstan/releases/tag/1.11.0), there is support for a `@param-closure-this` annotation that allows us to define what `$this` means in a `Closure`.

This MR applies this annotation to the `test()`, `it()`, `beforeEach()` and `afterEach()` methods, which looks like this:

![CleanShot 2024-05-23 at 17 08 31](https://github.com/pestphp/pest/assets/7697/a37514ba-095e-4a25-8e7a-9a27d851b79b)

## Caveats

The annotation is currently bound to the `PHPUnit\Framework\TestCase` object, which is fine in _most_ cases, but if you use a custom `TestCase` object, this annotation might cause errors such as "phpstan: Call to an undefined method PHPUnit\Framework\TestCase::mock()". I am not sure if there is an easy fix for that, apart from overriding the annotation on a test-level, so I have kept this out of scope for now.
