### PR TITLE
Fix Laravel 11 TestCase.php stub

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -468,6 +468,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is a list.
+     *
+     * @return self<TValue>
+     */
+    public function toBeList(string $message = ''): self
+    {
+        Assert::assertIsList($this->value, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is of type bool.
      *
      * @return self<TValue>

--- a/stubs/init-laravel/TestCase.php.stub
+++ b/stubs/init-laravel/TestCase.php.stub
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication;
+    
 }

--- a/tests/Features/Expect/toBeList.php
+++ b/tests/Features/Expect/toBeList.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect([1, 2, 3])->toBeList();
+    expect(['a' => 1, 'b' => 2, 'c' => 3])->not->toBeList();
+});
+
+test('failures', function () {
+    expect(null)->toBeList();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect(null)->toBeList('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect(['a', 'b', 'c'])->not->toBeList();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeList.php
+++ b/tests/Features/Expect/toBeList.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 test('pass', function () {
     expect([1, 2, 3])->toBeList();
     expect(['a' => 1, 'b' => 2, 'c' => 3])->not->toBeList();
+    expect('1, 2, 3')->not->toBeList();
 });
 
 test('failures', function () {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

As Laravel 11 `tests/TestCase.php` it doesn't have `use CreatesApplication;` statement.

So in fresh Laravel install if you install Pest right after that, by default the `tests/TestCase.php` exists so it would recognized.

I manually removed the `tests/TestCase.php` so `pest:install` replaced the stubs, after running the `php artisan test` command i encouraged an error that shows  `use CreatesApplication;` is not found.
