### PR TITLE
Add `echo` and `print` to base preset

### DIFF
--- a/src/ArchPresets/Base.php
+++ b/src/ArchPresets/Base.php
@@ -24,6 +24,8 @@ final class Base extends AbstractPreset
             'usleep',
             'exit',
             'phpinfo',
+            'echo',
+            'print',
             'print_r',
             'var_export',
         ])->not->toBeUsed();


### PR DESCRIPTION
Make sure `echo` and `print` are not used using the Base preset.