### PR TITLE
feature(presets): Add security preset

### DIFF
--- a/src/ArchPresets/Security.php
+++ b/src/ArchPresets/Security.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\ArchPresets;
+
+/**
+ * @internal
+ */
+final class Security extends AbstractPreset
+{
+    /**
+     * Executes the arch preset.
+     */
+    public function execute(): void
+    {
+        $this->expectations[] = expect([
+            'md5',
+            'sha1',
+            'uniqid',
+            'rand',
+            'mt_rand',
+            'tempnam',
+            'str_shuffle',
+            'shuffle',
+            'array_rand'
+        ])->not->toBeUsed();
+    }
+}

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -8,6 +8,7 @@ use Pest\Arch\Support\Composer;
 use Pest\ArchPresets\AbstractPreset;
 use Pest\ArchPresets\Base;
 use Pest\ArchPresets\Strict;
+use Pest\ArchPresets\Security;
 use Pest\PendingCalls\TestCall;
 use stdClass;
 
@@ -45,6 +46,14 @@ final class Preset
     public function strict(): Strict
     {
         return $this->executePreset(new Strict($this->baseNamespaces()));
+    }
+
+    /**
+     * Uses the Pest security preset and returns the test call instance.
+     */
+    public function security(): AbstractPreset
+    {
+        return $this->executePreset(new Security($this->baseNamespaces()));
     }
 
     /**

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -9,6 +9,8 @@ arch()->preset()->base()->ignoring([
 
 arch()->preset()->strict();
 
+arch()->preset()->security();
+
 arch('globals')
     ->expect(['dd', 'dump', 'ray', 'die', 'var_dump', 'sleep'])
     ->not->toBeUsed()


### PR DESCRIPTION
Adds an additional preset for functions often seen as insecure.

I have a couple more laravel specific ones but I'll include those in another PR.