### PR TITLE
`toBePrintable()`

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1074,6 +1074,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is printable.
+     *
+     * @return self<TValue>
+     */
+    public function toBePrintable(string $message = ''): self
+    {
+        Assert::assertTrue(ctype_print((string) $this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is snake_case.
      *
      * @return self<TValue>

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -549,6 +549,12 @@
   ✓ failures with custom message
   ✓ not failures
 
+   PASS  Tests\Features\Expect\toBePrintable
+  ✓ pass
+  ✓ failures
+  ✓ failures with custom message
+  ✓ not failures
+
    PASS  Tests\Features\Expect\toBeReadableDirectory
   ✓ pass
   ✓ failures
@@ -1388,9 +1394,9 @@
   ✓ description
   ✓ latest description
 
-   PASS  Tests\Visual\Collision
+   FAIL  Tests\Visual\Collision
   ✓ collision with ([''])
-  ✓ collision with (['--parallel'])
+  ⨯ collision with (['--parallel'])
 
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
@@ -1423,5 +1429,28 @@
 
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
+  ────────────────────────────────────────────────────────────────────────────  
+   FAILED  Tests\Visual\Collision > collision with (['--parallel'])             
+  Failed asserting that the string value matches its snapshot (tests/.pest/snapshots/Visual/Collision/collision_with_data_set_______parallel__________parallel___.snap).
+Failed asserting that two strings are identical.
+   '
+  -  .⨯.
+  +  ⨯..
+     ────────────────────────────────────────────────────────────────────────────  
+      FAILED  Tests\Fixtures\CollisionTest > error                     Exception   
+     error
+  
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1013 passed (2405 assertions)
+  at tests/Visual/Collision.php:26
+     22▕         array_pop($outputContent);
+     23▕         array_pop($outputContent);
+     24▕     }
+     25▕ 
+  ➜  26▕     expect(implode("\n", $outputContent))->toMatchSnapshot();
+     27▕ })->with([
+     28▕     [['']],
+     29▕     [['--parallel']],
+     30▕ ])->skipOnWindows();
+
+
+  Tests:    2 deprecated, 1 failed, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1016 passed (2414 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1394,9 +1394,9 @@
   ✓ description
   ✓ latest description
 
-   FAIL  Tests\Visual\Collision
+   PASS  Tests\Visual\Collision
   ✓ collision with ([''])
-  ⨯ collision with (['--parallel'])
+  ✓ collision with (['--parallel'])
 
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
@@ -1429,28 +1429,5 @@
 
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
-  ────────────────────────────────────────────────────────────────────────────  
-   FAILED  Tests\Visual\Collision > collision with (['--parallel'])             
-  Failed asserting that the string value matches its snapshot (tests/.pest/snapshots/Visual/Collision/collision_with_data_set_______parallel__________parallel___.snap).
-Failed asserting that two strings are identical.
-   '
-  -  .⨯.
-  +  ⨯..
-     ────────────────────────────────────────────────────────────────────────────  
-      FAILED  Tests\Fixtures\CollisionTest > error                     Exception   
-     error
-  
 
-  at tests/Visual/Collision.php:26
-     22▕         array_pop($outputContent);
-     23▕         array_pop($outputContent);
-     24▕     }
-     25▕ 
-  ➜  26▕     expect(implode("\n", $outputContent))->toMatchSnapshot();
-     27▕ })->with([
-     28▕     [['']],
-     29▕     [['--parallel']],
-     30▕ ])->skipOnWindows();
-
-
-  Tests:    2 deprecated, 1 failed, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1016 passed (2414 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 20 skipped, 1017 passed (2414 assertions)

--- a/tests/Features/Expect/toBePrintable.php
+++ b/tests/Features/Expect/toBePrintable.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('printable')->toBePrintable();
+    expect("not\n\r\tprintable")->not->toBePrintable();
+});
+
+test('failures', function () {
+    expect(null)->toBePrintable();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect(null)->toBePrintable('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('printable')->not->toBePrintable();
+})->throws(ExpectationFailedException::class);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 998 passed (2358 assertions)')
+        ->toContain('Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 13 todos, 16 skipped, 1002 passed (2367 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces `toBePrintable` expectation, which makes sure that the passed string is printable.

```php
expect('printable')->toBePrintable();
expect("not\n\r\tprintable")->not->toBePrintable();
```