### PR TITLE
Include ds from Laradumps in ArchPresets

### DIFF
--- a/src/ArchPresets/Base.php
+++ b/src/ArchPresets/Base.php
@@ -20,6 +20,7 @@ final class Base extends AbstractPreset
             'debug_print_backtrace',
             'dump',
             'ray',
+            'ds',                           
             'die',
             'goto',
             'global',


### PR DESCRIPTION

### What:

Small improvement to the ArchPresets feature of Pest 3

### Description:

Adds check for Laradump's `ds` 

https://laradumps.dev

