### PR TITLE
Add dubious ownership error control

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "test:refacto": "rector --dry-run",
         "test:lint": "pint --test",
         "test:type:check": "phpstan analyse --ansi --memory-limit=-1 --debug",
-        "test:type:coverage": "php bin/pest --type-coverage --min=100",
+        "test:type:coverage": "php -d memory_limit=-1  bin/pest --type-coverage --min=100",
         "test:unit": "php bin/pest --colors=always --exclude-group=integration --compact",
         "test:inline": "php bin/pest --colors=always --configuration=phpunit.inline.xml",
         "test:parallel": "php bin/pest --colors=always --exclude-group=integration --parallel --processes=3",

--- a/src/Bootstrappers/BootSubscribers.php
+++ b/src/Bootstrappers/BootSubscribers.php
@@ -32,8 +32,7 @@ final class BootSubscribers implements Bootstrapper
      */
     public function __construct(
         private readonly Container $container,
-    ) {
-    }
+    ) {}
 
     /**
      * Boots the list of Subscribers.

--- a/src/Exceptions/DubiousFolderOwnership.php
+++ b/src/Exceptions/DubiousFolderOwnership.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class DubiousFolderOwnership extends RuntimeException
+{
+    /**
+     * Creates a new Exception instance.
+     */
+    public function __construct()
+    {
+        parent::__construct('Dubious folder ownership');
+    }
+}

--- a/src/Expectations/EachExpectation.php
+++ b/src/Expectations/EachExpectation.php
@@ -24,9 +24,7 @@ final class EachExpectation
      *
      * @param  Expectation<TValue>  $original
      */
-    public function __construct(private readonly Expectation $original)
-    {
-    }
+    public function __construct(private readonly Expectation $original) {}
 
     /**
      * Creates a new expectation.

--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -36,9 +36,7 @@ final class OppositeExpectation
      *
      * @param  Expectation<TValue>  $original
      */
-    public function __construct(private readonly Expectation $original)
-    {
-    }
+    public function __construct(private readonly Expectation $original) {}
 
     /**
      * Asserts that the value array not has the provided $keys.

--- a/src/Factories/Covers/CoversClass.php
+++ b/src/Factories/Covers/CoversClass.php
@@ -9,7 +9,5 @@ namespace Pest\Factories\Covers;
  */
 final class CoversClass
 {
-    public function __construct(public string $class)
-    {
-    }
+    public function __construct(public string $class) {}
 }

--- a/src/Factories/Covers/CoversFunction.php
+++ b/src/Factories/Covers/CoversFunction.php
@@ -9,7 +9,5 @@ namespace Pest\Factories\Covers;
  */
 final class CoversFunction
 {
-    public function __construct(public string $function)
-    {
-    }
+    public function __construct(public string $function) {}
 }

--- a/src/Factories/Covers/CoversNothing.php
+++ b/src/Factories/Covers/CoversNothing.php
@@ -7,6 +7,4 @@ namespace Pest\Factories\Covers;
 /**
  * @internal
  */
-final class CoversNothing
-{
-}
+final class CoversNothing {}

--- a/src/Logging/TeamCity/ServiceMessage.php
+++ b/src/Logging/TeamCity/ServiceMessage.php
@@ -17,8 +17,7 @@ final class ServiceMessage
     public function __construct(
         private readonly string $type,
         private readonly array $parameters,
-    ) {
-    }
+    ) {}
 
     public function toString(): string
     {

--- a/src/Logging/TeamCity/Subscriber/Subscriber.php
+++ b/src/Logging/TeamCity/Subscriber/Subscriber.php
@@ -14,9 +14,7 @@ abstract class Subscriber
     /**
      * Creates a new Subscriber instance.
      */
-    public function __construct(private readonly TeamCityLogger $logger)
-    {
-    }
+    public function __construct(private readonly TeamCityLogger $logger) {}
 
     /**
      * Creates a new TeamCityLogger instance.

--- a/src/Matchers/Any.php
+++ b/src/Matchers/Any.php
@@ -7,6 +7,4 @@ namespace Pest\Matchers;
 /**
  * @internal
  */
-final class Any
-{
-}
+final class Any {}

--- a/src/Plugins/Parallel/Paratest/ResultPrinter.php
+++ b/src/Plugins/Parallel/Paratest/ResultPrinter.php
@@ -63,8 +63,7 @@ final class ResultPrinter
         {
             public function __construct(
                 private readonly OutputInterface $output,
-            ) {
-            }
+            ) {}
 
             public function print(string $buffer): void
             {
@@ -79,9 +78,7 @@ final class ResultPrinter
                 $this->output->write(OutputFormatter::escape($buffer));
             }
 
-            public function flush(): void
-            {
-            }
+            public function flush(): void {}
         };
 
         $this->compactPrinter = CompactPrinter::default();

--- a/src/Repositories/SnapshotRepository.php
+++ b/src/Repositories/SnapshotRepository.php
@@ -21,8 +21,7 @@ final class SnapshotRepository
     public function __construct(
         readonly private string $testsPath,
         readonly private string $snapshotsPath,
-    ) {
-    }
+    ) {}
 
     /**
      * Checks if the snapshot exists.

--- a/src/Subscribers/EnsureTeamCityEnabled.php
+++ b/src/Subscribers/EnsureTeamCityEnabled.php
@@ -24,8 +24,7 @@ final class EnsureTeamCityEnabled implements ConfiguredSubscriber
         private readonly InputInterface $input,
         private readonly OutputInterface $output,
         private readonly TestSuite $testSuite,
-    ) {
-    }
+    ) {}
 
     /**
      * Runs the subscriber.

--- a/src/Support/ExpectationPipeline.php
+++ b/src/Support/ExpectationPipeline.php
@@ -30,8 +30,7 @@ final class ExpectationPipeline
      */
     public function __construct(
         private readonly Closure $closure
-    ) {
-    }
+    ) {}
 
     /**
      * Creates a new instance of Expectation Pipeline with given closure.

--- a/src/Support/NullClosure.php
+++ b/src/Support/NullClosure.php
@@ -16,7 +16,6 @@ final class NullClosure
      */
     public static function create(): Closure
     {
-        return Closure::fromCallable(function (): void {
-        });
+        return Closure::fromCallable(function (): void {});
     }
 }

--- a/src/TestCaseFilters/GitDirtyTestCaseFilter.php
+++ b/src/TestCaseFilters/GitDirtyTestCaseFilter.php
@@ -49,9 +49,9 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
         $process = new Process(['git', 'status', '--short', '--', '*.php']);
         $process->run();
 
-        if (! $process->isSuccessful()) {
+        if (!$process->isSuccessful()) {
             if ($process->getExitCode() === self::EXIT_CODE_GIT_DUBIOUS_OWNERSHIP) {
-                throw new InvalidArgumentException('Dubiuous folder ownership');
+                throw new InvalidArgumentException('Dubious folder ownership');
             }
 
             throw new MissingDependency('Filter by dirty files', 'git');
@@ -78,7 +78,7 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
 
         $dirtyFiles = array_filter(
             $dirtyFiles,
-            fn (string $file): bool => str_starts_with('.'.DIRECTORY_SEPARATOR.$file, TestSuite::getInstance()->testPath)
+            fn (string $file): bool => str_starts_with('.' . DIRECTORY_SEPARATOR . $file, TestSuite::getInstance()->testPath)
                 || str_starts_with($file, TestSuite::getInstance()->testPath)
         );
 

--- a/src/TestCaseFilters/GitDirtyTestCaseFilter.php
+++ b/src/TestCaseFilters/GitDirtyTestCaseFilter.php
@@ -49,11 +49,11 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
         $process = new Process(['git', 'status', '--short', '--', '*.php']);
         $process->run();
 
-        if ($process->getExitCode() === self::EXIT_CODE_GIT_DUBIOUS_OWNERSHIP) {
-            throw new InvalidArgumentException('Dubiuous folder ownership');
-        }
-
         if (!$process->isSuccessful()) {
+            if ($process->getExitCode() === self::EXIT_CODE_GIT_DUBIOUS_OWNERSHIP) {
+                throw new InvalidArgumentException('Dubiuous folder ownership');
+            }
+
             throw new MissingDependency('Filter by dirty files', 'git');
         }
 

--- a/src/TestCaseFilters/GitDirtyTestCaseFilter.php
+++ b/src/TestCaseFilters/GitDirtyTestCaseFilter.php
@@ -49,7 +49,7 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
         $process = new Process(['git', 'status', '--short', '--', '*.php']);
         $process->run();
 
-        if (!$process->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             if ($process->getExitCode() === self::EXIT_CODE_GIT_DUBIOUS_OWNERSHIP) {
                 throw new InvalidArgumentException('Dubiuous folder ownership');
             }
@@ -78,7 +78,7 @@ final class GitDirtyTestCaseFilter implements TestCaseFilter
 
         $dirtyFiles = array_filter(
             $dirtyFiles,
-            fn (string $file): bool => str_starts_with('.' . DIRECTORY_SEPARATOR . $file, TestSuite::getInstance()->testPath)
+            fn (string $file): bool => str_starts_with('.'.DIRECTORY_SEPARATOR.$file, TestSuite::getInstance()->testPath)
                 || str_starts_with($file, TestSuite::getInstance()->testPath)
         );
 

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -10,9 +10,7 @@ use Tests\Fixtures\Covers\CoversTrait;
 
 $runCounter = 0;
 
-function testCoversFunction()
-{
-}
+function testCoversFunction() {}
 
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();

--- a/tests/Features/Expect/toBeCallable.php
+++ b/tests/Features/Expect/toBeCallable.php
@@ -3,8 +3,7 @@
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
-    expect(function () {
-    })->toBeCallable();
+    expect(function () {})->toBeCallable();
     expect(null)->not->toBeCallable();
 });
 

--- a/tests/Features/Expect/toHaveMethods.php
+++ b/tests/Features/Expect/toHaveMethods.php
@@ -4,13 +4,9 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 $object = new class
 {
-    public function foo(): void
-    {
-    }
+    public function foo(): void {}
 
-    public function bar(): void
-    {
-    }
+    public function bar(): void {}
 };
 
 test('pass', function () use ($object) {

--- a/tests/Features/Expect/toMatchSnapshot.php
+++ b/tests/Features/Expect/toMatchSnapshot.php
@@ -43,9 +43,7 @@ test('pass with `__toString`', function () {
 
     $object = new class($this->snapshotable)
     {
-        public function __construct(protected string $snapshotable)
-        {
-        }
+        public function __construct(protected string $snapshotable) {}
 
         public function __toString()
         {
@@ -61,9 +59,7 @@ test('pass with `toString`', function () {
 
     $object = new class($this->snapshotable)
     {
-        public function __construct(protected string $snapshotable)
-        {
-        }
+        public function __construct(protected string $snapshotable) {}
 
         public function toString()
         {
@@ -97,9 +93,7 @@ test('pass with `toArray`', function () {
 
     $object = new class($this->snapshotable)
     {
-        public function __construct(protected string $snapshotable)
-        {
-        }
+        public function __construct(protected string $snapshotable) {}
 
         public function toArray()
         {
@@ -125,9 +119,7 @@ test('pass with `toSnapshot`', function () {
 
     $object = new class($this->snapshotable)
     {
-        public function __construct(protected string $snapshotable)
-        {
-        }
+        public function __construct(protected string $snapshotable) {}
 
         public function toSnapshot()
         {

--- a/tests/Features/Expect/toThrow.php
+++ b/tests/Features/Expect/toThrow.php
@@ -2,9 +2,7 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
-class CustomException extends Exception
-{
-}
+class CustomException extends Exception {}
 
 test('passes', function () {
     expect(function () {
@@ -15,15 +13,13 @@ test('passes', function () {
     })->toThrow(Exception::class);
     expect(function () {
         throw new RuntimeException();
-    })->toThrow(function (RuntimeException $e) {
-    });
+    })->toThrow(function (RuntimeException $e) {});
     expect(function () {
         throw new RuntimeException('actual message');
     })->toThrow(function (Exception $e) {
         expect($e->getMessage())->toBe('actual message');
     });
-    expect(function () {
-    })->not->toThrow(Exception::class);
+    expect(function () {})->not->toThrow(Exception::class);
     expect(function () {
         throw new RuntimeException('actual message');
     })->toThrow('actual message');
@@ -35,22 +31,18 @@ test('passes', function () {
     })->toThrow(RuntimeException::class, 'actual message');
     expect(function () {
         throw new RuntimeException('actual message');
-    })->toThrow(function (RuntimeException $e) {
-    }, 'actual message');
+    })->toThrow(function (RuntimeException $e) {}, 'actual message');
     expect(function () {
         throw new CustomException('foo');
     })->toThrow(new CustomException('foo'));
 });
 
 test('failures 1', function () {
-    expect(function () {
-    })->toThrow(RuntimeException::class);
+    expect(function () {})->toThrow(RuntimeException::class);
 })->throws(ExpectationFailedException::class, 'Exception "'.RuntimeException::class.'" not thrown.');
 
 test('failures 2', function () {
-    expect(function () {
-    })->toThrow(function (RuntimeException $e) {
-    });
+    expect(function () {})->toThrow(function (RuntimeException $e) {});
 })->throws(ExpectationFailedException::class, 'Exception "'.RuntimeException::class.'" not thrown.');
 
 test('failures 3', function () {
@@ -77,8 +69,7 @@ test('failures 5', function () {
 })->throws(ExpectationFailedException::class, 'Failed asserting that \'actual message\' [ASCII](length: 14) contains "expected message" [ASCII](length: 16).');
 
 test('failures 6', function () {
-    expect(function () {
-    })->toThrow('actual message');
+    expect(function () {})->toThrow('actual message');
 })->throws(ExpectationFailedException::class, 'Exception with message "actual message" not thrown');
 
 test('failures 7', function () {
@@ -106,15 +97,11 @@ test('not failures', function () {
 })->throws(ExpectationFailedException::class);
 
 test('closure missing parameter', function () {
-    expect(function () {
-    })->toThrow(function () {
-    });
+    expect(function () {})->toThrow(function () {});
 })->throws(InvalidArgumentException::class, 'The given closure must have a single parameter type-hinted as the class string.');
 
 test('closure missing type-hint', function () {
-    expect(function () {
-    })->toThrow(function ($e) {
-    });
+    expect(function () {})->toThrow(function ($e) {});
 })->throws(InvalidArgumentException::class, 'The given closure\'s parameter must be type-hinted as the class string.');
 
 it('can handle a non-defined exception', function () {

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/InvokableClass.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
 
 class InvokableClass
 {
-    public function __invoke(): void
-    {
-
-    }
+    public function __invoke(): void {}
 }

--- a/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/ParentInvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsInvokable/ParentInvokableClass.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToBeInvokable\IsInvokable;
 
 class ParentInvokableClass
 {
-    public function __invoke(): void
-    {
-
-    }
+    public function __invoke(): void {}
 }

--- a/tests/Fixtures/Arch/ToBeInvokable/IsNotInvokable/IsNotInvokableClass.php
+++ b/tests/Fixtures/Arch/ToBeInvokable/IsNotInvokable/IsNotInvokableClass.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToBeInvokable\IsNotInvokable;
 
 class IsNotInvokableClass
 {
-    public function handle(): void
-    {
-
-    }
+    public function handle(): void {}
 }

--- a/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/Attributes/AsAttribute.php
@@ -7,6 +7,4 @@ namespace Tests\Fixtures\Arch\ToHaveAttribute\Attributes;
 use Attribute;
 
 #[Attribute()]
-class AsAttribute
-{
-}
+class AsAttribute {}

--- a/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/HaveAttribute/HaveAttributeClass.php
@@ -7,6 +7,4 @@ namespace Tests\Fixtures\Arch\ToHaveAttribute\HaveAttribute;
 use Tests\Fixtures\Arch\ToHaveAttribute\Attributes\AsAttribute;
 
 #[AsAttribute]
-class HaveAttributeClass
-{
-}
+class HaveAttributeClass {}

--- a/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
+++ b/tests/Fixtures/Arch/ToHaveAttribute/NotHaveAttribute/NotHaveAttributeClass.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHaveAttribute\NotHaveAttribute;
 
-class NotHaveAttributeClass
-{
-}
+class NotHaveAttributeClass {}

--- a/tests/Fixtures/Arch/ToHaveConstructor/HasConstructor/HasConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveConstructor/HasConstructor/HasConstructor.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveConstructor\HasConstructor;
 
 class HasConstructor
 {
-    public function __construct()
-    {
-
-    }
+    public function __construct() {}
 }

--- a/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveConstructor/HasNoConstructor/HasNoConstructor.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHaveConstructor\HasNoConstructor;
 
-class HasNoConstructor
-{
-}
+class HasNoConstructor {}

--- a/tests/Fixtures/Arch/ToHaveDestructor/HasDestructor/HasDestructor.php
+++ b/tests/Fixtures/Arch/ToHaveDestructor/HasDestructor/HasDestructor.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveDestructor\HasDestructor;
 
 class HasDestructor
 {
-    public function __destruct()
-    {
-
-    }
+    public function __destruct() {}
 }

--- a/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
+++ b/tests/Fixtures/Arch/ToHaveDestructor/HasNoDestructor/HasNoDestructor.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHaveDestructor\HasNoDestructor;
 
-class HasNoDestructor
-{
-}
+class HasNoDestructor {}

--- a/tests/Fixtures/Arch/ToHaveMethod/HasMethod/HasMethod.php
+++ b/tests/Fixtures/Arch/ToHaveMethod/HasMethod/HasMethod.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveMethod\HasMethod;
 
 class HasMethod
 {
-    public function foo(): void
-    {
-
-    }
+    public function foo(): void {}
 }

--- a/tests/Fixtures/Arch/ToHaveMethod/HasMethod/HasMethodTrait.php
+++ b/tests/Fixtures/Arch/ToHaveMethod/HasMethod/HasMethodTrait.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveMethod\HasMethod;
 
 trait HasMethodTrait
 {
-    public function foo(): void
-    {
-
-    }
+    public function foo(): void {}
 }

--- a/tests/Fixtures/Arch/ToHaveMethod/HasMethod/ParentHasMethodClass.php
+++ b/tests/Fixtures/Arch/ToHaveMethod/HasMethod/ParentHasMethodClass.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveMethod\HasMethod;
 
 class ParentHasMethodClass
 {
-    public function foo(): void
-    {
-
-    }
+    public function foo(): void {}
 }

--- a/tests/Fixtures/Arch/ToHaveMethod/HasNoMethod/HasNoMethodClass.php
+++ b/tests/Fixtures/Arch/ToHaveMethod/HasNoMethod/HasNoMethodClass.php
@@ -6,8 +6,5 @@ namespace Tests\Fixtures\Arch\ToHaveMethod\HasNoMethod;
 
 class HasNoMethodClass
 {
-    public function bar(): void
-    {
-
-    }
+    public function bar(): void {}
 }

--- a/tests/Fixtures/Arch/ToHavePrefix/HasNoPrefix/ClassWithout.php
+++ b/tests/Fixtures/Arch/ToHavePrefix/HasNoPrefix/ClassWithout.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHavePrefix\HasNoPrefix;
 
-class ClassWithout
-{
-}
+class ClassWithout {}

--- a/tests/Fixtures/Arch/ToHavePrefix/HasPrefix/PrefixClassWith.php
+++ b/tests/Fixtures/Arch/ToHavePrefix/HasPrefix/PrefixClassWith.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHavePrefix\HasPrefix;
 
-class PrefixClassWith
-{
-}
+class PrefixClassWith {}

--- a/tests/Fixtures/Arch/ToHaveSuffix/HasNoSuffix/ClassWithout.php
+++ b/tests/Fixtures/Arch/ToHaveSuffix/HasNoSuffix/ClassWithout.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHaveSuffix\HasNoSuffix;
 
-class ClassWithout
-{
-}
+class ClassWithout {}

--- a/tests/Fixtures/Arch/ToHaveSuffix/HasSuffix/ClassWithSuffix.php
+++ b/tests/Fixtures/Arch/ToHaveSuffix/HasSuffix/ClassWithSuffix.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\Arch\ToHaveSuffix\HasSuffix;
 
-class ClassWithSuffix
-{
-}
+class ClassWithSuffix {}

--- a/tests/Fixtures/Covers/CoversClass1.php
+++ b/tests/Fixtures/Covers/CoversClass1.php
@@ -4,7 +4,5 @@ namespace Tests\Fixtures\Covers;
 
 class CoversClass1
 {
-    public function foo()
-    {
-    }
+    public function foo() {}
 }

--- a/tests/Fixtures/Covers/CoversClass2.php
+++ b/tests/Fixtures/Covers/CoversClass2.php
@@ -2,6 +2,4 @@
 
 namespace Tests\Fixtures\Covers;
 
-class CoversClass2
-{
-}
+class CoversClass2 {}

--- a/tests/Fixtures/Covers/CoversClass3.php
+++ b/tests/Fixtures/Covers/CoversClass3.php
@@ -2,6 +2,4 @@
 
 namespace Tests\Fixtures\Covers;
 
-class CoversClass3
-{
-}
+class CoversClass3 {}

--- a/tests/Fixtures/Covers/CoversTrait.php
+++ b/tests/Fixtures/Covers/CoversTrait.php
@@ -2,6 +2,4 @@
 
 namespace Tests\Fixtures\Covers;
 
-trait CoversTrait
-{
-}
+trait CoversTrait {}

--- a/tests/Unit/Support/Container.php
+++ b/tests/Unit/Support/Container.php
@@ -50,21 +50,15 @@ it('cannot resolve a parameter without type', function () {
 
 class ClassWithDependency
 {
-    public function __construct(Container $container)
-    {
-    }
+    public function __construct(Container $container) {}
 }
 
 class ClassWithSubDependency
 {
-    public function __construct(ClassWithDependency $param)
-    {
-    }
+    public function __construct(ClassWithDependency $param) {}
 }
 
 class ClassWithoutTypeParameter
 {
-    public function __construct($param)
-    {
-    }
+    public function __construct($param) {}
 }

--- a/tests/Unit/Support/Reflection.php
+++ b/tests/Unit/Support/Reflection.php
@@ -3,8 +3,7 @@
 use Pest\Support\Reflection;
 
 it('gets file name from closure', function () {
-    $fileName = Reflection::getFileNameFromClosure(function () {
-    });
+    $fileName = Reflection::getFileNameFromClosure(function () {});
 
     expect($fileName)->toBe(__FILE__);
 });

--- a/tests/Unit/TestSuite.php
+++ b/tests/Unit/TestSuite.php
@@ -19,8 +19,7 @@ it('does not allow to add the same test description twice', function () {
 it('alerts users about tests with arguments but no input', function () {
     $testSuite = new TestSuite(getcwd(), 'tests');
 
-    $method = new TestCaseMethodFactory('foo', 'bar', function (int $arg) {
-    });
+    $method = new TestCaseMethodFactory('foo', 'bar', function (int $arg) {});
 
     $testSuite->tests->set($method);
 })->throws(


### PR DESCRIPTION
Now the filter informs the user if git complains about the ownership of the current repository folder. Before this change, Pest kept saying that git was not installed if the process failed.

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Using Docker on a GNU/Linux machine, Pest throws an error complaining about missing Git as a dependency although it is indeed installed. The real problem comes with the fact that the user used to mount the Docker volumes differs from the one assigned to the current user, so what is happening is that Git is complaining about dubious folder ownership.

This behaviour can be reproduced by performing a `chmod 100000:100000 .` (or whatever non-existing user and group ids) and trying to check the repository status with `git status`. Launching `pest --dirty` in this context will throw a `MissingDependency` exception which is not true.

This PR tries to check the exit code related to this Git error (`128`) and inform the user accordingly, saving lots of research about what is happening.

### Related:

https://github.com/pestphp/pest/issues/837