### PR TITLE
[2.x] Fix non-zero exitcodes when using CLI --fail-on-xxx config options

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -40,13 +40,14 @@ final class Result
      */
     public static function exitCode(Configuration $configuration, TestResult $result): int
     {
+        $returnCode = self::FAILURE_EXIT;
         if ($result->wasSuccessfulIgnoringPhpunitWarnings()
             && ! $result->hasTestTriggeredPhpunitWarningEvents()) {
-            return self::SUCCESS_EXIT;
+            $returnCode = self::SUCCESS_EXIT;
         }
 
         if ($configuration->failOnEmptyTestSuite() && ResultReflection::numberOfTests($result) === 0) {
-            return self::FAILURE_EXIT;
+            $returnCode = self::FAILURE_EXIT;
         }
 
         if ($result->wasSuccessfulIgnoringPhpunitWarnings()) {
@@ -69,12 +70,16 @@ final class Result
             if ($configuration->failOnSkipped() && $result->hasTestSkippedEvents()) {
                 $returnCode = self::FAILURE_EXIT;
             }
+
+            if ($configuration->failOnNotice() && $result->hasNotices()) {
+                $returnCode = self::FAILURE_EXIT;
+            }
         }
 
         if ($result->hasTestErroredEvents()) {
-            return self::EXCEPTION_EXIT;
+            $returnCode = self::EXCEPTION_EXIT;
         }
 
-        return self::FAILURE_EXIT;
+        return $returnCode;
     }
 }


### PR DESCRIPTION
### What:
- [x] Bug Fix

### Description:
This commit updates the Result.php class so that it returns the correct exit code when PHPunit is passed a configuration option like '--fail-on-warning'.

In addition, it adds a condition for '--fail-on-notice' which is supported based on the output from `pest --help`, though not listed in the online [Documentation](https://github.com/pestphp/docs/blob/master/cli-api-reference.md).

![Screenshot of pest --help output](https://github.com/pestphp/pest/assets/26375/7237cb79-a736-4347-b36b-e789b2dc625a)
