### PR TITLE
Include method name in toHaveMethod error message

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -515,7 +515,7 @@ final class Expectation
         return Targeted::make(
             $this,
             fn (ObjectDescription $object): bool => $object->reflectionClass->hasMethod($method),
-            'to have method',
+            sprintf("to have method '%s'", $method),
             FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
         );
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Currently when using `toHaveMethod` the method name is not included in the assertion error message. Take for example the test below:

```php
arch('all policies have required methods')
    ->expect('App\Policies')
    ->toHaveMethod('viewAny')
    ->toHaveMethod('view')
    ->toHaveMethod('create')
    ->toHaveMethod('update')
    ->toHaveMethod('delete')
    ->toHaveMethod('forceDelete')
    ->toHaveMethod('restore');
```

**Before**
```
Expecting 'app/Policies/UserPolicy.php' to have method.
```


**After**
```
Expecting 'app/Policies/UserPolicy.php' to have method 'viewAny'.
```
