### PR TITLE
Fix coverage result for 99.95%+

### DIFF
--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -130,7 +130,7 @@ final class Coverage implements AddsOutput, HandlesArguments
                 $this->output->writeln(sprintf(
                     "\n  <fg=white;bg=red;options=bold> FAIL </> Code coverage below expected <fg=white;options=bold> %s %%</>, currently <fg=red;options=bold> %s %%</>.",
                     number_format($this->coverageMin, 1),
-                    number_format($coverage, 1)
+                    number_format(floor($coverage * 10) / 10, 1)
                 ));
             }
 

--- a/src/Support/Coverage.php
+++ b/src/Support/Coverage.php
@@ -138,7 +138,7 @@ final class Coverage
 
         $totalCoverageAsString = $totalCoverage->asFloat() === 0.0
             ? '0.0'
-            : number_format($totalCoverage->asFloat(), 1, '.', '');
+            : number_format(floor($totalCoverage->asFloat() * 10) / 10, 1, '.', '');
 
         renderUsing($output);
         render(<<<HTML


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

The exact % of my coverage was 99.95670995671% but Pest was reporting this as 100%, which was then giving me this error in my CI/CD pipeline as I use the `min` flag set to 100. 

![Screenshot 2024-08-26 at 21 50 26](https://github.com/user-attachments/assets/4f74cad6-5609-43ea-aebb-7d1d033135e9)

This PR adds some additional logic to the output so it no longer rounds up so you get a more true value:

![Screenshot 2024-08-26 at 21 51 36](https://github.com/user-attachments/assets/9e9a5059-6cef-4f3d-916c-4b421c5bc33e)
