### PR TITLE
Exclude Global Scopes from the required "Model" suffix

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -37,7 +37,8 @@ final class Laravel extends AbstractPreset
 
         $this->expectations[] = expect('App\Models')
             ->classes()
-            ->toExtend('Illuminate\Database\Eloquent\Model');
+            ->toExtend('Illuminate\Database\Eloquent\Model')
+            ->ignoring('App\Models\Scopes');
 
         $this->expectations[] = expect('App\Models')
             ->classes()


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The Laravel preset doesn't take into account Global Scopes, which are created in the Models folder when running `php artisan make:scope`. Let's ignore them!