### PR TITLE
chore: Use new rector syntax

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,15 +2,11 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__.'/src',
-    ])
-    ->withRules([
-        InlineConstructorDefaultToPropertyRector::class,
     ])
     ->withSkip([
         __DIR__.'/src/Plugins/Parallel/Paratest/WrapperRunner.php',

--- a/rector.php
+++ b/rector.php
@@ -4,28 +4,22 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
         __DIR__.'/src',
-    ]);
-
-    $rectorConfig->rules([
+    ])
+    ->withRules([
         InlineConstructorDefaultToPropertyRector::class,
-    ]);
-
-    $rectorConfig->skip([
+    ])
+    ->withSkip([
         __DIR__.'/src/Plugins/Parallel/Paratest/WrapperRunner.php',
-    ]);
-
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_81,
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::TYPE_DECLARATION,
-        SetList::PRIVATIZATION,
-    ]);
-};
+    ])
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        privatization: true,
+        earlyReturn: true,
+    )
+    ->withPhpSets();


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This will use the newer Rector syntax, as well as removing the `InlineConstructorDefaultToPropertyRector` rule since it's already a part of the `codeQuality` ruleset.
