### PR TITLE
feat: [3.x] add `uses` counterpart to `covers`

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -488,15 +488,18 @@ final class TestCall
     public function covers(string ...$classesOrFunctions): self
     {
         foreach ($classesOrFunctions as $classOrFunction) {
-            $isClass = class_exists($classOrFunction) || trait_exists($classOrFunction);
+            $isClass = class_exists($classOrFunction);
+            $isTrait = trait_exists($classOrFunction);
             $isMethod = function_exists($classOrFunction);
 
-            if (! $isClass && ! $isMethod) {
+            if (! $isClass && ! $isTrait && ! $isMethod) {
                 throw new InvalidArgumentException(sprintf('No class or method named "%s" has been found.', $classOrFunction));
             }
 
             if ($isClass) {
                 $this->coversClass($classOrFunction);
+            } elseif ($isTrait) {
+                $this->coversTrait($classOrFunction);
             } else {
                 $this->coversFunction($classOrFunction);
             }
@@ -514,6 +517,21 @@ final class TestCall
             $this->testCaseFactoryAttributes[] = new Attribute(
                 \PHPUnit\Framework\Attributes\CoversClass::class,
                 [$class],
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the covered traits.
+     */
+    public function coversTrait(string ...$traits): self
+    {
+        foreach ($traits as $trait) {
+            $this->testCaseFactoryAttributes[] = new Attribute(
+                \PHPUnit\Framework\Attributes\CoversTrait::class,
+                [$trait],
             );
         }
 
@@ -544,6 +562,77 @@ final class TestCall
             \PHPUnit\Framework\Attributes\CoversNothing::class,
             [],
         );
+
+        return $this;
+    }
+
+    /**
+     * Sets the used classes or methods.
+     */
+    public function uses(string ...$classesOrFunctions): self
+    {
+        foreach ($classesOrFunctions as $classOrFunction) {
+            $isClass = class_exists($classOrFunction);
+            $isTrait = trait_exists($classOrFunction);
+            $isMethod = function_exists($classOrFunction);
+
+            if (! $isClass && ! $isTrait && ! $isMethod) {
+                throw new InvalidArgumentException(sprintf('No class or method named "%s" has been found.', $classOrFunction));
+            }
+
+            if ($isClass) {
+                $this->usesClass($classOrFunction);
+            } elseif ($isTrait) {
+                $this->usesTrait($classOrFunction);
+            } else {
+                $this->usesFunction($classOrFunction);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the used classes.
+     */
+    public function usesClass(string ...$classes): self
+    {
+        foreach ($classes as $class) {
+            $this->testCaseFactoryAttributes[] = new Attribute(
+                \PHPUnit\Framework\Attributes\UsesClass::class,
+                [$class],
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the uses traits.
+     */
+    public function usesTrait(string ...$traits): self
+    {
+        foreach ($traits as $trait) {
+            $this->testCaseFactoryAttributes[] = new Attribute(
+                \PHPUnit\Framework\Attributes\UsesTrait::class,
+                [$trait],
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the uses functions.
+     */
+    public function usesFunction(string ...$functions): self
+    {
+        foreach ($functions as $function) {
+            $this->testCaseFactoryAttributes[] = new Attribute(
+                \PHPUnit\Framework\Attributes\UsesFunction::class,
+                [$function],
+            );
+        }
 
         return $this;
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -65,11 +65,11 @@
 
    PASS  Tests\Features\Covers
   ✓ it uses the correct PHPUnit attribute for class
-  ✓ it uses the correct PHPUnit attribute for function
-  ✓ it guesses if the given argument is a class or function
   ✓ it uses the correct PHPUnit attribute for trait
+  ✓ it uses the correct PHPUnit attribute for function
+  ✓ it guesses if the given argument is a class, trait, or function
   ✓ it uses the correct PHPUnit attribute for covers nothing
-  ✓ it throws exception if no class nor method has been found
+  ✓ it throws exception if no class, trait, nor method has been found
 
    PASS  Tests\Features\DatasetsTests - 1 todo
   ✓ it throws exception if dataset does not exist
@@ -1273,6 +1273,13 @@
   ↓ it may have an associated note
   // a note
 
+   PASS  Tests\Features\Uses
+  ✓ it uses the correct PHPUnit attribute for class
+  ✓ it uses the correct PHPUnit attribute for trait
+  ✓ it uses the correct PHPUnit attribute for function
+  ✓ it guesses if the given argument is a class, trait, or function
+  ✓ it throws exception if no class, trait, nor method has been found
+
    WARN  Tests\Features\Warnings
   ! warning → Undefined property: P\Tests\Features\Warnings::$fooqwdfwqdfqw
   ! user warning → This is a warning description
@@ -1559,4 +1566,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 9 incomplete, 2 notices, 17 todos, 24 skipped, 1079 passed (2613 assertions)
+  Tests:    2 deprecated, 4 warnings, 9 incomplete, 2 notices, 17 todos, 24 skipped, 1084 passed (2629 assertions)

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -4,9 +4,11 @@ use Pest\PendingCalls\TestCall;
 use Pest\TestSuite;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use Tests\Fixtures\Covers\CoversClass1;
 use Tests\Fixtures\Covers\CoversClass3;
-use Tests\Fixtures\Covers\CoversTrait;
+use Tests\Fixtures\Covers\CoversTrait1;
 
 $runCounter = 0;
 
@@ -15,43 +17,46 @@ function testCoversFunction() {}
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes[1]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[1]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[1]->getName())->toBe(CoversClass::class);
+    expect($attributes[1]->getArguments()[0])->toBe(CoversClass1::class);
 })->coversClass(CoversClass1::class);
-
-it('uses the correct PHPUnit attribute for function', function () {
-    $attributes = (new ReflectionClass($this))->getAttributes();
-
-    expect($attributes[2]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
-    expect($attributes[2]->getArguments()[0])->toBe('testCoversFunction');
-})->coversFunction('testCoversFunction');
-
-it('guesses if the given argument is a class or function', function () {
-    $attributes = (new ReflectionClass($this))->getAttributes();
-
-    expect($attributes[3]->getName())->toBe(CoversClass::class);
-    expect($attributes[3]->getArguments()[0])->toBe(CoversClass3::class);
-
-    expect($attributes[4]->getName())->toBe(CoversFunction::class);
-    expect($attributes[4]->getArguments()[0])->toBe('testCoversFunction');
-})->covers(CoversClass3::class, 'testCoversFunction');
 
 it('uses the correct PHPUnit attribute for trait', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes[5]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[5]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversTrait');
-})->coversClass(CoversTrait::class);
+    expect($attributes[2]->getName())->toBe(CoversTrait::class);
+    expect($attributes[2]->getArguments()[0])->toBe(CoversTrait1::class);
+})->coversTrait(CoversTrait1::class);
+
+it('uses the correct PHPUnit attribute for function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[3]->getName())->toBe(CoversFunction::class);
+    expect($attributes[3]->getArguments()[0])->toBe('testCoversFunction');
+})->coversFunction('testCoversFunction');
+
+it('guesses if the given argument is a class, trait, or function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[4]->getName())->toBe(CoversClass::class);
+    expect($attributes[4]->getArguments()[0])->toBe(CoversClass3::class);
+
+    expect($attributes[5]->getName())->toBe(CoversTrait::class);
+    expect($attributes[5]->getArguments()[0])->toBe(CoversTrait1::class);
+
+    expect($attributes[6]->getName())->toBe(CoversFunction::class);
+    expect($attributes[6]->getArguments()[0])->toBe('testCoversFunction');
+})->covers(CoversClass3::class, CoversTrait1::class, 'testCoversFunction');
 
 it('uses the correct PHPUnit attribute for covers nothing', function () {
     $attributes = (new ReflectionMethod($this, $this->name()))->getAttributes();
 
-    expect($attributes[2]->getName())->toBe('PHPUnit\Framework\Attributes\CoversNothing');
+    expect($attributes[2]->getName())->toBe(CoversNothing::class);
     expect($attributes[2]->getArguments())->toHaveCount(0);
 })->coversNothing();
 
-it('throws exception if no class nor method has been found', function () {
-    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'description', fn () => 'closure');
+it('throws exception if no class, trait, nor method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'covers-filename', 'covers-description', fn () => 'closure');
 
     $testCall->covers('fakeName');
 })->throws(InvalidArgumentException::class, 'No class or method named "fakeName" has been found.');

--- a/tests/Features/Uses.php
+++ b/tests/Features/Uses.php
@@ -1,0 +1,54 @@
+<?php
+
+use Pest\PendingCalls\TestCall;
+use Pest\TestSuite;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\UsesFunction;
+use PHPUnit\Framework\Attributes\UsesTrait;
+use Tests\Fixtures\Covers\CoversClass1;
+use Tests\Fixtures\Covers\CoversClass3;
+use Tests\Fixtures\Covers\CoversTrait1;
+
+$runCounter = 0;
+
+function testUsesFunction() {}
+
+it('uses the correct PHPUnit attribute for class', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[1]->getName())->toBe(UsesClass::class);
+    expect($attributes[1]->getArguments()[0])->toBe(CoversClass1::class);
+})->usesClass(CoversClass1::class);
+
+it('uses the correct PHPUnit attribute for trait', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[2]->getName())->toBe(UsesTrait::class);
+    expect($attributes[2]->getArguments()[0])->toBe(CoversTrait1::class);
+})->usesTrait(CoversTrait1::class);
+
+it('uses the correct PHPUnit attribute for function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[3]->getName())->toBe(UsesFunction::class);
+    expect($attributes[3]->getArguments()[0])->toBe('testUsesFunction');
+})->usesFunction('testUsesFunction');
+
+it('guesses if the given argument is a class, trait, or function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[4]->getName())->toBe(UsesClass::class);
+    expect($attributes[4]->getArguments()[0])->toBe(CoversClass3::class);
+
+    expect($attributes[5]->getName())->toBe(UsesTrait::class);
+    expect($attributes[5]->getArguments()[0])->toBe(CoversTrait1::class);
+
+    expect($attributes[6]->getName())->toBe(UsesFunction::class);
+    expect($attributes[6]->getArguments()[0])->toBe('testUsesFunction');
+})->uses(CoversClass3::class, CoversTrait1::class, 'testUsesFunction');
+
+it('throws exception if no class, trait, nor method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'uses-filename', 'uses-description', fn () => 'closure');
+
+    $testCall->uses('fakeName');
+})->throws(InvalidArgumentException::class, 'No class or method named "fakeName" has been found.');

--- a/tests/Fixtures/Covers/CoversTrait1.php
+++ b/tests/Fixtures/Covers/CoversTrait1.php
@@ -2,4 +2,4 @@
 
 namespace Tests\Fixtures\Covers;
 
-trait CoversTrait {}
+trait CoversTrait1 {}

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1069 passed (2585 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1074 passed (2601 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

Right now, pest supports `covers` for classes, functions, and "nothing" to include sections of code to track coverage for. This adds the `uses` counterpart, which exclude sections of code. (see https://docs.phpunit.de/en/11.3/code-coverage.html#targeting-units-of-code). This would be especially useful for `--mutate` allowing you to disable coverage (and therefore mutations) for specific parts of code on a per-test basis. While adding this, I saw that phpunit added a `coversTrait` and `usesTrait` in version 11.2, so I also included that in this MR.

Locally I ran `composer lint`, `composer update:snapshots`, and `composer test`. Almost everything succeeded but I had trouble with the `tests/Visual/Success.php` test. It also failed on the 3.x branch, so I'm hoping it's not related to my changes.

Thanks!