### PR TITLE
Update Init.php to change how Laravel is detected

### DIFF
--- a/src/Plugins/Init.php
+++ b/src/Plugins/Init.php
@@ -119,6 +119,6 @@ final class Init implements HandlesArguments
      */
     private function isLaravelInstalled(): bool
     {
-        return InstalledVersions::isInstalled('laravel/laravel');
+        return InstalledVersions::isInstalled('laravel/laravel') || InstalledVersions::isInstalled('laravel/framework');
     }
 }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Running `vendor/bin/pest --init` currently checks for Laravel by looking for `laravel/laravel` however a new Laravel 11 install does not include that.

As a result `isLaravelInstalled()` incorrectly returns false

That means it does not add the Laravel stub and so defaults to using phpunit for the base case in TestCase.php. Which then causes an undefined error when running any Feature test, including the example one.

(I'm not sure if this is the only file that does this check however manually changing this file and then running `vendor/bin/pest --init` appears to fix it for me.)

### Related:

https://github.com/pestphp/pest/issues/1192
