### PR TITLE
Add `dump` to Laravel preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -141,6 +141,7 @@ final class Laravel extends AbstractPreset
         $this->expectations[] = expect([
             'dd',
             'ddd',
+            'dump',
             'env',
             'exit',
             'ray',


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR adds `dump` to the list of methods **not** to be allowed in Laravel globals.
