### PR TITLE
feat: [3.x] add `doesntCover`

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -243,3 +243,19 @@ if (! function_exists('covers')) {
         }
     }
 }
+
+if (! function_exists('doesntCover')) {
+    /**
+     * Specifies which classes, or functions, a test method doesnt covers.
+     *
+     * @param  array<int, string>|string  $classesOrFunctions
+     */
+    function doesntCover(array|string ...$classesOrFunctions): void
+    {
+        $filename = Backtrace::file();
+
+        $beforeEachCall = (new BeforeEachCall(TestSuite::getInstance(), $filename));
+
+        $beforeEachCall->doesntCover(...$classesOrFunctions);
+    }
+}

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -65,11 +65,11 @@
 
    PASS  Tests\Features\Covers
   ✓ it uses the correct PHPUnit attribute for class
-  ✓ it uses the correct PHPUnit attribute for function
-  ✓ it guesses if the given argument is a class or function
   ✓ it uses the correct PHPUnit attribute for trait
+  ✓ it uses the correct PHPUnit attribute for function
+  ✓ it guesses if the given argument is a class, trait, or function
   ✓ it uses the correct PHPUnit attribute for covers nothing
-  ✓ it throws exception if no class nor method has been found
+  ✓ it throws exception if no class, trait, nor method has been found
 
    PASS  Tests\Features\DatasetsTests - 1 todo
   ✓ it throws exception if dataset does not exist
@@ -223,6 +223,13 @@
   ✓ a "describe" group of tests → get 'foo'
   ✓ a "describe" group of tests → get 'foo' → get 'bar' → expect true → toBeTrue
   ✓ a "describe" group of tests → get 'foo' → expect true → toBeTrue
+
+   PASS  Tests\Features\DoesntCover
+  ✓ it uses the correct PHPUnit attribute for class
+  ✓ it uses the correct PHPUnit attribute for trait
+  ✓ it uses the correct PHPUnit attribute for function
+  ✓ it guesses if the given argument is a class, trait, or function
+  ✓ it throws exception if no class, trait, nor method has been found
 
    PASS  Tests\Features\Done
   ✓ it may have an associated assignee [@nunomaduro]
@@ -1573,4 +1580,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1088 passed (2615 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1093 passed (2631 assertions)

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -4,9 +4,11 @@ use Pest\PendingCalls\TestCall;
 use Pest\TestSuite;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use Tests\Fixtures\Covers\CoversClass1;
 use Tests\Fixtures\Covers\CoversClass3;
-use Tests\Fixtures\Covers\CoversTrait;
+use Tests\Fixtures\Covers\CoversTrait1;
 
 $runCounter = 0;
 
@@ -17,43 +19,46 @@ covers([CoversClass1::class]);
 it('uses the correct PHPUnit attribute for class', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes[1]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
-    expect($attributes[1]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[1]->getName())->toBe(CoversClass::class);
+    expect($attributes[1]->getArguments()[0])->toBe(CoversClass1::class);
 });
-
-it('uses the correct PHPUnit attribute for function', function () {
-    $attributes = (new ReflectionClass($this))->getAttributes();
-
-    expect($attributes[3]->getName())->toBe('PHPUnit\Framework\Attributes\CoversFunction');
-    expect($attributes[3]->getArguments()[0])->toBe('testCoversFunction');
-})->coversFunction('testCoversFunction');
-
-it('guesses if the given argument is a class or function', function () {
-    $attributes = (new ReflectionClass($this))->getAttributes();
-
-    expect($attributes[5]->getName())->toBe(CoversClass::class);
-    expect($attributes[5]->getArguments()[0])->toBe(CoversClass3::class);
-
-    expect($attributes[6]->getName())->toBe(CoversFunction::class);
-    expect($attributes[6]->getArguments()[0])->toBe('testCoversFunction');
-})->covers(CoversClass3::class, 'testCoversFunction');
 
 it('uses the correct PHPUnit attribute for trait', function () {
     $attributes = (new ReflectionClass($this))->getAttributes();
 
-    expect($attributes[8]->getName())->toBe('PHPUnit\Framework\Attributes\CoversTrait');
-    expect($attributes[8]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversTrait');
-})->coversTrait(CoversTrait::class);
+    expect($attributes[3]->getName())->toBe(CoversTrait::class);
+    expect($attributes[3]->getArguments()[0])->toBe(CoversTrait1::class);
+})->coversTrait(CoversTrait1::class);
+
+it('uses the correct PHPUnit attribute for function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[5]->getName())->toBe(CoversFunction::class);
+    expect($attributes[5]->getArguments()[0])->toBe('testCoversFunction');
+})->coversFunction('testCoversFunction');
+
+it('guesses if the given argument is a class, trait, or function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[7]->getName())->toBe(CoversClass::class);
+    expect($attributes[7]->getArguments()[0])->toBe(CoversClass3::class);
+
+    expect($attributes[8]->getName())->toBe(CoversTrait::class);
+    expect($attributes[8]->getArguments()[0])->toBe(CoversTrait1::class);
+
+    expect($attributes[9]->getName())->toBe(CoversFunction::class);
+    expect($attributes[9]->getArguments()[0])->toBe('testCoversFunction');
+})->covers(CoversClass3::class, CoversTrait1::class, 'testCoversFunction');
 
 it('uses the correct PHPUnit attribute for covers nothing', function () {
     $attributes = (new ReflectionMethod($this, $this->name()))->getAttributes();
 
-    expect($attributes[3]->getName())->toBe('PHPUnit\Framework\Attributes\CoversNothing');
+    expect($attributes[3]->getName())->toBe(CoversNothing::class);
     expect($attributes[3]->getArguments())->toHaveCount(0);
 })->coversNothing();
 
-it('throws exception if no class nor method has been found', function () {
-    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'description', fn () => 'closure');
+it('throws exception if no class, trait, nor method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'covers-filename', 'covers-description', fn () => 'closure');
 
     $testCall->covers('fakeName');
 })->throws(InvalidArgumentException::class, 'No class, trait or method named "fakeName" has been found.');

--- a/tests/Features/DoesntCover.php
+++ b/tests/Features/DoesntCover.php
@@ -1,0 +1,56 @@
+<?php
+
+use Pest\PendingCalls\TestCall;
+use Pest\TestSuite;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\UsesFunction;
+use PHPUnit\Framework\Attributes\UsesTrait;
+use Tests\Fixtures\Covers\CoversClass1;
+use Tests\Fixtures\Covers\CoversClass3;
+use Tests\Fixtures\Covers\CoversTrait1;
+
+$runCounter = 0;
+
+function testDoesntCoverFunction() {}
+
+doesntCover([CoversClass1::class]);
+
+it('uses the correct PHPUnit attribute for class', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[1]->getName())->toBe(UsesClass::class);
+    expect($attributes[1]->getArguments()[0])->toBe(CoversClass1::class);
+});
+
+it('uses the correct PHPUnit attribute for trait', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[3]->getName())->toBe(UsesTrait::class);
+    expect($attributes[3]->getArguments()[0])->toBe(CoversTrait1::class);
+})->doesntCoverTrait(CoversTrait1::class);
+
+it('uses the correct PHPUnit attribute for function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[5]->getName())->toBe(UsesFunction::class);
+    expect($attributes[5]->getArguments()[0])->toBe('testDoesntCoverFunction');
+})->doesntCoverFunction('testDoesntCoverFunction');
+
+it('guesses if the given argument is a class, trait, or function', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[7]->getName())->toBe(UsesClass::class);
+    expect($attributes[7]->getArguments()[0])->toBe(CoversClass3::class);
+
+    expect($attributes[8]->getName())->toBe(UsesTrait::class);
+    expect($attributes[8]->getArguments()[0])->toBe(CoversTrait1::class);
+
+    expect($attributes[9]->getName())->toBe(UsesFunction::class);
+    expect($attributes[9]->getArguments()[0])->toBe('testDoesntCoverFunction');
+})->doesntCover(CoversClass3::class, CoversTrait1::class, 'testDoesntCoverFunction');
+
+it('throws exception if no class, trait, nor method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'uses-filename', 'uses-description', fn () => 'closure');
+
+    $testCall->doesntCover('fakeName');
+})->throws(InvalidArgumentException::class, 'No class, trait or method named "fakeName" has been found.');

--- a/tests/Fixtures/Covers/CoversTrait1.php
+++ b/tests/Fixtures/Covers/CoversTrait1.php
@@ -2,4 +2,4 @@
 
 namespace Tests\Fixtures\Covers;
 
-trait CoversTrait {}
+trait CoversTrait1 {}

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1078 passed (2591 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1083 passed (2607 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

A rebase of https://github.com/pestphp/pest/pull/1212

Right now, pest supports `covers` for classes, traits, functions, and "nothing" to include sections of code to track coverage for. This adds the `doesntCover`. This was originally called `uses` in phpunit (see https://docs.phpunit.de/en/11.3/code-coverage.html#targeting-units-of-code), but that conflicts with pest's `uses()`, so I renamed it, but open to suggestions. This would be useful for `--strict-coverage`. Originally I thought this would be useful for `--mutate`, thinking that it would disable coverage for that test for that code, however, I misunderstood the feature. It doesn't disable coverage, but rather just marks a test as risky when something is "covered" that isn't "used". Not what I wanted, but would be helpful for `--strict-coverage`

Locally I ran `composer lint`, `composer update:snapshots`, and `composer test`. They all succeeded :)

Thanks!

Edit: Closing because "doesntCover" isn't the right wording. It's really "CoversUnintentionallyAndThatsOkay", but that's obviously not a good name for it. I'll think more about this before requesting to repoen