### PR TITLE
Fixes parallel mutation testing when using Laravel Herd

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -158,7 +158,7 @@ final class WrapperRunner implements RunnerInterface
     /**
      * Handles Laravel Herd's debug and coverage modes.
      *
-     * @param array<string> $parameters
+     * @param  array<string>  $parameters
      * @return array<string>
      */
     private function handleLaravelHerd(array $parameters): array

--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -122,6 +122,8 @@ final class WrapperRunner implements RunnerInterface
             $parameters = array_merge($parameters, $options->passthruPhp);
         }
 
+        $parameters = $this->handleLaravelHerd($parameters);
+
         $parameters[] = $wrapper;
 
         $this->parameters = $parameters;
@@ -151,6 +153,21 @@ final class WrapperRunner implements RunnerInterface
         $this->waitForAllToFinish();
 
         return $this->complete($result);
+    }
+
+    /**
+     * Handles Laravel Herd's debug and coverage modes.
+     *
+     * @param array<string> $parameters
+     * @return array<string>
+     */
+    private function handleLaravelHerd(array $parameters): array
+    {
+        if (isset($_ENV['HERD_DEBUG_INI'])) {
+            return array_merge($parameters, ['-c', $_ENV['HERD_DEBUG_INI']]);
+        }
+
+        return $parameters;
     }
 
     private function startWorkers(): void


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

I discovered an issue where mutation testing in parallel doesn't work when combined with Laravel Herd Pro. This is because the parent process is running `herd coverage`, but the child processes spawn bare `php` instances without access to a coverage driver.

A similar issue would be encountered for debugging in parallel using Herd Pro I think.

Anyhow, after a long day of debugging and chatting with @mpociot and @gehrisandro, I've added a little check that will essentially load in the debug.ini file from Herd if needed.
