### PR TITLE
fix: unify the `locationHint` prefix and prettify both `locationHint` and `name` parameters for testing with datasets

### DIFF
--- a/src/Logging/TeamCity/ServiceMessage.php
+++ b/src/Logging/TeamCity/ServiceMessage.php
@@ -38,7 +38,7 @@ final class ServiceMessage
     {
         return new self('testSuiteStarted', [
             'name' => $name,
-            'locationHint' => $location === null ? null : "file://$location",
+            'locationHint' => $location === null ? null : "pest_qn://$location",
         ]);
     }
 

--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -1,4 +1,4 @@
-##teamcity[testSuiteStarted name='Tests/tests/Failure' locationHint='file://tests/.tests/Failure.php' flowId='1234']
+##teamcity[testSuiteStarted name='Tests/tests/Failure' locationHint='pest_qn://tests/.tests/Failure.php' flowId='1234']
 ##teamcity[testCount count='8' flowId='1234']
 ##teamcity[testStarted name='it can fail with comparison' locationHint='pest_qn://tests/.tests/Failure.php::it can fail with comparison' flowId='1234']
 ##teamcity[testFailed name='it can fail with comparison' message='Failed asserting that true matches expected false.' details='at tests/.tests/Failure.php:6' type='comparisonFailure' actual='true' expected='false' flowId='1234']

--- a/tests/.snapshots/SuccessOnly.php.inc
+++ b/tests/.snapshots/SuccessOnly.php.inc
@@ -1,11 +1,15 @@
-##teamcity[testSuiteStarted name='Tests/tests/SuccessOnly' locationHint='file://tests/.tests/SuccessOnly.php' flowId='1234']
-##teamcity[testCount count='2' flowId='1234']
+##teamcity[testSuiteStarted name='Tests/tests/SuccessOnly' locationHint='pest_qn://tests/.tests/SuccessOnly.php' flowId='1234']
+##teamcity[testCount count='3' flowId='1234']
 ##teamcity[testStarted name='it can pass with comparison' locationHint='pest_qn://tests/.tests/SuccessOnly.php::it can pass with comparison' flowId='1234']
 ##teamcity[testFinished name='it can pass with comparison' duration='100000' flowId='1234']
 ##teamcity[testStarted name='can also pass' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can also pass' flowId='1234']
 ##teamcity[testFinished name='can also pass' duration='100000' flowId='1234']
+##teamcity[testSuiteStarted name='can pass with dataset' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can pass with dataset' flowId='1234']
+##teamcity[testStarted name='can pass with dataset with data set "(true)"' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can pass with dataset with data set "(true)"' flowId='1234']
+##teamcity[testFinished name='can pass with dataset with data set "(true)"' duration='100000' flowId='1234']
+##teamcity[testSuiteFinished name='can pass with dataset' flowId='1234']
 ##teamcity[testSuiteFinished name='Tests/tests/SuccessOnly' flowId='1234']
 
-  [90mTests:[39m    [32;1m2 passed[39;22m[90m (2 assertions)[39m
+  [90mTests:[39m    [32;1m3 passed[39;22m[90m (3 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m
 

--- a/tests/.tests/SuccessOnly.php
+++ b/tests/.tests/SuccessOnly.php
@@ -9,3 +9,7 @@ it('can pass with comparison', function () {
 test('can also pass', function () {
     expect("string")->toBeString();
 });
+
+test('can pass with dataset', function ($value) {
+    expect($value)->toEqual(true);
+})->with([true]);

--- a/tests/Visual/JUnit.php
+++ b/tests/Visual/JUnit.php
@@ -36,8 +36,8 @@ test('junit output', function () use ($normalizedPath, $run) {
     expect($result['testsuite']['@attributes'])
         ->name->toBe('Tests\tests\SuccessOnly')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
-        ->tests->toBe('2')
-        ->assertions->toBe('2')
+        ->tests->toBe('3')
+        ->assertions->toBe('3')
         ->errors->toBe('0')
         ->failures->toBe('0')
         ->skipped->toBe('0');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

- Unify the `locationHint` prefix for all TeamCity events in the Pest execution output (`pest_qn`)
- Clarify the `locationHint` for tests with datasets (the exact method instead of the whole file)
- Prettify the `name` for test with dataset (the real method name instead of "__pest_evaluable_method_name")

### Related:

#1236

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
