### PR TITLE
feat: Add support for covers class method annotation

### DIFF
--- a/src/Factories/Attribute.php
+++ b/src/Factories/Attribute.php
@@ -10,7 +10,7 @@ namespace Pest\Factories;
 final class Attribute
 {
     /**
-     * @param  iterable<int, string>  $arguments
+     * @param  iterable<int|class-string, string>  $arguments
      */
     public function __construct(public string $name, public iterable $arguments)
     {

--- a/tests/Features/Covers.php
+++ b/tests/Features/Covers.php
@@ -5,6 +5,7 @@ use Pest\TestSuite;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use Tests\Fixtures\Covers\CoversClass1;
+use Tests\Fixtures\Covers\CoversClass2;
 use Tests\Fixtures\Covers\CoversClass3;
 use Tests\Fixtures\Covers\CoversTrait;
 
@@ -53,7 +54,51 @@ it('uses the correct PHPUnit attribute for covers nothing', function () {
 })->coversNothing();
 
 it('throws exception if no class nor method has been found', function () {
-    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'description', fn () => 'closure');
+    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'no class nor method has been found', fn () => 'closure');
 
     $testCall->covers('fakeName');
-})->throws(InvalidArgumentException::class, 'No class, trait or method named "fakeName" has been found.');
+})->throws(InvalidArgumentException::class, 'No class, method, trait or function named "fakeName" has been found.');
+
+it('uses the correct PHPUnit attribute for covers with single class method as array', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[12]->getName())->toBe('PHPUnit\Framework\Attributes\CoversMethod');
+    expect($attributes[12]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[12]->getArguments()[1])->toBe('foo');
+})->covers([[CoversClass1::class, 'foo']]);
+
+it('uses the correct PHPUnit attribute for covers with single class method', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[14]->getName())->toBe('PHPUnit\Framework\Attributes\CoversMethod');
+    expect($attributes[14]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[14]->getArguments()[1])->toBe('foo');
+})->covers([CoversClass1::class, 'foo']);
+
+it('uses the correct PHPUnit attribute for mixed covers with class method', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[16]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[16]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass2');
+
+    expect($attributes[17]->getName())->toBe('PHPUnit\Framework\Attributes\CoversMethod');
+    expect($attributes[17]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[17]->getArguments()[1])->toBe('foo');
+})->covers(CoversClass2::class, [CoversClass1::class, 'foo']);
+
+it('uses the correct PHPUnit attribute for mixed covers with class method as array', function () {
+    $attributes = (new ReflectionClass($this))->getAttributes();
+
+    expect($attributes[19]->getName())->toBe('PHPUnit\Framework\Attributes\CoversClass');
+    expect($attributes[19]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass2');
+
+    expect($attributes[20]->getName())->toBe('PHPUnit\Framework\Attributes\CoversMethod');
+    expect($attributes[20]->getArguments()[0])->toBe('Tests\Fixtures\Covers\CoversClass1');
+    expect($attributes[20]->getArguments()[1])->toBe('foo');
+})->covers([CoversClass2::class, [CoversClass1::class, 'foo']]);
+
+it('throws exception if no class method has been found', function () {
+    $testCall = new TestCall(TestSuite::getInstance(), 'filename', 'no class method has been found', fn () => 'closure');
+
+    $testCall->covers([['fakeClass', 'fakeMethod']]);
+})->throws(InvalidArgumentException::class, 'No class, method, trait or function named "fakeClass::fakeMethod" has been found.');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds support for the CoversMethod annotation. As a bonus it fixes these two ignored uncovered types:

```
  src/PendingCalls/TestCall.php ...... pa521, pa521 100%
```

#### Usage

For single class method alone:

```php
covers([ClassName::class, 'method']);
// or
covers([
     [ClassName::class, 'method']
]);
```

For multiple values:

```php
covers(ClassName::class, [OtherClassName::class, 'method']);
// or
covers([
    ClassName::class, 
    [OtherClassName::class, 'method']
]);
```





### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
