### PR TITLE
feat: Add `references` method for two-way test-source linking

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -49,6 +49,13 @@ final class TestCall
     private readonly bool $descriptionLess;
 
     /**
+     * This property is not actually used in the codebase, it's only here to make Rector happy.
+     *
+     * @var string|array<class-string|string>
+     */
+    public array|string $references;
+
+    /**
      * Creates a new Pending Call.
      */
     public function __construct(
@@ -611,6 +618,21 @@ final class TestCall
             \PHPUnit\Framework\Attributes\CoversNothing::class,
             [],
         );
+
+        return $this;
+    }
+
+    /**
+     * Adds a reference to the tested method or class.
+     * This helps to link test cases to the source code
+     * for easier navigation during development.
+     *
+     * @param  string|array<class-string|string>  $classes
+     */
+    public function reference(string|array ...$classes): self
+    {
+        // For rector
+        $this->references = $classes; // @phpstan-ignore-line
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -51,7 +51,7 @@ final class TestCall
     /**
      * This property is not actually used in the codebase, it's only here to make Rector happy.
      *
-     * @var array<class-string|string>
+     * @var array<int|string, class-string|array<class-string|string>>
      */
     public array $references;
 
@@ -623,11 +623,10 @@ final class TestCall
     }
 
     /**
-     * Adds a reference to the tested method or class.
-     * This helps to link test cases to the source code
-     * for easier navigation during development.
+     * Adds a reference to the tested method or class. This helps to link test
+     * cases to the source code for easier navigation.
      *
-     * @param  string|array<class-string|string>  $classes
+     * @param  array<class-string|string>|class-string  ...$classes
      */
     public function reference(string|array ...$classes): self
     {

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -51,9 +51,9 @@ final class TestCall
     /**
      * This property is not actually used in the codebase, it's only here to make Rector happy.
      *
-     * @var string|array<class-string|string>
+     * @var array<class-string|string>
      */
-    public array|string $references;
+    public array $references;
 
     /**
      * Creates a new Pending Call.
@@ -632,7 +632,7 @@ final class TestCall
     public function reference(string|array ...$classes): self
     {
         // For rector
-        $this->references = $classes; // @phpstan-ignore-line
+        $this->references = $classes;
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -49,13 +49,6 @@ final class TestCall
     private readonly bool $descriptionLess;
 
     /**
-     * This property is not actually used in the codebase, it's only here to make Rector happy.
-     *
-     * @var array<int|string, class-string|array<class-string|string>>
-     */
-    public array $references;
-
-    /**
      * Creates a new Pending Call.
      */
     public function __construct(

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -628,7 +628,7 @@ final class TestCall
      *
      * @param  array<class-string|string>|class-string  ...$classes
      */
-    public function reference(string|array ...$classes): self
+    public function references(string|array ...$classes): self
     {
         // For rector
         $this->references = $classes;

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -630,8 +630,7 @@ final class TestCall
      */
     public function references(string|array ...$classes): self
     {
-        // For rector
-        $this->references = $classes;
+        assert($classes !== []);
 
         return $this;
     }

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -623,8 +623,8 @@ final class TestCall
     }
 
     /**
-     * Adds a reference to the tested method or class. This helps to link test
-     * cases to the source code for easier navigation.
+     * Adds one or more references to the tested method or class. This helps
+     * to link test cases to the source code for easier navigation.
      *
      * @param  array<class-string|string>|class-string  ...$classes
      */


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

In this pull request, I am adding a reference method to address an adaptation issue we encountered during our transition from PHPUnit to PEST. While using PHPUnit, we heavily rely on the `@see` annotation to provide direct references from test methods to source code methods.

<img width="977" alt="screenshot 57" src="https://github.com/user-attachments/assets/259ade06-0ca3-423e-97df-14f8ada6eb8a">

<img width="978" alt="screenshot 59" src="https://github.com/user-attachments/assets/b24c276c-68ad-4ffa-89f4-4328fff0f7b7">

This makes navigation in IDEs like PHPStorm smoother and improves the development process. However, when we transition to PEST, this functionality is lost.

To solve this, the reference() method comes into play. This method restores the lost functionality in PEST, enabling direct references between test callbacks and the source code methods. IDEs like PHPStorm will be able to navigate from test functions directly to the source code methods, similar to how it worked with `@see` in PHPUnit. Additionally, the method is lightweight and doesn't introduce any performance overhead.

<img width="889" alt="screenshot 58" src="https://github.com/user-attachments/assets/88736524-2ee4-4f43-a667-ac6a210adbed">

---

> If we had just added a `@see` annotation to the test, we’d only be able to navigate to the source code. The real goal here is two-way navigation: allowing us to jump from the test to the source code and also back from the source code to the test.

### Benefits of this Method:

**Improved IDE Support:** 

With the reference method, developers using PHPStorm will be able to maintain the connection between test functions and the source code methods. This makes it easier to navigate between tests and code, just like when using `@see` in PHPUnit.

**Easier Migration:** 

One of the key challenges for companies migrating from PHPUnit to PEST is the loss of reference functionality provided by `@see`. This reference method helps alleviate this issue and makes the transition smoother while keeping the tests readable and maintainable.

**No Performance Impact:** 

Since the method is empty, it has no performance impact on PEST. It simply serves as a way to provide IDE integration and navigation without adding any overhead.

**Broad Applicability:** 

We believe this solution is not only beneficial to our company but also for many other teams that rely on strong references between tests and the source code methods. Any company using `@see` annotations in their tests will find this method useful in PEST.

With the recent release of PEST PHP version 3, this method provides a lightweight solution that enhances IDE integration without imposing any additional burden or disrupting the framework’s structure. For developers using powerful IDEs like PHPStorm, this feature will be highly beneficial, offering improved functionality without adding unnecessary overhead to PEST.

> Note: This method could be made even more functional in the future. It might be a good idea to highlight the test's source in console output, providing further clarity during debugging.


https://github.com/user-attachments/assets/939e052f-8f84-487c-9df5-907b8e42c7f4