### PR TITLE
feat: Add ability to extend `TestCall` to create custom chained helpers

### DIFF
--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1324,6 +1324,10 @@
   ✓ a test
   ✓ higher order message test
 
+   PASS  Tests\Features\TestCallExtend
+  ✓ it uses fooBar extension with ('foo')
+  ✓ it uses fooBar extension with ('bar')
+
    PASS  Tests\Features\ThrowsNoExceptions
   ✓ it allows access to the underlying expectNotToPerformAssertions method
   ✓ it allows performing no expectations without being risky
@@ -1698,4 +1702,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 33 skipped, 1144 passed (2736 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 33 skipped, 1146 passed (2738 assertions)

--- a/tests/Features/TestCallExtend.php
+++ b/tests/Features/TestCallExtend.php
@@ -1,0 +1,17 @@
+<?php
+
+use function PHPUnit\Framework\assertTrue;
+
+test()->extend('fooBar', function () {
+    return $this->with([
+        'foo',
+        'bar',
+    ]);
+});
+
+it('uses fooBar extension', function ($value) {
+    assertTrue(in_array($value, [
+        'foo',
+        'bar',
+    ]));
+})->fooBar();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 24 skipped, 1134 passed (2712 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 24 skipped, 1136 passed (2714 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

Adds the ability to `->extend(...)` `TestCall` in the same fashion that expectations are extendable.

```php
test()->extend('fooBar', function () {
    return $this->with([
        'foo',
        'bar',
    ]);
});
```

I had this idea after [discussing on Pinkary](https://pinkary.com/@JHWelch/questions/9d08842d-5f42-4e2d-9509-6117b868f054) and realize this was not currently a way Pest could be extended.

This opens up the framework for a whole new area of extensibility.

If this is something you want to add, I can PR the docs repo wherever makes sense.

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
