### PR TITLE
feat: add ignoring of Concerns folder inside App\Enums and App\Features

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -27,10 +27,12 @@ final class Laravel extends AbstractPreset
             ->ignoring('App\Enums');
 
         $this->expectations[] = expect('App\Enums')
-            ->toBeEnums();
+            ->toBeEnums()
+            ->ignoring('App\Enums\Concerns');
 
         $this->expectations[] = expect('App\Features')
-            ->toBeClasses();
+            ->toBeClasses()
+            ->ignoring('App\Features\Concerns');
 
         $this->expectations[] = expect('App\Features')
             ->toHaveMethod('resolve');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Currently having a Concerns subfolder to store traits is flagged as illegal by the Laravel presets in `App\Enums` as well as `App\Features` due to both enforce specific php file type, respectively `toBeEnum` and `toBeClass`.

This makes sure the Laravel presets ignores those `Concerns` subfolder

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
