### PR TITLE
ignore App\Exceptions\Handler.php in arch laravel preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -31,7 +31,7 @@ final class Laravel extends AbstractPreset
             ->ignoring('App\Enums\Concerns');
 
         $this->expectations[] = expect('App\Features')
-            ->toBeClasses()
+            ->toBeClasses()->
             ->ignoring('App\Features\Concerns');
 
         $this->expectations[] = expect('App\Features')
@@ -39,7 +39,8 @@ final class Laravel extends AbstractPreset
 
         $this->expectations[] = expect('App\Exceptions')
             ->classes()
-            ->toImplement('Throwable');
+            ->toImplement('Throwable')
+            ->ignoring('App\Exceptions\Handler');
 
         $this->expectations[] = expect('App')
             ->not->toImplement(Throwable::class)

--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -31,7 +31,7 @@ final class Laravel extends AbstractPreset
             ->ignoring('App\Enums\Concerns');
 
         $this->expectations[] = expect('App\Features')
-            ->toBeClasses()->
+            ->toBeClasses()
             ->ignoring('App\Features\Concerns');
 
         $this->expectations[] = expect('App\Features')


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR ignores App\Exceptions\Handler.php in arch Laravel preset which is in pre-11 Laravel versions

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
