### PR TITLE
Strict types expectation allows for comments above declaration

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -509,7 +509,7 @@ final class Expectation
     {
         return Targeted::make(
             $this,
-            fn (ObjectDescription $object): bool => (bool) preg_match('/^<\?php\s+declare\(.*?strict_types\s?=\s?1.*?\);/', (string) file_get_contents($object->path)),
+            fn (ObjectDescription $object): bool => (bool) preg_match('/^<\?php\s*(\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$)|\s)*declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;/m', (string) file_get_contents($object->path)),
             'to use strict types',
             FileLineFinder::where(fn (string $line): bool => str_contains($line, '<?php')),
         );

--- a/tests/Features/Expect/toUseStrictTypes.php
+++ b/tests/Features/Expect/toUseStrictTypes.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+use Tests\Fixtures\Arch\ToUseStrictTypes\HasNoStrictType;
+use Tests\Fixtures\Arch\ToUseStrictTypes\HasStrictType;
+use Tests\Fixtures\Arch\ToUseStrictTypes\HasStrictTypeWithCommentsAbove;
+
+test('pass', function () {
+    expect(HasStrictType::class)->toUseStrictTypes()
+        ->and(HasStrictTypeWithCommentsAbove::class)->toUseStrictTypes();
+});
+
+test('failures', function () {
+    expect(HasNoStrictType::class)->toUseStrictTypes();
+})->throws(ArchExpectationFailedException::class);
+

--- a/tests/Fixtures/Arch/ToUseStrictTypes/HasNoStrictType.php
+++ b/tests/Fixtures/Arch/ToUseStrictTypes/HasNoStrictType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Arch\ToUseStrictTypes;
+
+class HasNoStrictType
+{
+
+}

--- a/tests/Fixtures/Arch/ToUseStrictTypes/HasStrictType.php
+++ b/tests/Fixtures/Arch/ToUseStrictTypes/HasStrictType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseStrictTypes;
+
+class HasStrictType
+{
+
+}

--- a/tests/Fixtures/Arch/ToUseStrictTypes/HasStrictTypeWithCommentsAbove.php
+++ b/tests/Fixtures/Arch/ToUseStrictTypes/HasStrictTypeWithCommentsAbove.php
@@ -1,0 +1,12 @@
+<?php /** @noinspection PhpUnused */
+
+// some other comment
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseStrictTypes;
+
+class HasStrictTypeWithCommentsAbove
+{
+
+}


### PR DESCRIPTION
### What:

- [X ] Bug Fix
- [ ] New Feature

### Description:

This fixes an issue where you're using `toUseStrictTypes`, but have comments above the declaration, for example ide suppression comments. I have updated the regex use to allow for comments. I've added three tests to ensure that comments  do not cause the test to fail when the `declare(strict_types=1);` is present.

(From my commit message)
Introduced new test cases to ensure strict type declaration handling. Files with and without strict types are tested, including scenarios with comments preceding the declaration. Updated the regex in `Expectation.php` to accommodate comments and whitespaces before the `declare(strict_types=1)` statement.
