### PR TITLE
Fix: Add middleware to the allowable public methods for Laravel Preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -149,7 +149,7 @@ final class Laravel extends AbstractPreset
             ->toOnlyBeUsedIn('App\Http');
 
         $this->expectations[] = expect('App\Http\Controllers')
-            ->not->toHavePublicMethodsBesides(['__construct', '__invoke', 'index', 'show', 'create', 'store', 'edit', 'update', 'destroy']);
+            ->not->toHavePublicMethodsBesides(['__construct', '__invoke', 'index', 'show', 'create', 'store', 'edit', 'update', 'destroy', 'middleware']);
 
         $this->expectations[] = expect([
             'dd',


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Current the middleware method is missing from the Laravel Presets for allowable public methods in controllers.
Re: https://laravel.com/docs/11.x/controllers#controller-middleware

<!-- describe what your PR is solving -->

### Related:
Closes #1252 
<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
