### PR TITLE
Feat: Add a "toPassAny" expectation method

### DIFF
--- a/tests/Features/Expect/toPassAny.php
+++ b/tests/Features/Expect/toPassAny.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\AssertionFailedError;
+
+it('throws first exception', function (array $tests) {
+    $mappedTests = array_map(fn ($i) => fn ($e) => $e->toContain($i), $tests);
+    expect(fn () => expect('Foo')->toPassAny(...$mappedTests))
+        ->toThrow(fn (AssertionFailedError $e) => expect($e->getMessage())->toContain('Foo')->toContain($tests[0]));
+
+    // Make sure inverted test has the opposite effect
+    expect(fn () => expect('Foo')->not->toPassAny(...$mappedTests))->not->toThrow(\Throwable::class);
+})->with([
+    [['First']],
+    [['First', 'Second']],
+    [['First', 'Second', 'Third']],
+]);
+
+it('succeeds with valid tests', function ($tests) {
+    $mappedTests = array_map(fn ($i) => fn ($e) => $e->toBe($i), $tests);
+    expect(fn () => expect('Foo')->toPassAny(...$mappedTests))
+        ->not->toThrow(\Throwable::class);
+
+    // Make sure inverted test has the opposite effect
+    expect(fn () => expect('Foo')->not->toPassAny(...$mappedTests))
+        ->toThrow(AssertionFailedError::class);
+})->with([
+    [['Fail', 'Fail', 'Fail', 'Foo']],
+    [['Fail', 'Fail', 'Foo', 'Fail']],
+    [['Fail', 'Foo', 'Fail', 'Fail']],
+    [['Foo', 'Fail', 'Fail', 'Fail']],
+    [['Foo', 'Foo', 'Foo', 'Foo']],
+    [['Fail', 'Foo']],
+    [['Foo']],
+    [[]],
+]);


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Add a `toPassAny` expectation to allow for effective `->or` branches:

```php
// Succeeds because the second test doesn't throw
expect(1)->toPassAny(
    fn($e) => $e->toBeGreaterThan(10),
    fn($e) => $e->toBeLessThan(5),
);

// Fails because all tests fail
expect(new \Exception())->toPassAny(
    fn($e) => $e->toBeInstanceOf(Foo::class),
    fn($e) => $e->toBeInstanceOf(Baz::class),
    fn($e) => $e->toBeInstanceOf(Bar::class),
);
```

For example if I want to make sure an array only contains `(InterfaceA & InterfaceB) | OtherBaseClass`
```php
expect($array)->each()->toPassAny(
    fn($e) => $e->toBeInstanceOf(A::class) && $e->toBeInstanceOf(B::class),
    fn($e) => $e->toBeInstanceOf(Foo::class),
);
```

### Open questions

> Should this be it's own Expectation type?

I don't believe so, the functionality `toPassAny` provides is fully encapsulated and doesn't have any effect on later expectation calls.

> Should there be a special exception type that outputs all of the failures instead of just the first?

If we have an exception that outputs all the failures, we run the risk of outputting very long failures when a lot of branches are provided. 

If we have an exception that is generic and doesn't output any of the failures, we make it hard to debug issues folks run into when tests fail.
