### PR TITLE
Add toNotIncludeSuspiciousCharacters() expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -886,6 +886,21 @@ final class Expectation
     }
 
     /**
+     * Asserts that the source code of the given expectation target does not include suspicious characters.
+     */
+    public function toNotIncludeSuspiciousCharacters(): ArchExpectation
+    {
+        $checker = new Spoofchecker();
+
+        return Targeted::make(
+            $this,
+            fn (ObjectDescription $object) => ! $checker->isSuspicious(file_get_contents($object->path)),
+            'to not include suspicious characters',
+            FileLineFinder::where(fn (string $line) => $checker->isSuspicious($line)),
+        );
+    }
+
+    /**
      * Not supported.
      */
     public function toBeUsed(): void


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

I recently had to debug an issue that turned out to be caused by a [small cyrillic c](https://www.compart.com/en/unicode/U+0441) in the source code.
There are probably lots of other ways to prevent things like this from happening, but I wanted to see if it was possible with an Arch expectation in Pest.

I'm not sure if this feature has a broad enough appeal, or if the spoof check should be implemented on the base Expectation in stead, allowing users to run it on string literals.

If you're interested in this feature, I'll obviously add tests. And since I'm new to Pest I'd appreciate any feedback about better ways to implement this.
