### PR TITLE
feat: add toBeOneOf() expectation

### DIFF
--- a/tests/Features/Expect/toBeOneOf.php
+++ b/tests/Features/Expect/toBeOneOf.php
@@ -1,0 +1,40 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+expect(true)->toBeTrue()->and(false)->toBeFalse();
+
+test('risky with no assertions', function () {
+    expect(1)->toBeOneOf();
+})->throwsNoExceptions();
+
+test('to be one of', function () {
+    expect(1)->toBeOneOf(fn ($e) => $e->toBe(1), fn ($e) => $e->toBe(2), fn ($e) => $e->toBe(3));
+});
+
+test('it does not short-circuit', function () {
+    $executed = 0;
+    expect(1)->toBeOneOf(function ($e) use (&$executed) {
+        $executed++;
+
+        return $e->toBe(1);
+    }, function ($e) use (&$executed) {
+        $executed++;
+
+        return $e->toBe(2);
+    }, function ($e) use (&$executed) {
+        $executed++;
+
+        return $e->toBe(3);
+    });
+
+    expect($executed)->toBe(3);
+});
+
+test('failure with multiple matches', function () {
+    expect(1)->toBeOneOf(fn ($e) => $e->toBe(1), fn ($e) => $e->toBe(1));
+})->throws(ExpectationFailedException::class, 'Failed asserting value matches exactly one expectation (matches: 0, 1).');
+
+test('failure with no matches', function () {
+    expect(1)->toBeOneOf(fn ($e) => $e->toBe(2), fn ($e) => $e->toBe(2));
+})->throws(ExpectationFailedException::class, 'Failed asserting value matches any expectations.');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds a `toBeOneOf` expectation that allows you to ensure that a value matches **only** one of a set of assertions. This is complimentary to #1286.
