### PR TITLE
Add Policy suffix to policies

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -162,5 +162,9 @@ final class Laravel extends AbstractPreset
             'exit',
             'ray',
         ])->not->toBeUsed();
+
+        $this->expectations[] = expect('App\Policies')
+            ->classes()
+            ->toHaveSuffix('Policy');
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds a new laravel expectation for policies. 

Expect all policies to be suffixed with Policy.
When looking at Laravel documentation, all the policies that are created are also suffixed this way

