### PR TITLE
Fix an issue where a describe block will prevent a beforeEach call from executing

### DIFF
--- a/src/PendingCalls/DescribeCall.php
+++ b/src/PendingCalls/DescribeCall.php
@@ -15,8 +15,10 @@ final class DescribeCall
 {
     /**
      * The current describe call.
+     *
+     * @var string[]
      */
-    private static ?string $describing = null;
+    private static array $describing = [];
 
     /**
      * The describe "before each" call.
@@ -40,7 +42,7 @@ final class DescribeCall
      */
     public static function describing(): ?string
     {
-        return self::$describing;
+        return self::$describing[count(self::$describing) - 1] ?? null;
     }
 
     /**
@@ -50,12 +52,12 @@ final class DescribeCall
     {
         unset($this->currentBeforeEachCall);
 
-        self::$describing = $this->description;
+        self::$describing[] = $this->description;
 
         try {
             ($this->tests)();
         } finally {
-            self::$describing = null;
+            array_pop(self::$describing);
         }
     }
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -215,6 +215,7 @@
   ✓ depends on describe → bar
   ✓ depends on describe using with → foo with (3)
   ✓ depends on describe using with → bar with (3)
+  ✓ with test after describe → it should run the before each
 
    PASS  Tests\Features\DescriptionLess
   ✓ get 'foo'
@@ -1584,4 +1585,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1095 passed (2648 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1096 passed (2649 assertions)

--- a/tests/Features/Describe.php
+++ b/tests/Features/Describe.php
@@ -96,3 +96,15 @@ describe('depends on describe using with', function () {
         expect($foo + $foo)->toBe(6);
     })->depends('foo');
 })->with([3]);
+
+describe('with test after describe', function () {
+    beforeEach(function () {
+        $this->count++;
+    });
+
+    describe('foo', function () {});
+
+    it('should run the before each', function () {
+        expect($this->count)->toBe(2);
+    });
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1085 passed (2624 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1086 passed (2625 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

This PR fixes an issue where a describe block will prevent a parent describe block or a before each call from applying. This is due to the describing string being statically stored and set to null in the destructor. For example
 
```php
describe('outer', function () {
    beforeEach(function () {});

    test('test1', function () {});

    describe('nested', function () {});

    test('test2', function () {});
});
```

The this example, the before each call will execute for `test1` but not for `test2`. Also, the parent describe is not applied to `test2`. The following is the test output before and after this change

**Before**
```
string(11) "before each"

WARN  Text
! outer → test1 → This test did not perform any assertions
! test2 → This test did not perform any assertions

Tests:    2 risky (0 assertions)
```

**After**
```
string(11) "before each"
string(11) "before each"

WARN  Tests\Feature\TechnicianCapacityOverviewReportTest
! outer → test1 → This test did not perform any assertions
! outer → test2 → This test did not perform any assertions

Tests:    2 risky (0 assertions)
```
