### PR TITLE
fix: Pest ignores '-c' option

### DIFF
--- a/src/Plugins/Configuration.php
+++ b/src/Plugins/Configuration.php
@@ -34,7 +34,7 @@ final class Configuration implements HandlesArguments, Terminable
      */
     public function handleArguments(array $arguments): array
     {
-        if ($this->hasArgument('--configuration', $arguments) || $this->hasCustomConfigurationFile()) {
+        if ($this->hasArgument('--configuration', $arguments) || $this->hasArgument('-c', $arguments) || $this->hasCustomConfigurationFile()) {
             return $arguments;
         }
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

# Description:
This PR fixes an issue where the -c flag was not being treated the same as --configuration.

Now, running:

```bash
./vendor/bin/pest -c phpunit.example.xml
```
will behave as expected and is equivalent to:

```bash
./vendor/bin/pest --configuration phpunit.example.xml
````

as the [Pest documentation](https://pestphp.com/docs/cli-api-reference#content-configuration) suggests.

### Related:


[https://github.com/pestphp/pest/issues/1298](https://github.com/pestphp/pest/issues/1298) 
