### PR TITLE
`toBeDeepOf()`

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -27,6 +27,8 @@ use ReflectionNamedType;
 use Throwable;
 use Traversable;
 
+use function Pest\getArrayDepth;
+
 /**
  * @internal
  *
@@ -433,6 +435,20 @@ final class Expectation
     public function toBeArray(string $message = ''): self
     {
         Assert::assertIsArray($this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is an array of depth = $depth.
+     *
+     * @return self<TValue>
+     */
+    public function toBeDeepOf(int $depth, string $message = ''): self
+    {
+        Assert::assertIsArray($this->value, $message);
+
+        Assert::assertEquals(getArrayDepth($this->value), $depth, $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -447,6 +447,7 @@ final class Expectation
     public function toBeDeepOf(int $depth, string $message = ''): self
     {
         Assert::assertIsArray($this->value, $message);
+        Assert::assertGreaterThanOrEqual(0, $depth, $message);
 
         Assert::assertEquals(getArrayDepth($this->value), $depth, $message);
 

--- a/src/Pest.php
+++ b/src/Pest.php
@@ -13,3 +13,21 @@ function testDirectory(string $file = ''): string
 {
     return TestSuite::getInstance()->testPath.DIRECTORY_SEPARATOR.$file;
 }
+
+/**
+ * Returns array depth.
+ *
+ * @param  array<mixed>  $array
+ */
+function getArrayDepth(array $array): int
+{
+    $depth = 0;
+
+    foreach ($array as $elem) {
+        if (is_array($elem)) {
+            $depth = getArrayDepth($elem) + 1;
+        }
+    }
+
+    return $depth;
+}

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -403,6 +403,13 @@
   ✓ failures with custom message
   ✓ not failures
 
+   PASS  Tests\Features\Expect\toBeDeepOf
+  ✓ pass
+  ✓ failures
+  ✓ failures when not array passed
+  ✓ failures with custom message
+  ✓ not failures
+
    PASS  Tests\Features\Expect\toBeDigits
   ✓ pass
   ✓ failures
@@ -1584,4 +1591,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1095 passed (2648 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1100 passed (2669 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -407,6 +407,7 @@
   ✓ pass
   ✓ failures
   ✓ failures when not array passed
+  ✓ failures when depth is negative
   ✓ failures with custom message
   ✓ not failures
 
@@ -1591,4 +1592,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1100 passed (2669 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 28 skipped, 1101 passed (2687 assertions)

--- a/tests/Features/Expect/toBeDeepOf.php
+++ b/tests/Features/Expect/toBeDeepOf.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+uses()->group('deep');
+
+test('pass', function () {
+    expect([])->toBeDeepOf(0);
+    expect([1, 2, 3])->toBeDeepOf(0);
+    expect([1, 2 => [1, 2], 3 => [1]])->toBeDeepOf(1);
+    expect([1, 2 => [1, 2], 3 => [1 => [1]]])->toBeDeepOf(2);
+    expect('1, 2, 3')->not->toBeDeepOf(1);
+});
+
+test('failures', function () {
+    expect([1, 2, 3])->toBeDeepOf(1);
+})->throws(ExpectationFailedException::class);
+
+test('failures when not array passed', function () {
+    expect('not array')->toBeDeepOf(1);
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect([1, 2, 3])->toBeDeepOf(1, 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect([1, 2, 3])->not->toBeDeepOf(0);
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeDeepOf.php
+++ b/tests/Features/Expect/toBeDeepOf.php
@@ -2,8 +2,6 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
-uses()->group('deep');
-
 test('pass', function () {
     expect([])->toBeDeepOf(0);
     expect([1, 2, 3])->toBeDeepOf(0);
@@ -18,6 +16,10 @@ test('failures', function () {
 
 test('failures when not array passed', function () {
     expect('not array')->toBeDeepOf(1);
+})->throws(ExpectationFailedException::class);
+
+test('failures when depth is negative', function () {
+    expect([])->toBeDeepOf(-1);
 })->throws(ExpectationFailedException::class);
 
 test('failures with custom message', function () {

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1085 passed (2624 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1090 passed (2645 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1090 passed (2645 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 17 todos, 19 skipped, 1091 passed (2663 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
Hello 👋🏻 

This PR introduces a new expectation: **toBeDeepOf()**, which makes sure that an array is deep of specific value.

### Examples
```php
$array = [1, 2, 3, 4];

expect($array)->toBeDeepOf(0); // true
expect($array)->toBeDeepOf(1); // false
```

```php
$array = [1, 2, 3 => [1, 2], 4];

expect($array)->toBeDeepOf(0); // false
expect($array)->toBeDeepOf(1); // true
```