### PR TITLE
feat: add support for anonymous tests

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -1044,6 +1044,29 @@ final class Expectation
     }
 
     /**
+     * Asserts that the given expectation target has a non-public constructor method.
+     */
+    public function toHaveNonPublicConstructor(): ArchExpectation
+    {
+        $callback = function (ObjectDescription $object): bool {
+            $constructor = $object->reflectionClass->getConstructor();
+
+            if ($constructor === null) {
+                return false;
+            }
+
+            return ! $constructor->isPublic();
+        };
+
+        return Targeted::make(
+            $this,
+            $callback,
+            'to have non-public constructor',
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, '__construct')),
+        );
+    }
+
+    /**
      * Asserts that the given expectation target has a constructor method.
      */
     public function toHaveConstructor(): ArchExpectation

--- a/tests/Features/Expect/toHaveNonPublicConstructor.php
+++ b/tests/Features/Expect/toHaveNonPublicConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+test('class has private constructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveNonPublicConstructor\HasPrivateConstructor')
+    ->toHaveNonPublicConstructor();
+
+test('class has protected constructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveNonPublicConstructor\HasProtectedConstructor')
+    ->toHaveNonPublicConstructor();
+
+test('class has public constructor')
+    ->expect('Tests\Fixtures\Arch\ToHaveConstructor\HasConstructor\HasConstructor')
+    ->not->toHaveNonPublicConstructor();

--- a/tests/Fixtures/Arch/ToHaveNonPublicConstructor/HasPrivateConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveNonPublicConstructor/HasPrivateConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveNonPublicConstructor;
+
+class HasPrivateConstructor
+{
+    private function __construct() {}
+}

--- a/tests/Fixtures/Arch/ToHaveNonPublicConstructor/HasProtectedConstructor.php
+++ b/tests/Fixtures/Arch/ToHaveNonPublicConstructor/HasProtectedConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveNonPublicConstructor;
+
+class HasProtectedConstructor
+{
+    protected function __construct() {}
+}


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

Sometimes we start thinking about the test code rather than its title.

Given these situations, I think it makes sense to allow specifying the closure from the first argument and in that case, take as title the relative path of the test file and the line where the closure is defined. In those cases, it would be necessary to be able to filter this type of tests.

```php
<?php

test(function () {
    expect(true)->toBe(true);
});
```

Output result:

![imagen](https://github.com/user-attachments/assets/00bff04b-13fd-47a7-9793-59d7b2c99740)

