### PR TITLE
Allow custom arch expectations

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -330,7 +330,7 @@ final class Expectation
      * @param  array<int, mixed>  $parameters
      * @return Expectation<TValue>|HigherOrderExpectation<Expectation<TValue>, TValue>
      */
-    public function __call(string $method, array $parameters): Expectation|HigherOrderExpectation|PendingArchExpectation
+    public function __call(string $method, array $parameters): Expectation|HigherOrderExpectation|PendingArchExpectation|ArchExpectation
     {
         if (! self::hasMethod($method)) {
             if (! is_object($this->value) && method_exists(PendingArchExpectation::class, $method)) {
@@ -354,6 +354,10 @@ final class Expectation
         $closure = $this->getExpectationClosure($method);
         $reflectionClosure = new \ReflectionFunction($closure);
         $expectation = $reflectionClosure->getClosureThis();
+
+        if ($reflectionClosure->getReturnType()?->__toString() === ArchExpectation::class) {
+            return $closure(...$parameters);
+        }
 
         assert(is_object($expectation));
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:
Allow adding custom arch expectations into pest.

A custom arch expectation needs to have typehinted the return type to the `ArchExpectation` for it to work with this implementation. 

An example could be the following added as a custom expectation
```php
expect()->extend('toHaveMethodsDocumentedMatching', function (string $pattern): ArchExpectation {
    return Targeted::make(
        $this, // @phpstan-ignore-line
        fn (ObjectDescription $object): bool => isset($object->reflectionClass) === false
            || (
                array_filter(
                Reflection::getMethodsFromReflectionClass($object->reflectionClass),
                fn(ReflectionMethod $method): bool => (enum_exists($object->name) === false || in_array($method->name, ['from', 'tryFrom', 'cases'], true) === false)
                    && realpath($method->getFileName() ?: '/') === realpath($object->path)
                    && !Str::isMatch($pattern, $method->getDocComment()),
                ) === []
            ),
        'to have methods with documentation / annotations matching pattern',
        FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class'))
    );
});
```


### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
