### PR TITLE
fix: uses beforeAll not being called since 3.0.4

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -119,6 +119,8 @@ trait Testable
             self::$__latestPrs = $method->prs;
             $this->__describing = $method->describing;
             $this->__test = $method->getClosure();
+
+            $method->setUp($this);
         }
     }
 
@@ -241,8 +243,6 @@ trait Testable
         TestSuite::getInstance()->test = $this;
 
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
-
-        $method->setUp($this);
 
         $description = $method->description;
         if ($this->dataName()) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1425,6 +1425,9 @@
   ✓ nested → nested afterEach execution order
   ✓ global afterEach execution order
 
+   PASS  Tests\Hooks\BeforeAllTest
+  ✓ beforeAll is called
+
    PASS  Tests\Hooks\BeforeEachTest
   ✓ global beforeEach execution order
 
@@ -1708,4 +1711,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 33 skipped, 1152 passed (2744 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 33 skipped, 1153 passed (2748 assertions)

--- a/tests/Hooks/BeforeAllTest.php
+++ b/tests/Hooks/BeforeAllTest.php
@@ -1,0 +1,19 @@
+<?php
+
+$_SERVER['beforeAllCalls'] = 0;
+
+pest()->beforeAll(function () {
+    $_SERVER['beforeAllCalls']++;
+
+    expect($_SERVER['beforeAllCalls'])->toBe(1);
+});
+
+beforeAll(function () {
+    $_SERVER['beforeAllCalls']++;
+
+    expect($_SERVER['beforeAllCalls'])->toBe(2);
+});
+
+test('beforeAll is called', function () {
+    expect($_SERVER['beforeAllCalls'])->toBe(2);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -74,7 +74,7 @@ pest()->in('Hooks')
             ->toHaveProperty('afterAll')
             ->and($_SERVER['globalHook']->afterAll)
             ->toBe(0)
-            ->and($_SERVER['beforeAll'])
+            ->and($_SERVER['globalHook']->beforeAll)
             ->toBe(1);
 
         $_SERVER['globalHook']->afterAll = 1;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -73,7 +73,9 @@ pest()->in('Hooks')
         expect($_SERVER['globalHook'])
             ->toHaveProperty('afterAll')
             ->and($_SERVER['globalHook']->afterAll)
-            ->toBe(0);
+            ->toBe(0)
+            ->and($_SERVER['beforeAll'])
+            ->toBe(1);
 
         $_SERVER['globalHook']->afterAll = 1;
     });

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 24 skipped, 1142 passed (2720 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 24 skipped, 1143 passed (2724 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

fixes regresion from 3.0.4 that beforeAll hook from pest()/uses() is not called
moved TestCaseMethodFactory setUp method call back to testable constructor because calling it in setUp was already to late

### Related:

#1282 
