### PR TITLE
Add Attributes to Laravel preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -166,5 +166,11 @@ final class Laravel extends AbstractPreset
         $this->expectations[] = expect('App\Policies')
             ->classes()
             ->toHaveSuffix('Policy');
+
+        $this->expectations[] = expect('App\Attributes')
+            ->classes()
+            ->toImplement('Illuminate\Contracts\Container\ContextualAttribute')
+            ->toHaveAttribute('Attribute')
+            ->toHaveMethod('resolve');
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces a new expectation in Laravel preset for custom contextual attributes.

Expect all attributes to implement `Illuminate\Contracts\Container\ContextualAttribute`, to have an attribute `Attribute` and to have a method `resolve`

### Related:
