### PR TITLE
feat: add toBeUlid() expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1132,6 +1132,22 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is ULID.
+     *
+     * @return self<TValue>
+     */
+    public function toBeUlid(string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(Str::isUlid($this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is between 2 specified values
      *
      * @return self<TValue>

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -102,6 +102,14 @@ final class Str
     }
 
     /**
+     * Determine if a given value is a valid ULID.
+     */
+    public static function isUlid(string $value): bool
+    {
+        return preg_match('/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/iD', $value) > 0;
+    }
+
+    /**
      * Creates a describe block as `$describeDescription` → `$testDescription` format.
      *
      * @param  array<int, string>  $describeDescriptions

--- a/tests/Features/Expect/toBeUlid.php
+++ b/tests/Features/Expect/toBeUlid.php
@@ -1,0 +1,24 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('failures with wrong type', function () {
+    expect([])->toBeUlid();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
+
+test('pass', function () {
+    expect('01JEWKD14JZJC6GKVQG8CAF93G')->toBeUlid();
+});
+
+test('failures', function () {
+    expect('foo')->toBeUlid();
+})->throws(ExpectationFailedException::class);
+
+test('failures with message', function () {
+    expect('bar')->toBeUlid('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('foo')->not->toBeUlid();
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces a new expectation: `toBeUlid()`, which makes sure that `$value` is a valid ULID.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
