### PR TITLE
[3.x] Allow container bindings for http classes (laravel arch preset)

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -149,7 +149,8 @@ final class Laravel extends AbstractPreset
             ->toHaveSuffix('Controller');
 
         $this->expectations[] = expect('App\Http')
-            ->toOnlyBeUsedIn('App\Http');
+            ->toOnlyBeUsedIn('App\Http')
+            ->ignoring('App\Providers');
 
         $this->expectations[] = expect('App\Http\Controllers')
             ->not->toHavePublicMethodsBesides(['__construct', '__invoke', 'index', 'show', 'create', 'store', 'edit', 'update', 'destroy', 'middleware']);


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Current Laravel arch preset only allows `App\Http` classes to be used within `App\Http`.

This makes sense MOST of the time.

But feels reasonable to accept that container bindings for controllers/middleware MAY be manually registered in service providers eg. primitives https://laravel.com/docs/11.x/container#binding-primitives 

This means `App\Http` also needs to be usable in `App\Providers`.