### PR TITLE
chore: Sync overrides

### DIFF
--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -212,7 +212,7 @@ final class JunitXmlLogger
      */
     public function testFinished(Finished $event): void
     {
-        if ($this->preparationFailed) {
+        if (!$this->prepared || $this->preparationFailed) {
             return;
         }
 

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -225,7 +225,7 @@ final class JunitXmlLogger
      */
     public function testFinished(Finished $event): void
     {
-        if (!$this->prepared || $this->preparationFailed) {
+        if (! $this->prepared || $this->preparationFailed) {
             return;
         }
 

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -27,6 +27,7 @@ use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\MarkedIncomplete;
 use PHPUnit\Event\Test\PreparationStarted;
 use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PrintedUnexpectedOutput;
 use PHPUnit\Event\Test\Skipped;
 use PHPUnit\Event\TestSuite\Started;
 use PHPUnit\Event\UnknownSubscriberTypeException;
@@ -207,6 +208,18 @@ final class JunitXmlLogger
         $this->prepared = true;
     }
 
+    public function testPrintedUnexpectedOutput(PrintedUnexpectedOutput $event): void
+    {
+        assert($this->currentTestCase !== null);
+
+        $systemOut = $this->document->createElement(
+            'system-out',
+            Xml::prepareString($event->output()),
+        );
+
+        $this->currentTestCase->appendChild($systemOut);
+    }
+
     /**
      * @throws InvalidArgumentException
      */
@@ -301,6 +314,7 @@ final class JunitXmlLogger
             new TestPreparationStartedSubscriber($this),
             new TestPreparationFailedSubscriber($this),
             new TestPreparedSubscriber($this),
+            new TestPrintedUnexpectedOutputSubscriber($this),
             new TestFinishedSubscriber($this),
             new TestErroredSubscriber($this),
             new TestFailedSubscriber($this),

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -41,6 +41,8 @@ use function str_replace;
 use function trim;
 
 /**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
 final class JunitXmlLogger
@@ -59,32 +61,32 @@ final class JunitXmlLogger
     private array $testSuites = [];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteTests = [0];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteAssertions = [0];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteErrors = [0];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteFailures = [0];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteSkipped = [0];
 
     /**
-     * @psalm-var array<int,int>
+     * @var array<int,int>
      */
     private array $testSuiteTimes = [0];
 
@@ -195,17 +197,11 @@ final class JunitXmlLogger
         $this->createTestCase($event);
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     public function testPreparationFailed(): void
     {
         $this->preparationFailed = true;
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     public function testPrepared(): void
     {
         $this->prepared = true;
@@ -431,7 +427,7 @@ final class JunitXmlLogger
     /**
      * @throws InvalidArgumentException
      *
-     * @psalm-assert !null $this->currentTestCase
+     * @phpstan-assert !null $this->currentTestCase
      */
     private function createTestCase(Errored|Failed|MarkedIncomplete|PreparationStarted|Prepared|Skipped $event): void
     {

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -304,6 +304,7 @@ final class JunitXmlLogger
             new TestFinishedSubscriber($this),
             new TestErroredSubscriber($this),
             new TestFailedSubscriber($this),
+            new TestMarkedIncompleteSubscriber($this),
             new TestSkippedSubscriber($this),
             new TestRunnerExecutionFinishedSubscriber($this),
         );

--- a/overrides/Logging/JUnit/JunitXmlLogger.php
+++ b/overrides/Logging/JUnit/JunitXmlLogger.php
@@ -115,7 +115,7 @@ final class JunitXmlLogger
 
     public function flush(): void
     {
-        $this->printer->print($this->document->saveXML());
+        $this->printer->print($this->document->saveXML() ?: '');
 
         $this->printer->flush();
     }

--- a/overrides/Runner/ResultCache/DefaultResultCache.php
+++ b/overrides/Runner/ResultCache/DefaultResultCache.php
@@ -46,6 +46,7 @@ declare(strict_types=1);
 namespace PHPUnit\Runner\ResultCache;
 
 use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
 
 use PHPUnit\Framework\TestStatus\TestStatus;
 use PHPUnit\Runner\DirectoryCannotBeCreatedException;
@@ -65,6 +66,8 @@ use function json_encode;
 use function Pest\version;
 
 /**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
 final class DefaultResultCache implements ResultCache
@@ -77,12 +80,12 @@ final class DefaultResultCache implements ResultCache
     private readonly string $cacheFilename;
 
     /**
-     * @psalm-var array<string, TestStatus>
+     * @var array<string, TestStatus>
      */
     private array $defects = [];
 
     /**
-     * @psalm-var array<string, float>
+     * @var array<string, float>
      */
     private array $times = [];
 
@@ -117,6 +120,17 @@ final class DefaultResultCache implements ResultCache
     public function time(string $id): float
     {
         return $this->times[$id] ?? 0.0;
+    }
+
+    public function mergeWith(self $other): void
+    {
+        foreach ($other->defects as $id => $defect) {
+            $this->defects[$id] = $defect;
+        }
+
+        foreach ($other->times as $id => $time) {
+            $this->times[$id] = $time;
+        }
     }
 
     public function load(): void


### PR DESCRIPTION
Hey Nuno,

I checked the difference between the files we are overwriting and found that we missed a few things.

**JunitXmlLogger**:
https://github.com/sebastianbergmann/phpunit/issues/6098
https://github.com/sebastianbergmann/phpunit/issues/5771

**DefaultResultCache**:
https://github.com/sebastianbergmann/phpunit/pull/6081

As you also use phpstorm you can check the diff like so
```sh
phpstorm diff overrides/Logging/JUnit/JunitXmlLogger.php vendor/phpunit/phpunit/src/Logging/JUnit/JunitXmlLogger.php
```

cheers adrian