### PR TITLE
fix: incorrect toMatchArray expectation message

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -783,14 +783,16 @@ final class Expectation
             Assert::assertArrayHasKey($key, $valueAsArray, $message);
 
             if ($message === '') {
-                $message = sprintf(
+                $defaultMessage = sprintf(
                     'Failed asserting that an array has a key %s with the value %s.',
                     $this->export($key),
                     $this->export($valueAsArray[$key]),
                 );
+            } else {
+                $defaultMessage = $message;
             }
 
-            Assert::assertEquals($value, $valueAsArray[$key], $message);
+            Assert::assertEquals($value, $valueAsArray[$key], $message !== '' ? $message : $defaultMessage);
         }
 
         return $this;

--- a/tests/Features/Expect/toMatchArray.php
+++ b/tests/Features/Expect/toMatchArray.php
@@ -36,3 +36,10 @@ test('not failures', function () {
         'id' => 1,
     ]);
 })->throws(ExpectationFailedException::class);
+
+test('failures with default message', function () {
+    expect($this->user)->toMatchArray([
+        'id' => 1,
+        'email' => 'enunomaduro@gmall.com',
+    ]);
+})->throws(ExpectationFailedException::class, 'Failed asserting that an array has a key \'email\' with the value \'enunomaduro@gmail.com\'');


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fixes incorrect toMatchArray expectation message.

Test:

```php
expect($this->user)->toMatchArray([
    'id' => 1,
    'email' => 'enunomaduro@gmall.com',
]);
```

Before:

```
Failed asserting that an array has a key 'id' with the value 1.
Failed asserting that two strings are equal.
Expected :'enunomaduro@gmall.com'
Actual   :'enunomaduro@gmail.com'
```

After:

```
Failed asserting that an array has a key 'email' with the value 'enunomaduro@gmail.com'.
Failed asserting that two strings are equal.
Expected :'enunomaduro@gmall.com'
Actual   :'enunomaduro@gmail.com'
```

### Related:

https://github.com/pestphp/pest/pull/583
