### PR TITLE
Add quiet-coverage option

### DIFF
--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -33,6 +33,11 @@ final class Coverage implements AddsOutput, HandlesArguments
     private const EXACTLY_OPTION = 'exactly';
 
     /**
+     * @var string
+     */
+    private const QUIET_COVERAGE_OPTION = 'quiet-coverage';
+
+    /**
      * Whether it should show the coverage or not.
      */
     public bool $coverage = false;
@@ -53,6 +58,11 @@ final class Coverage implements AddsOutput, HandlesArguments
     public ?float $coverageExactly = null;
 
     /**
+     * Whether it should hide files where coverage is 100% or not
+     */
+    public bool $quietCoverage = false;
+
+    /**
      * Creates a new Plugin instance.
      */
     public function __construct(private readonly OutputInterface $output)
@@ -66,7 +76,12 @@ final class Coverage implements AddsOutput, HandlesArguments
     public function handleArguments(array $originals): array
     {
         $arguments = [...[''], ...array_values(array_filter($originals, function (string $original): bool {
-            foreach ([self::COVERAGE_OPTION, self::MIN_OPTION, self::EXACTLY_OPTION] as $option) {
+            foreach ([
+                self::COVERAGE_OPTION,
+                self::MIN_OPTION,
+                self::EXACTLY_OPTION,
+                self::QUIET_COVERAGE_OPTION
+             ] as $option) {
                 if ($original === sprintf('--%s', $option)) {
                     return true;
                 }
@@ -89,6 +104,7 @@ final class Coverage implements AddsOutput, HandlesArguments
         $inputs[] = new InputOption(self::COVERAGE_OPTION, null, InputOption::VALUE_NONE);
         $inputs[] = new InputOption(self::MIN_OPTION, null, InputOption::VALUE_REQUIRED);
         $inputs[] = new InputOption(self::EXACTLY_OPTION, null, InputOption::VALUE_REQUIRED);
+        $inputs[] = new InputOption(self::QUIET_COVERAGE_OPTION, null, InputOption::VALUE_NONE);
 
         $input = new ArgvInput($arguments, new InputDefinition($inputs));
         if ((bool) $input->getOption(self::COVERAGE_OPTION)) {
@@ -129,6 +145,10 @@ final class Coverage implements AddsOutput, HandlesArguments
             $this->coverageExactly = (float) $exactlyOption;
         }
 
+        if ((bool) $input->getOption(self::COVERAGE_OPTION)) {
+            $this->quietCoverage = true;
+        }
+
         if ($_SERVER['COLLISION_PRINTER_COMPACT'] ?? false) {
             $this->compact = true;
         }
@@ -153,7 +173,7 @@ final class Coverage implements AddsOutput, HandlesArguments
                 exit(1);
             }
 
-            $coverage = \Pest\Support\Coverage::report($this->output, $this->compact);
+            $coverage = \Pest\Support\Coverage::report($this->output, $this->compact, $this->quietCoverage);
             $exitCode = (int) ($coverage < $this->coverageMin);
 
             if ($exitCode === 0 && $this->coverageExactly !== null) {

--- a/src/Plugins/Help.php
+++ b/src/Plugins/Help.php
@@ -156,7 +156,10 @@ final readonly class Help implements HandlesArguments
         ], [
             'arg' => '--coverage --min',
             'desc' => 'Set the minimum required coverage percentage, and fail if not met',
-        ], ...$content['Code Coverage']];
+        ], ...$content['Code Coverage'], [
+            'arg' => '--quiet-coverage ',
+            'desc' => 'Do not report any files where code coverage is 100%',
+        ]];
 
         $content['Mutation Testing'] = [[
             'arg' => '--mutate ',

--- a/src/Support/Coverage.php
+++ b/src/Support/Coverage.php
@@ -74,8 +74,11 @@ final class Coverage
      * Reports the code coverage report to the
      * console and returns the result in float.
      */
-    public static function report(OutputInterface $output, bool $compact = false): float
-    {
+    public static function report(
+        OutputInterface $output,
+        bool $compact = false,
+        bool $quietCoverage = false,
+    ): float {
         if (! file_exists($reportPath = self::getPath())) {
             if (self::usingXdebug()) {
                 $output->writeln(
@@ -113,7 +116,7 @@ final class Coverage
                 ? '100.0'
                 : number_format($file->percentageOfExecutedLines()->asFloat(), 1, '.', '');
 
-            if ($percentage === '100.0' && $compact) {
+            if ($percentage === '100.0' && ($compact || $quietCoverage)) {
                 continue;
             }
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Now that the `--quiet-coverage` option has been added to Collision, this PR adds the same functionality to Pest. If this command line flag is set, then files where code coverage is 100% will not be shown. Notice that this is different from the `--compact` flag, which also hides these files with full coverage but which also affects other parts of the output

### Related:

https://github.com/nunomaduro/collision/pull/314