### PR TITLE
fix: Incorrect exit code with --fail-on-incomplete

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -40,44 +40,36 @@ final class Result
      */
     public static function exitCode(Configuration $configuration, TestResult $result): int
     {
-        if ($result->wasSuccessfulIgnoringPhpunitWarnings()) {
-            if ($configuration->failOnWarning()) {
-                $warnings = $result->numberOfTestsWithTestTriggeredPhpunitWarningEvents()
-                    + count($result->warnings())
-                    + count($result->phpWarnings());
-
-                if ($warnings > 0) {
-                    return self::FAILURE_EXIT;
-                }
-            }
-
-            if (! $result->hasTestTriggeredPhpunitWarningEvents()) {
-                return self::SUCCESS_EXIT;
-            }
+        if ($result->hasTestErroredEvents()) {
+            return self::EXCEPTION_EXIT;
         }
 
         if ($configuration->failOnEmptyTestSuite() && ResultReflection::numberOfTests($result) === 0) {
             return self::FAILURE_EXIT;
         }
 
-        if ($result->wasSuccessfulIgnoringPhpunitWarnings()) {
-            if ($configuration->failOnRisky() && $result->hasTestConsideredRiskyEvents()) {
-                $returnCode = self::FAILURE_EXIT;
-            }
+        if ($configuration->failOnWarning()) {
+            $warnings = $result->numberOfTestsWithTestTriggeredPhpunitWarningEvents()
+                + count($result->warnings())
+                + count($result->phpWarnings());
 
-            if ($configuration->failOnIncomplete() && $result->hasTestMarkedIncompleteEvents()) {
-                $returnCode = self::FAILURE_EXIT;
-            }
-
-            if ($configuration->failOnSkipped() && $result->hasTestSkippedEvents()) {
-                $returnCode = self::FAILURE_EXIT;
+            if ($warnings > 0) {
+                return self::FAILURE_EXIT;
             }
         }
 
-        if ($result->hasTestErroredEvents()) {
-            return self::EXCEPTION_EXIT;
+        if ($configuration->failOnRisky() && $result->hasTestConsideredRiskyEvents()) {
+            return self::FAILURE_EXIT;
         }
 
-        return self::FAILURE_EXIT;
+        if ($configuration->failOnIncomplete() && $result->hasTestMarkedIncompleteEvents()) {
+            return self::FAILURE_EXIT;
+        }
+
+        if ($configuration->failOnSkipped() && $result->hasTestSkippedEvents()) {
+            return self::FAILURE_EXIT;
+        }
+
+        return self::SUCCESS_EXIT;
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1679,6 +1679,10 @@
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
 
+   WARN  Tests\Visual\Incompleted
+  - incompleted test with fail-on-incomplete returns non-zero exit code
+  - incompleted test with fail-on-incomplete returns non-zero exit code parallel
+
    WARN  Tests\Visual\JUnit
   ✓ junit output
   - junit with parallel → Not working yet
@@ -1708,4 +1712,4 @@
    WARN  Tests\Visual\Version
   - visual snapshot of help command output
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 33 skipped, 1152 passed (2744 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 38 todos, 35 skipped, 1152 passed (2744 assertions)

--- a/tests/Visual/Incompleted.php
+++ b/tests/Visual/Incompleted.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+$run = function (bool $parallel) {
+    $process = new Process(
+        ['php', 'bin/pest', 'tests/Features/Incompleted.php', $parallel ? '--parallel' : '', '--fail-on-incomplete'],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true'],
+    );
+
+    $process->run();
+
+    expect($process->getExitCode())->toBe(1);
+
+    return removeAnsiEscapeSequences($process->getOutput());
+};
+
+test('incompleted test with fail-on-incomplete returns non-zero exit code', function () use ($run) {
+    expect($run(false))
+        ->toContain('Tests:    5 incomplete');
+})
+    ->skipOnWindows()
+    ->skip(! getenv('REBUILD_SNAPSHOTS') && getenv('EXCLUDE'));
+
+test('incompleted test with fail-on-incomplete returns non-zero exit code parallel', function () use ($run) {
+    expect($run(true))
+        ->toContain('Tests:    5 incomplete');
+})
+    ->skipOnWindows()
+    ->skip(! getenv('REBUILD_SNAPSHOTS') && getenv('EXCLUDE'));


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This fixes cases where running pest with `--fail-on-incomplete` (and possibly other `--fail-on` arguments) returns an exit code of 0 (success) instead of 1 (error).

### Related:

- Fixes #1328 