### PR TITLE
fix: add ignoring clause for `App\Features\Concerns` on Laravel Preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -35,7 +35,8 @@ final class Laravel extends AbstractPreset
             ->ignoring('App\Features\Concerns');
 
         $this->expectations[] = expect('App\Features')
-            ->toHaveMethod('resolve');
+            ->toHaveMethod('resolve')
+            ->ignoring('App\Features\Concerns');
 
         $this->expectations[] = expect('App\Exceptions')
             ->classes()


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->
This pull request added an ignoring clause for `App\Features\Concerns` in the expectations for `App\Features` to have the `resolve` method.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
