### PR TITLE
toMatchArray/Object wrong field fix

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -780,17 +780,16 @@ final class Expectation
         }
 
         foreach ($array as $key => $value) {
+            $message = '';
             Assert::assertArrayHasKey($key, $valueAsArray, $message);
 
-            if ($message === '') {
-                $message = sprintf(
-                    'Failed asserting that an array has a key %s with the value %s.',
-                    $this->export($key),
-                    $this->export($valueAsArray[$key]),
-                );
-            }
+            $second_message = $message !== '' ? $message : sprintf(
+                'Failed asserting that an array has a key %s with the value %s.',
+                $this->export($key),
+                $this->export($valueAsArray[$key]),
+            );
 
-            Assert::assertEquals($value, $valueAsArray[$key], $message);
+            Assert::assertEquals($value, $valueAsArray[$key], $second_message);
         }
 
         return $this;
@@ -815,15 +814,14 @@ final class Expectation
             /* @phpstan-ignore-next-line */
             $propertyValue = $this->value->{$property};
 
-            if ($message === '') {
-                $message = sprintf(
+            $second_message = $message !== '' ? $message : sprintf(
                     'Failed asserting that an object has a property %s with the value %s.',
                     $this->export($property),
                     $this->export($propertyValue),
                 );
             }
 
-            Assert::assertEquals($value, $propertyValue, $message);
+            Assert::assertEquals($value, $propertyValue, $second_message);
         }
 
         return $this;

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -815,11 +815,10 @@ final class Expectation
             $propertyValue = $this->value->{$property};
 
             $second_message = $message !== '' ? $message : sprintf(
-                    'Failed asserting that an object has a property %s with the value %s.',
-                    $this->export($property),
-                    $this->export($propertyValue),
-                );
-            }
+                'Failed asserting that an object has a property %s with the value %s.',
+                $this->export($property),
+                $this->export($propertyValue),
+            );
 
             Assert::assertEquals($value, $propertyValue, $second_message);
         }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -780,7 +780,6 @@ final class Expectation
         }
 
         foreach ($array as $key => $value) {
-            $message = '';
             Assert::assertArrayHasKey($key, $valueAsArray, $message);
 
             $second_message = $message !== '' ? $message : sprintf(


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The functions toMatchArray and toMatchObject indicate that the wrong field is mismatching from the second loop on. This is  because the 'message' parameter is overwritten and taken into the following loop. This patch creates a $second_message variable for the second test (value test) and therefore keeps the loop clean.

### Related:

https://github.com/pestphp/pest/issues/945