### PR TITLE
Exclude DescriptionLess from `composer lint`

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,5 @@
+{
+    "notPath": [
+        "tests/Features/DescriptionLess.php"
+    ]
+}


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Resolves an annoying bug where running `composer lint` incorrectly changes the `DescriptionLess` file.

**Note**: This is more of a bandaid than a straight fix.

A more ideal solution would be to ignore the individual lines with comments like `// pint ignore` or nesting within `// pint ignore-start` and `// pint ignore-end`, but neither Laravel Pint nor php-cs-fixer (which it's built off of) provides such a surgical solution at this moment.

### Related

- https://laravel.com/docs/12.x/pint#excluding-files-or-folders
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/4512#issuecomment-2516806145