### PR TITLE
throw exception instead of using Panic in the TestSuite.php

### DIFF
--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -101,7 +101,7 @@ final class TestSuite
         }
 
         if (! self::$instance instanceof self) {
-            Panic::with(new InvalidPestCommand);
+            throw new InvalidPestCommand;
         }
 
         return self::$instance;


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Hi, I'm working on API Platform and we're trying to build _autoconfigurable_ interfaces. To do so, we need to loop over a set of PHP files, gather the PHP class and check its interfaces to automatically create services. 
If we always use PSR-4 we could use the filename to get a class name but the easiest is just to `require_once file.php` then to loop over `get_declared_classes` see https://github.com/api-platform/core/blob/main/src/Metadata/Util/ReflectionClassRecursiveIterator.php#L47-L89. 

Now we're using this to avoid issues: 

```
                    try {
                        require_once $sourceFile;
                    } catch (\Throwable) {
                        // invalid PHP file (example: missing parent class)
                        continue;
                    }
```

With Pest, we use `Panic` inside the `TestSuite` executing `exit 1`. I suggest that we let the TestSuite throw, as anyways the `bin/pest` already does:

https://github.com/pestphp/pest/blob/ed70c9dc2b6ed2ded11a2784f3a80963ddf9b87d/bin/pest#L186-L189