### PR TITLE
[Feature] Skip tests based on current environment

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -361,7 +361,7 @@ final class TestCall // @phpstan-ignore-line
      */
     private function skipOnEnvironment(string $environment): self
     {
-        if(Environment::name() === $environment) {
+        if (Environment::name() === $environment) {
             return $this->skip(sprintf('This test is skipped on %s.', $environment));
         }
 

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -12,6 +12,7 @@ use Pest\Factories\Attribute;
 use Pest\Factories\TestCaseMethodFactory;
 use Pest\Mutate\Repositories\ConfigurationRepository;
 use Pest\PendingCalls\Concerns\Describable;
+use Pest\Plugins\Environment;
 use Pest\Plugins\Only;
 use Pest\Support\Backtrace;
 use Pest\Support\Container;
@@ -337,6 +338,50 @@ final class TestCall // @phpstan-ignore-line
     public function onlyOnLinux(): self
     {
         return $this->skipOnWindows()->skipOnMac();
+    }
+
+    /**
+     * Skips the current test if the given test is running on CI.
+     */
+    public function skipOnCi(): self
+    {
+        return $this->skipOnEnvironment(Environment::CI);
+    }
+
+    /**
+     * Skips the current test if the given test is running on Local.
+     */
+    public function skipOnLocal(): self
+    {
+        return $this->skipOnEnvironment(Environment::LOCAL);
+    }
+
+    /**
+     * Skips the current test if the given test is running on the given environment.
+     */
+    private function skipOnEnvironment(string $environment): self
+    {
+        if(Environment::name() === $environment) {
+            return $this->skip(sprintf('This test is skipped on %s.', $environment));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Skips the current test unless the given test is running on CI.
+     */
+    public function onlyOnCi(): self
+    {
+        return $this->skipOnLocal();
+    }
+
+    /**
+     * Skips the current test unless the given test is running on Local.
+     */
+    public function onlyOnLocal(): self
+    {
+        return $this->skipOnCi();
     }
 
     /**


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Skips tests based on the output of `Environment::name()` which is either `local` or `ci` depending on whether the `--ci` option is used.

This skip is handy if a test case shouldn't be executed on CI (or locally) due to platform, memory and/or time restrictions.
This could be an integration test utilizing an external API which cannot be mocked properly that can't/shouldn't be called from CI.

It could be handled manually, but since the `Environment` class is marked as `@internal` code inspections locally would mark it as an issue.

Style inspiration taken from `skipOnOs` aliases.

Added features:
 - `skipOnLocal` skips test on `local`
 - `skipOnCi` skips test on `ci`
 - `onlyOnLocal` skips test if not on `local`
 - `onlyOnCi` skips test if not on `ci`
