### PR TITLE
fix: initialize $__latestDescription to prevent fatal error with empty datasets

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -466,7 +466,7 @@ trait Testable
      */
     public static function getLatestPrintableTestCaseMethodName(): string
     {
-        return self::$__latestDescription;
+        return self::$__latestDescription ?? '';
     }
 
     /**


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This fixes a fatal error caused when accessing the static property `$__latestDescription` before it was initialized. The error occurs in specific situations where a conditional dataset returns an empty array.

### Related:

#1384