### PR TITLE
[4.x] Remove Language Option from Profanity Composer Script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "lint": "pint",
         "test:refacto": "rector --dry-run",
         "test:lint": "pint --test",
-        "test:profanity": "php bin/pest --profanity --compact --language=en",
+        "test:profanity": "php bin/pest --profanity --compact",
         "test:type:check": "phpstan analyse --ansi --memory-limit=-1 --debug",
         "test:type:coverage": "php -d memory_limit=-1  bin/pest --type-coverage --min=100",
         "test:unit": "php bin/pest --exclude-group=integration --compact",


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

I was speaking to Nuno on Discord about making `en` the default language used for the Profanity plugin, which is now done (https://github.com/pestphp/pest-plugin-profanity/commit/36a3df5d18977807d735997ea31bfd9baddd3f07). This PR simplifies the composer script to not specify the language, given it's already the default. 
