### PR TITLE
Remove Period from `ShouldNotHappen` message

### DIFF
--- a/src/Exceptions/ShouldNotHappen.php
+++ b/src/Exceptions/ShouldNotHappen.php
@@ -20,7 +20,7 @@ final class ShouldNotHappen extends RuntimeException
         $message = $exception->getMessage();
 
         parent::__construct(sprintf(<<<'EOF'
-This should not happen - please create an new issue here: https://github.com/pestphp/pest
+This should not happen - please create an new issue here: https://github.com/pestphp/pest/issues
 
   Issue: %s
   PHP version: %s

--- a/src/Exceptions/ShouldNotHappen.php
+++ b/src/Exceptions/ShouldNotHappen.php
@@ -20,7 +20,7 @@ final class ShouldNotHappen extends RuntimeException
         $message = $exception->getMessage();
 
         parent::__construct(sprintf(<<<'EOF'
-This should not happen - please create an new issue here: https://github.com/pestphp/pest.
+This should not happen - please create an new issue here: https://github.com/pestphp/pest
 
   Issue: %s
   PHP version: %s


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

I noticed this when my GitHub runner threw a `ShouldNotHappen` exception because of an issue that https://github.com/pestphp/pest/pull/1409 addresses. Clicking through to the repo results in a 404 because the period is being treat as part of the URL. This PR simply removes that period and replaces it with `/issues` so that the user is redirected straight to the issues page.
