### PR TITLE
[4.x] Throw a fatal exception if the tests directory does not exist

### DIFF
--- a/src/Bootstrappers/BootFiles.php
+++ b/src/Bootstrappers/BootFiles.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Bootstrappers;
 
 use Pest\Contracts\Bootstrapper;
+use Pest\Exceptions\FatalException;
 use Pest\Support\DatasetInfo;
 use Pest\Support\Str;
 use Pest\TestSuite;
@@ -39,6 +40,10 @@ final class BootFiles implements Bootstrapper
     {
         $rootPath = TestSuite::getInstance()->rootPath;
         $testsPath = $rootPath.DIRECTORY_SEPARATOR.testDirectory();
+
+        if (! is_dir($testsPath)) {
+            throw new FatalException(sprintf('The test directory [%s] does not exist.', $testsPath));
+        }
 
         foreach (self::STRUCTURE as $filename) {
             $filename = sprintf('%s%s%s', $testsPath, DIRECTORY_SEPARATOR, $filename);


### PR DESCRIPTION
## Summary
This PR throws a `FatalException` when the configured `test-directory` for running tests does not exist, increasing the resilience the test runner needs to have the directory specified (e.g. in a modular application).

```bash
pest -c ./phpunit.xml.dist --test-directory=./modules/currency-conversion/tests
```

## The Problem
If you incorrectly type the directory path for the `--test-directory` flag, for example a missing `r` in `conversion`:

```bash
pest -c ./phpunit.xml.dist --test-directory=./modules/currency-convesion/tests
```

The tests still run, but without applying any `Pest.php`, `Helpers.php`, or `Expectations.php` files.

This can lead to tests incorrectly returning a false positive. For example, any mock service bindings applied to a test suite via `uses(MockServiceBindings)->in('Unit')` might resolve to real instances (for example `Stripe` instead of `FakeStripe` and then fail coz the real service performance a HTTP call instead of using in-memory storage.

## Explanation
Take a payment provider for instance. The app may utilise a modular architecture and have a module, let's say, for handling invoicing and another module that handles currency conversion. The invoicing module can `composer require` the currency conversion module to convert invoices from GBP to USD for US customers.

To reduce duplicate dependency resolution and to improve IDE performance, we use the main projects vendor binaries within the module for things like PHPStan and Pest. Not doing causes cyclical dependency issues within the project and slows down IDE performance for IDE's such as PHPStorm. Because Pest (unlike PHPStan) does not have support for modular applications, we have to work around this by specifying the `phpunit` configuration and test directory like so: