### PR TITLE
[4.x] fix: respect --colors=never option in parallel mode

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -22,7 +22,8 @@ $bootPest = (static function (): void {
 
     $input = new ArgvInput;
 
-    $output = new ConsoleOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $isDecorated = $workerArgv->getParameterOption('--colors', 'always') !== 'never';
+    $output = new ConsoleOutput(OutputInterface::VERBOSITY_NORMAL, $isDecorated);
 
     Kernel::boot($testSuite, $input, $output);
 });

--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -16,6 +16,7 @@ use Pest\TestSuite;
 use Stringable;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 use function Pest\version;
 
@@ -127,7 +128,11 @@ final class Parallel implements HandlesArguments
             $arguments
         );
 
-        $exitCode = $this->paratestCommand()->run(new ArgvInput($filteredArguments), new CleanConsoleOutput);
+        $input = new ArgvInput($filteredArguments);
+        $isDecorated = $input->getParameterOption('--colors', 'always') !== 'never';
+        $output = new CleanConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);
+
+        $exitCode = $this->paratestCommand()->run($input, $output);
 
         return CallsAddsOutput::execute($exitCode);
     }

--- a/src/Plugins/Parallel/Paratest/ResultPrinter.php
+++ b/src/Plugins/Parallel/Paratest/ResultPrinter.php
@@ -81,7 +81,7 @@ final class ResultPrinter
             public function flush(): void {}
         };
 
-        $this->compactPrinter = CompactPrinter::default();
+        $this->compactPrinter = CompactPrinter::create($this->output->isDecorated());
 
         if (! $this->options->configuration->hasLogfileTeamcity()) {
             return;

--- a/src/Plugins/Parallel/Support/CompactPrinter.php
+++ b/src/Plugins/Parallel/Support/CompactPrinter.php
@@ -60,16 +60,24 @@ final class CompactPrinter
     }
 
     /**
+     * Creates a new instance of the Compact Printer with decoration setting.
+     */
+    public static function create(bool $decorated): self
+    {
+        return new self(
+            terminal(),
+            new ConsoleOutput(decorated: $decorated),
+            new Style(new ConsoleOutput(decorated: $decorated)),
+            terminal()->width() - 4,
+        );
+    }
+
+    /**
      * Creates a new instance of the Compact Printer.
      */
     public static function default(): self
     {
-        return new self(
-            terminal(),
-            new ConsoleOutput(decorated: true),
-            new Style(new ConsoleOutput(decorated: true)),
-            terminal()->width() - 4,
-        );
+        return self::create(true);
     }
 
     /**

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -23,3 +23,22 @@ test('parallel', function () use ($run) {
 test('a parallel test can extend another test with same name', function () use ($run) {
     expect($run('tests/Fixtures/Inheritance'))->toContain('Tests:    1 skipped, 2 passed (2 assertions)');
 });
+
+test('parallel mode respects --colors=never option', function () {
+    $process = new Process([
+        'php',
+        './bin/pest',
+        '--parallel',
+        '--processes=2',
+        '--colors=never',
+        'tests/Fixtures/DirectoryWithTests/ExampleTest.php',
+    ], dirname(__DIR__, 2), ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true']);
+    $process->run();
+    $output = $process->getOutput();
+
+    // Output should not contain ANSI color codes when --colors=never is used
+    expect($output)
+        ->not->toMatch('/\x1b\[[0-9;]*m/')  // ANSI color codes pattern
+        ->toContain('Tests:')               // Should still have test output
+        ->toContain('Parallel:');           // Should still indicate parallel mode
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

See the 3.x PR #1430 

Fixes issue where `--colors=never` option was being disregarded when using `--parallel` flag.

**Problem:**
When running tests with both `--parallel` and `--colors=never` options, ANSI color codes were still being output, inconsistent with non-parallel mode behavior.

**Root Cause:**
The issue occurred in three places:

1. **Worker processes** (`bin/worker.php`): Were hardcoded to use decorated output (`true`)
2. **Main parallel process** (`src/Plugins/Parallel.php`): Was not passing decoration setting to `CleanConsoleOutput`  
3. **Progress printer** (`CompactPrinter`): Was hardcoded to use decorated output

**Solution:**
- Modified worker processes to respect the `--colors` parameter from command line arguments
- Updated main parallel process to check `--colors` option and pass decoration setting to output
- Added `CompactPrinter::create()` method to accept decoration parameter and updated `ResultPrinter` to use it

**Testing:**
- Added test case to verify `--colors=never` works correctly in parallel mode
- Verified existing functionality still works
- Manual testing confirms ANSI codes are properly suppressed when `--colors=never` is used with `--parallel`

```bash
# This should show NO ANSI color codes
vendor/bin/pest --parallel --colors=never

# This should show ANSI color codes (default behavior)  
vendor/bin/pest --parallel --colors=always
```

### Related:

Closes #1258