### PR TITLE
feat: add toBeCasedCorrectly arch test assertion

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -18,6 +18,7 @@ use Pest\Arch\Expectations\ToOnlyUse;
 use Pest\Arch\Expectations\ToUse;
 use Pest\Arch\Expectations\ToUseNothing;
 use Pest\Arch\PendingArchExpectation;
+use Pest\Arch\Support\Composer;
 use Pest\Arch\Support\FileLineFinder;
 use Pest\Concerns\Extendable;
 use Pest\Concerns\Pipeable;
@@ -667,6 +668,41 @@ final class Expectation
     public function toHavePrivateMethods(): void
     {
         throw InvalidExpectation::fromMethods(['toHavePrivateMethods']);
+    }
+
+    /**
+     * Asserts that the given expectation target is cased correctly.
+     */
+    public function toBeCasedCorrectly(): ArchExpectation
+    {
+        return Targeted::make(
+            $this,
+            function (ObjectDescription $object): bool {
+                if (! isset($object->reflectionClass)) {
+                    return false;
+                }
+
+                $realPath = realpath($object->path);
+
+                foreach (Composer::userNamespaces() as $directory => $namespace) {
+                    if (str_starts_with($realPath, $directory)) {
+                        $relativePath = substr($realPath, strlen($directory) + 1);
+                        $relativePath = explode('.', $relativePath)[0];
+                        $classFromPath = $namespace . '\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $relativePath);
+
+                        if ($classFromPath === $object->reflectionClass->getName()) {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                }
+
+                return false;
+            },
+            "to be cased correctly",
+            FileLineFinder::where(fn (string $line): bool => str_contains($line, 'class')),
+        );
     }
 
     /**

--- a/tests/Features/Expect/toBeCasedCorrectly.php
+++ b/tests/Features/Expect/toBeCasedCorrectly.php
@@ -1,0 +1,12 @@
+<?php
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('pass')
+    ->expect('Tests\Fixtures\Arch\ToBeCasedCorrectly\CorrectCasing')
+    ->toBeCasedCorrectly();
+
+test('failure')
+    ->expect('Tests\Fixtures\Arch\ToBeCasedCorrectly\IncorrectCasing')
+    ->toBeCasedCorrectly()
+    ->throws(ArchExpectationFailedException::class);

--- a/tests/Fixtures/Arch/ToBeCasedCorrectly/CorrectCasing/CorrectCasing.php
+++ b/tests/Fixtures/Arch/ToBeCasedCorrectly/CorrectCasing/CorrectCasing.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\ToBeCasedCorrectly\CorrectCasing;
+
+class CorrectCasing {}

--- a/tests/Fixtures/Arch/ToBeCasedCorrectly/IncorrectCasing/incorrectCasing.php
+++ b/tests/Fixtures/Arch/ToBeCasedCorrectly/IncorrectCasing/incorrectCasing.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\ToBeCasedCorrectly\IncorrectCasing;
+
+class IncorrectCasing {}

--- a/tests/Fixtures/Arch/ToBeCasedCorrectly/incorrectDirectoryCasing/CorrectCasing.php
+++ b/tests/Fixtures/Arch/ToBeCasedCorrectly/incorrectDirectoryCasing/CorrectCasing.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\ToBeCasedCorrectly\IncorrectDirectoryCasing;
+
+class CorrectCasing {}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds a new arch test assertion that compares the file path and namespace casing with each other to detect casing errors.

As most developers work on Mac OS or Windows, which by default have case insensitive file systems, these casing spelling errors might not be caught until deployed on linux environments. 

This feature helps solve this issue by comparing both namespace and file path with each other. 

### Important:

This PR depends on the following PR in the `pest-plugin-arch` plugin: https://github.com/pestphp/pest-plugin-arch/pull/27

### Example:

File path: `app/Providers/AppServiceProvider.php`

```php
<?php

namespace App\providers

class AppServiceProvider {}
```

The wrongly cased namespace part 'providers' will not cause a 'Class not found' exception on Mac OS, but will on linux.

With this feature, we can add the following test:

```php
arch()
    ->expect('App')
    ->toBeCasedCorrectly();
```

This will catch the miss-cased namespaces / file paths
