### PR TITLE
Prevent duplicate attributes

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -759,7 +759,12 @@ final class TestCall // @phpstan-ignore-line
         $this->testSuite->tests->set($this->testCaseMethod);
 
         if (! is_null($testCase = $this->testSuite->tests->get($this->filename))) {
-            $testCase->attributes = array_merge($testCase->attributes, $this->testCaseFactoryAttributes);
+            $attributesToMerge = array_filter(
+                $this->testCaseFactoryAttributes,
+                fn (Attribute $attributeToMerge): bool => array_filter($testCase->attributes, fn (Attribute $attribute): bool => serialize($attributeToMerge) === serialize($attribute)) === []
+            );
+
+            $testCase->attributes = array_merge($testCase->attributes, $attributesToMerge);
         }
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When using `covers()` in a test file, it adds the `Covers` attribute multiple times to the PHPUnit test class (one per test). Since PHPUnit 12.2 duplicate `Covers` attributes will result in a warning: https://github.com/sebastianbergmann/phpunit/commit/b9c8a7b3786b526efedc77c64b3ff2d8e8b2157c

This PR fixes this by checking if the same attribute already exists before it is added to the test case attributes.
