### PR TITLE
[4.x] Fixes `--processes` argument combined with sharding

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -100,7 +100,33 @@ final class Shard implements AddsOutput, HandlesArguments
      */
     private function removeParallelArguments(array $arguments): array
     {
-        return array_filter($arguments, fn (string $argument): bool => ! in_array($argument, ['--parallel', '-p'], strict: true));
+        $filtered = [];
+        $skipNext = false;
+
+        foreach ($arguments as $argument) {
+            if ($skipNext) {
+                $skipNext = false;
+
+                continue;
+            }
+
+            if (in_array($argument, ['--parallel', '-p'], strict: true)) {
+                continue;
+            }
+
+            if (str_starts_with($argument, '--processes')) {
+                if (str_contains($argument, '=')) {
+                    continue;
+                }
+                $skipNext = true;
+
+                continue;
+            }
+
+            $filtered[] = $argument;
+        }
+
+        return $filtered;
     }
 
     /**

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -85,7 +85,7 @@ final class Shard implements AddsOutput, HandlesArguments
     {
         $output = (new Process([
             'php',
-            ...$this->removeParallelArguments($arguments),
+            ...$this->removeParallelizationArguments($arguments),
             '--list-tests',
         ]))->mustRun()->getOutput();
 
@@ -95,38 +95,52 @@ final class Shard implements AddsOutput, HandlesArguments
     }
 
     /**
+     * Removes both parallel and processes arguments from the arguments array.
+     * This is useful when running commands that don't support parallel execution.
+     *
+     * @param  array<int, string>  $arguments
+     * @return array<int, string>
+     */
+    private function removeParallelizationArguments(array $arguments): array
+    {
+        return $this->removeProcessesArguments($this->removeParallelArguments($arguments));
+    }
+
+    /**
      * @param  array<int, string>  $arguments
      * @return array<int, string>
      */
     private function removeParallelArguments(array $arguments): array
     {
-        $filtered = [];
-        $skipNext = false;
+        return array_filter($arguments, fn (string $argument): bool => ! in_array($argument, ['--parallel', '-p'], strict: true));
+    }
 
-        foreach ($arguments as $argument) {
+    /**
+     * @param  array<int, string>  $arguments
+     * @return array<int, string>
+     */
+    private function removeProcessesArguments(array $arguments): array
+    {
+        return array_values(array_filter($arguments, function (string $argument) {
+            if (str_starts_with($argument, '--processes') && str_contains($argument, '=')) {
+                return false;
+            }
+
+            static $skipNext = false;
             if ($skipNext) {
                 $skipNext = false;
 
-                continue;
+                return false;
             }
 
-            if (in_array($argument, ['--parallel', '-p'], strict: true)) {
-                continue;
-            }
-
-            if (str_starts_with($argument, '--processes')) {
-                if (str_contains($argument, '=')) {
-                    continue;
-                }
+            if ($argument === '--processes') {
                 $skipNext = true;
 
-                continue;
+                return false;
             }
 
-            $filtered[] = $argument;
-        }
-
-        return $filtered;
+            return true;
+        }));
     }
 
     /**

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -1,0 +1,76 @@
+<?php
+
+use Pest\Plugins\Shard;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+it('processes arguments with sharding and removes parallel options from subprocess', function () {
+    $output = new BufferedOutput;
+    $shard = new Shard($output);
+
+    // Use reflection to test the private removeParallelArguments method
+    $reflection = new ReflectionClass($shard);
+    $method = $reflection->getMethod('removeParallelArguments');
+    $method->setAccessible(true);
+
+    $arguments = [
+        'php',
+        'bin/pest',
+        '--processes=12',
+        '--parallel',
+        '--shard=1/4',
+        '--verbose',
+    ];
+
+    $result = $method->invoke($shard, $arguments);
+
+    expect($result)->toBe(['php', 'bin/pest', '--shard=1/4', '--verbose'])
+        ->and($result)->not->toContain('--processes=12')
+        ->and($result)->not->toContain('--parallel');
+});
+
+it('removes space-separated processes arguments', function () {
+    $output = new BufferedOutput;
+    $shard = new Shard($output);
+
+    $reflection = new ReflectionClass($shard);
+    $method = $reflection->getMethod('removeParallelArguments');
+    $method->setAccessible(true);
+
+    $arguments = [
+        'php',
+        'bin/pest',
+        '--processes',
+        '8',
+        '--parallel',
+        '--other-flag',
+    ];
+
+    $result = $method->invoke($shard, $arguments);
+
+    expect($result)->toBe(['php', 'bin/pest', '--other-flag'])
+        ->and($result)->not->toContain('--processes')
+        ->and($result)->not->toContain('8')
+        ->and($result)->not->toContain('--parallel');
+});
+
+it('preserves non-parallel arguments when filtering', function () {
+    $output = new BufferedOutput;
+    $shard = new Shard($output);
+
+    $reflection = new ReflectionClass($shard);
+    $method = $reflection->getMethod('removeParallelArguments');
+    $method->setAccessible(true);
+
+    $arguments = [
+        'php',
+        'bin/pest',
+        '--filter',
+        'UserTest',
+        '--verbose',
+        '--stop-on-failure',
+    ];
+
+    $result = $method->invoke($shard, $arguments);
+
+    expect($result)->toBe($arguments); // Should be unchanged
+});

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -7,9 +7,9 @@ it('processes arguments with sharding and removes parallel options from subproce
     $output = new BufferedOutput;
     $shard = new Shard($output);
 
-    // Use reflection to test the private removeParallelArguments method
+    // Use reflection to test the private removeParallelizationArguments method
     $reflection = new ReflectionClass($shard);
-    $method = $reflection->getMethod('removeParallelArguments');
+    $method = $reflection->getMethod('removeParallelizationArguments');
     $method->setAccessible(true);
 
     $arguments = [
@@ -33,7 +33,7 @@ it('removes space-separated processes arguments', function () {
     $shard = new Shard($output);
 
     $reflection = new ReflectionClass($shard);
-    $method = $reflection->getMethod('removeParallelArguments');
+    $method = $reflection->getMethod('removeParallelizationArguments');
     $method->setAccessible(true);
 
     $arguments = [
@@ -58,7 +58,7 @@ it('preserves non-parallel arguments when filtering', function () {
     $shard = new Shard($output);
 
     $reflection = new ReflectionClass($shard);
-    $method = $reflection->getMethod('removeParallelArguments');
+    $method = $reflection->getMethod('removeParallelizationArguments');
     $method->setAccessible(true);
 
     $arguments = [

--- a/tests/Visual/Shard.php
+++ b/tests/Visual/Shard.php
@@ -1,0 +1,48 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+test('shard works with processes option - fixes bug #1454', function () {
+    $process = new Process([
+        'php',
+        'bin/pest',
+        '--processes=4',
+        '--shard=1/2',
+        '--parallel',
+        'tests/Fixtures/ExampleTest.php',
+    ], dirname(__DIR__, 2), [
+        'COLLISION_PRINTER' => 'DefaultPrinter',
+        'COLLISION_IGNORE_DURATION' => 'true',
+    ]);
+
+    $process->run();
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())
+        ->not->toContain('Unknown option "--processes"')
+        ->toContain('Tests:')
+        ->toContain('Shard:');
+})->skipOnWindows();
+
+test('shard removes processes from list-tests subprocess call', function () {
+    // This test verifies that --processes doesn't get passed to the --list-tests call
+    $process = new Process([
+        'php',
+        'bin/pest',
+        '--processes=2',
+        '--shard=1/1',
+        '--parallel',
+        'tests/Fixtures/ExampleTest.php',
+    ], dirname(__DIR__, 2), [
+        'COLLISION_PRINTER' => 'DefaultPrinter',
+        'COLLISION_IGNORE_DURATION' => 'true',
+    ]);
+
+    $process->run();
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())
+        ->not->toContain('Unknown option "--processes"')
+        ->not->toContain('The "--processes" option requires a value')
+        ->toContain('Shard:'); // Just check that shard output exists, don't be too specific
+})->skipOnWindows();


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->
Fixes #1454

When you try to use sharding since it has to see what tests, process is an illegal argument for that. I tried adding it to the array that filters out parallel, but it doesn't work because of the `=` i think. So I made a simple filter to get it
