### PR TITLE
BugFix: Fix toUseTrait to detect inherited and nested traits

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -781,7 +781,22 @@ final class Expectation
                         return false;
                     }
 
-                    if (! in_array($trait, $object->reflectionClass->getTraitNames(), true)) {
+                    $currentClass = $object->reflectionClass;
+                    $usedTraits = [];
+
+                    do {
+                        $classTraits = $currentClass->getTraits();
+                        foreach ($classTraits as $traitReflection) {
+                            $usedTraits[$traitReflection->getName()] = $traitReflection->getName();
+
+                            $nestedTraits = $traitReflection->getTraits();
+                            foreach ($nestedTraits as $nestedTrait) {
+                                $usedTraits[$nestedTrait->getName()] = $nestedTrait->getName();
+                            }
+                        }
+                    } while ($currentClass = $currentClass->getParentClass());
+
+                    if (! array_key_exists($trait, $usedTraits)) {
                         return false;
                     }
                 }

--- a/tests/Features/Expect/toUseTrait.php
+++ b/tests/Features/Expect/toUseTrait.php
@@ -14,3 +14,19 @@ test('failures', function () {
 test('not failures', function () {
     expect('Pest\Expectations\HigherOrderExpectation')->not->toUseTrait('Pest\Concerns\Retrievable');
 })->throws(ArchExpectationFailedException::class);
+
+test('trait inheritance - direct usage', function () {
+    expect('Tests\Fixtures\Arch\ToUseTrait\HasTrait\ParentClassWithTrait')->toUseTrait('Tests\Fixtures\Arch\ToUseTrait\HasTrait\TestTraitForInheritance');
+});
+
+test('trait inheritance - inherited usage', function () {
+    expect('Tests\Fixtures\Arch\ToUseTrait\HasInheritedTrait\ChildClassExtendingParent')->toUseTrait('Tests\Fixtures\Arch\ToUseTrait\HasTrait\TestTraitForInheritance');
+});
+
+test('trait inheritance - negative case', function () {
+    expect('Tests\Fixtures\Arch\ToUseTrait\HasInheritedTrait\ChildClassExtendingParent')->not->toUseTrait('NonExistentTrait');
+});
+
+test('nested trait inheritance', function () {
+    expect('Tests\Fixtures\Arch\ToUseTrait\HasInheritedTrait\ChildClassExtendingParent')->toUseTrait('Tests\Fixtures\Arch\ToUseTrait\HasNestedTrait\NestedTrait');
+});

--- a/tests/Fixtures/Arch/ToUseTrait/HasInheritedTrait/ChildClassExtendingParent.php
+++ b/tests/Fixtures/Arch/ToUseTrait/HasInheritedTrait/ChildClassExtendingParent.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait\HasInheritedTrait;
+
+use Tests\Fixtures\Arch\ToUseTrait\HasTrait\ParentClassWithTrait;
+
+class ChildClassExtendingParent extends ParentClassWithTrait
+{
+}

--- a/tests/Fixtures/Arch/ToUseTrait/HasNestedTrait/NestedTrait.php
+++ b/tests/Fixtures/Arch/ToUseTrait/HasNestedTrait/NestedTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait\HasNestedTrait;
+
+trait NestedTrait
+{
+    public function nestedMethod()
+    {
+        return 'nested';
+    }
+}

--- a/tests/Fixtures/Arch/ToUseTrait/HasTrait/ParentClassWithTrait.php
+++ b/tests/Fixtures/Arch/ToUseTrait/HasTrait/ParentClassWithTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait\HasTrait;
+
+class ParentClassWithTrait
+{
+    use TestTraitForInheritance;
+}

--- a/tests/Fixtures/Arch/ToUseTrait/HasTrait/TestTraitForInheritance.php
+++ b/tests/Fixtures/Arch/ToUseTrait/HasTrait/TestTraitForInheritance.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseTrait\HasTrait;
+
+use Tests\Fixtures\Arch\ToUseTrait\HasNestedTrait\NestedTrait;
+
+trait TestTraitForInheritance
+{
+    use NestedTrait;
+
+    public function testMethod()
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
### What:

-   [x] Bug Fix
-   [ ] New Feature

### Description:

The `toUseTrait` expectation was failing to detect traits in inheritance scenarios. When a class extends another class that uses a trait, `toUseTrait` would incorrectly return false.

**Problem:**

```php
use Illuminate\Foundation\Queue\Queueable;

abstract class Job
{
    use Queueable;
}

class ProcessPayment extends Job
{
    // Inherits Queueable trait from Job
}

arch('that jobs are queued properly')
    ->expect('App\Jobs')
    ->toUseTrait('Illuminate\Foundation\Queue\Queueable'); // Failed
```

**Root cause:** Only checked `getTraitNames()` which returns directly used traits, not inherited ones.

**Solution:** Updated to use `ReflectionClass->getTraits()` and walk the inheritance chain with `getParentClass()`. Also handles nested traits.

**After fix:**

```php
arch('that jobs are queued properly')
    ->expect('App\Jobs')
    ->expect('App\Jobs')->toUseTrait('Illuminate\Foundation\Queue\Queueable'); // Now passes

# Also works with other common Laravel patterns:
arch('that jobs serialize models properly')
    ->expect('App\Jobs')
    ->toUseTrait('Illuminate\Queue\SerializesModels');
```

Added test coverage for direct usage, inheritance, and nested traits.
