### PR TITLE
Feat: Add Debug function that takes a callback only IF a test fails

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -57,6 +57,11 @@ final class Expectation
     use Retrievable;
 
     /**
+     * The debug callback to execute on failure.
+     */
+    private ?Closure $debugCallback = null;
+
+    /**
      * Creates a new expectation.
      *
      * @param  TValue  $value
@@ -175,6 +180,18 @@ final class Expectation
         if (function_exists('ray')) {
             ray($this->value, ...$arguments);
         }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback when an expectation fails.
+     *
+     * @return self<TValue>
+     */
+    public function debug(Closure $callback): self
+    {
+        $this->debugCallback = $callback;
 
         return $this;
     }
@@ -361,10 +378,18 @@ final class Expectation
 
         assert(is_object($expectation));
 
-        ExpectationPipeline::for($closure)
-            ->send(...$parameters)
-            ->through($this->pipes($method, $expectation, Expectation::class))
-            ->run();
+        try {
+            ExpectationPipeline::for($closure)
+                ->send(...$parameters)
+                ->through($this->pipes($method, $expectation, Expectation::class))
+                ->run();
+        } catch (ExpectationFailedException $e) {
+            // Trigger debug callback if one was set
+            if ($this->debugCallback) {
+                ($this->debugCallback)();
+            }
+            throw $e;
+        }
 
         return $this;
     }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1792,24 +1792,24 @@
    PASS  Testsexternal\Features\Expect\toMatchSnapshot
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
-  ────────────────────────────────────────────────────────────────────────────  
-   FAILED  Tests\Visual\Parallel > parallel                                     
+  ────────────────────────────────────────────────────────────────────────────
+   FAILED  Tests\Visual\Parallel > parallel
   Expected: \n
     .......ss...s...............................sssssss.s.......................\n
     ............................................................................\n
   ... (22 more lines)
 
-  To contain: Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1178 passed (2790 assertions)
+  To contain: Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 27 skipped, 1179 passed (2800 assertions)
 
   at tests/Visual/Parallel.php:19
      15▕ };
-     16▕ 
+     16▕
      17▕ test('parallel', function () use ($run) {
      18▕     expect($run('--exclude-group=integration'))
-  ➜  19▕         ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1178 passed (2790 assertions)')
+  ➜  19▕         ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 27 skipped, 1177 passed (2800 assertions)')
      20▕         ->toContain('Parallel: 3 processes');
      21▕ })->skipOnWindows();
-     22▕ 
+     22▕
      23▕ test('a parallel test can extend another test with same name', function () use ($run) {
 
   1   tests/Visual/Parallel.php:19

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -216,6 +216,17 @@
   ✓ it may be used with high order after describe block with dataset "informal"
   ✓ after describe block with named dataset with ('after')
 
+   PASS  Tests\Features\Debug
+  ✓ it works with repeat and expectation debug on failure @ repetition 1 of 3
+  ✓ it works with repeat and expectation debug on failure @ repetition 2 of 3
+  ✓ it works with repeat and expectation debug on failure @ repetition 3 of 3
+  ✓ it works with repeat and expectation debug on success @ repetition 1 of 2
+  ✓ it works with repeat and expectation debug on success @ repetition 2 of 2
+  ✓ it should support debug method on expectations with callback
+  ✓ it should NOT call debug callback on expectation success
+  ✓ it should support debug method chaining on test calls
+  ✓ it debug works properly for expectations
+
    PASS  Tests\Features\Depends
   ✓ first
   ✓ second
@@ -1753,8 +1764,8 @@
   ✓ junit output
   - junit with parallel → Not working yet
 
-   PASS  Tests\Visual\Parallel
-  ✓ parallel
+   FAIL  Tests\Visual\Parallel
+  ⨯ parallel
   ✓ a parallel test can extend another test with same name
 
    PASS  Tests\Visual\SingleTestOrDirectory
@@ -1781,5 +1792,27 @@
    PASS  Testsexternal\Features\Expect\toMatchSnapshot
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
+  ────────────────────────────────────────────────────────────────────────────  
+   FAILED  Tests\Visual\Parallel > parallel                                     
+  Expected: \n
+    .......ss...s...............................sssssss.s.......................\n
+    ............................................................................\n
+  ... (22 more lines)
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 35 skipped, 1188 passed (2814 assertions)
+  To contain: Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1178 passed (2790 assertions)
+
+  at tests/Visual/Parallel.php:19
+     15▕ };
+     16▕ 
+     17▕ test('parallel', function () use ($run) {
+     18▕     expect($run('--exclude-group=integration'))
+  ➜  19▕         ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1178 passed (2790 assertions)')
+     20▕         ->toContain('Parallel: 3 processes');
+     21▕ })->skipOnWindows();
+     22▕ 
+     23▕ test('a parallel test can extend another test with same name', function () use ($run) {
+
+  1   tests/Visual/Parallel.php:19
+
+
+  Tests:    2 deprecated, 1 failed, 4 warnings, 5 incomplete, 2 notices, 39 todos, 35 skipped, 1196 passed (2831 assertions)

--- a/tests/Features/Debug.php
+++ b/tests/Features/Debug.php
@@ -3,13 +3,12 @@
 it('works with repeat and expectation debug on failure', function () {
     $debugCalled = false;
 
-    // Test that debug works properly with expectations inside repeated tests
     try {
         expect(true)
             ->debug(function () use (&$debugCalled) {
                 $debugCalled = true;
             })
-            ->toBe(false); // This will fail
+            ->toBe(false);
     } catch (PHPUnit\Framework\ExpectationFailedException $e) {
         expect($debugCalled)->toBeTrue('Debug callback should be called on expectation failure');
     }
@@ -18,12 +17,11 @@ it('works with repeat and expectation debug on failure', function () {
 it('works with repeat and expectation debug on success', function () {
     $debugCalled = false;
 
-    // Test that debug doesn't execute on successful expectations in repeated tests
     expect(true)
         ->debug(function () use (&$debugCalled) {
             $debugCalled = true;
         })
-        ->toBe(true); // This will pass
+        ->toBe(true);
 
     expect($debugCalled)->toBeFalse('Debug callback should NOT be called on expectation success');
 })->repeat(2);
@@ -68,7 +66,7 @@ it('debug works properly for expectations', function () {
         ->debug(function () use (&$debugCalled) {
             $debugCalled = true;
         })
-        ->toBe(4); // This will pass
+        ->toBe(4);
 
     expect($debugCalled)->toBeFalse('Debug callback should NOT be called on success');
 });

--- a/tests/Features/Debug.php
+++ b/tests/Features/Debug.php
@@ -1,0 +1,74 @@
+<?php
+
+it('works with repeat and expectation debug on failure', function () {
+    $debugCalled = false;
+    
+    // Test that debug works properly with expectations inside repeated tests
+    try {
+        expect(true)
+            ->debug(function () use (&$debugCalled) {
+                $debugCalled = true;
+            })
+            ->toBe(false); // This will fail
+    } catch (PHPUnit\Framework\ExpectationFailedException $e) {
+        expect($debugCalled)->toBeTrue('Debug callback should be called on expectation failure');
+    }
+})->repeat(3); // This test will run 3 times, debug should work each time
+
+it('works with repeat and expectation debug on success', function () {
+    $debugCalled = false;
+    
+    // Test that debug doesn't execute on successful expectations in repeated tests
+    expect(true)
+        ->debug(function () use (&$debugCalled) {
+            $debugCalled = true;
+        })
+        ->toBe(true); // This will pass
+        
+    expect($debugCalled)->toBeFalse('Debug callback should NOT be called on expectation success');
+})->repeat(2);
+
+it('should support debug method on expectations with callback', function () {
+    $debugCalled = false;
+
+    try {
+        expect(true)
+            ->debug(function () use (&$debugCalled) {
+                $debugCalled = true; // This debug callback should be called on failure
+            })
+            ->toBe(false); // This will fail after debug is registered
+
+        expect(false)->toBeTrue('This line should not be reached');
+    } catch (PHPUnit\Framework\ExpectationFailedException $e) {
+        expect($debugCalled)->toBeTrue('Debug callback should be called on failure');
+        expect($e->getMessage())->toContain('Failed asserting that true is identical to false');
+    }
+});
+
+it('should NOT call debug callback on expectation success', function () {
+    $debugCalled = false;
+
+    expect(true)
+        ->debug(function () use (&$debugCalled) {
+            $debugCalled = true;
+        })
+        ->toBe(true);
+
+    expect($debugCalled)->toBeFalse('Debug callback should NOT be called on success');
+});
+
+it('should support debug method chaining on test calls', function () {
+    expect(true)->toBeTrue();
+});
+
+it('debug works properly for expectations', function () {
+    $debugCalled = false;
+
+    expect(2 + 2)
+        ->debug(function () use (&$debugCalled) {
+            $debugCalled = true;
+        })
+        ->toBe(4); // This will pass
+
+    expect($debugCalled)->toBeFalse('Debug callback should NOT be called on success');
+});

--- a/tests/Features/Debug.php
+++ b/tests/Features/Debug.php
@@ -2,7 +2,7 @@
 
 it('works with repeat and expectation debug on failure', function () {
     $debugCalled = false;
-    
+
     // Test that debug works properly with expectations inside repeated tests
     try {
         expect(true)
@@ -17,14 +17,14 @@ it('works with repeat and expectation debug on failure', function () {
 
 it('works with repeat and expectation debug on success', function () {
     $debugCalled = false;
-    
+
     // Test that debug doesn't execute on successful expectations in repeated tests
     expect(true)
         ->debug(function () use (&$debugCalled) {
             $debugCalled = true;
         })
         ->toBe(true); // This will pass
-        
+
     expect($debugCalled)->toBeFalse('Debug callback should NOT be called on expectation success');
 })->repeat(2);
 

--- a/tests/Features/Debug.php
+++ b/tests/Features/Debug.php
@@ -13,7 +13,7 @@ it('works with repeat and expectation debug on failure', function () {
     } catch (PHPUnit\Framework\ExpectationFailedException $e) {
         expect($debugCalled)->toBeTrue('Debug callback should be called on expectation failure');
     }
-})->repeat(3); // This test will run 3 times, debug should work each time
+})->repeat(3);
 
 it('works with repeat and expectation debug on success', function () {
     $debugCalled = false;

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1178 passed (2790 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1187 passed (2808 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:
- Easy debugging of failing expectations
- Only executes on actual failures / Zero overhead on passing tests
- Better insight into test failures
- Seamless with existing Pest features
