### PR TITLE
feat: add 'die' to expectations preset laravel

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -158,6 +158,7 @@ final class Laravel extends AbstractPreset
         $this->expectations[] = expect([
             'dd',
             'ddd',
+            'die',
             'dump',
             'env',
             'exit',


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

It adds the `die` command to the Laravel's preset expectations list.
