### PR TITLE
Fix Undefined array key "testdox-columns" warning

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -86,7 +86,7 @@ $bootPest = (static function (): void {
         $getopt['teamcity-file'] ?? null,
         $getopt['testdox-file'] ?? null,
         isset($getopt['testdox-color']),
-        (int) $getopt['testdox-columns'] ?? null,
+        (int) ($getopt['testdox-columns'] ?? null),
     );
 
     while (true) {


### PR DESCRIPTION
Fix `Undefined array key "testdox-columns"` warning

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

[This commit](https://github.com/pestphp/pest/commit/cd5272d8cc9f37e66dbfb3288895023075a40f57) didn't fully resolve the issue. We are still getting a warning `"Undefined array key "testdox-columns"` in version `4.1.2` if testdox-columns don't isset in `$getopt`.

https://3v4l.org/ggUUG