### PR TITLE
Specify closure this for extend

### DIFF
--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -8,6 +8,8 @@ use Closure;
 
 /**
  * @internal
+ *
+ * @template T of object
  */
 trait Extendable
 {
@@ -20,6 +22,8 @@ trait Extendable
 
     /**
      * Register a new extend.
+     *
+     * @param-closure-this T $extend
      */
     public function extend(string $name, Closure $extend): void
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -52,7 +52,9 @@ use ReflectionProperty;
  */
 final class Expectation
 {
+    /** @use Extendable<self<TValue>> */
     use Extendable;
+
     use Pipeable;
     use Retrievable;
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When extending `expect()`, we are met with `phpstan: Undefined variable: $this`. This is resolved by specifying what `$this` will refer to in the closure.

Example of what this PR fixes:

```php
expect()->extend('toBeTrashed', function () {
    Assert::assertThat(
        $this->value, // phpstan: Undefined variable: $this
        new class () extends Constraint {
            public function matches(mixed $other): bool
            {
                if (!($other instanceof Model && method_exists($other, 'trashed'))) {
                    throw new InvalidArgumentException('Can only be used on Models, not on queries.');
                }

                return $other->trashed();
            }

            public function toString(): string
            {
                return 'is trashed';
            }
        }
    );

    return $this; // phpstan: Undefined variable: $this
});