### PR TITLE
[4.x] Add --attempts cli flag and test method

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -117,6 +117,16 @@ use Symfony\Component\Console\Output\ConsoleOutput;
             $arguments[] = '--no-output';
             unset($_SERVER['COLLISION_PRINTER']);
         }
+
+        if (str_contains($value, '--attempts=')) {
+            unset($arguments[$key]);
+        } elseif ($value === '--attempts') {
+            unset($arguments[$key]);
+
+            if (isset($arguments[$key + 1])) {
+                unset($arguments[$key + 1]);
+            }
+        }
     }
 
     // Used when Pest is required using composer.
@@ -172,6 +182,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
     if ($pr = $input->getParameterOption('--pull-request')) {
         $testSuite->tests->addTestCaseMethodFilter(new PrTestCaseFilter((int) $pr));
+    }
+
+    if ($attempts = $input->getParameterOption('--attempts')) {
+        $testSuite->attempts = max(1, (int) $attempts);
     }
 
     $isDecorated = $input->getParameterOption('--colors', 'always') !== 'never';

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -328,7 +328,58 @@ trait Testable
         $arguments = $this->__resolveTestArguments($args);
         $this->__ensureDatasetArgumentNameAndNumberMatches($arguments);
 
-        return $this->__callClosure($closure, $arguments);
+        return $this->__attemptTestRun(fn () => $this->__callClosure($closure, $arguments));
+    }
+
+    private function __attemptTestRun(Closure $closure)
+    {
+        $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
+        $maxAttempts = max(1, max($method->attempts, TestSuite::getInstance()->attempts));
+
+        $lastException = null;
+        $attemptNumber = 1;
+
+        while ($attemptNumber <= $maxAttempts) {
+            try {
+                $result = $closure();
+
+                // If we succeeded on a retry attempt, track it as flaky
+                if ($attemptNumber > 1) {
+                    \Pest\Support\FlakyTestTracker::getInstance()->track(
+                        $this->name(),
+                        $attemptNumber,
+                        true
+                    );
+                }
+
+                return $result;
+            } catch (Throwable $e) {
+                $lastException = $e;
+                $attemptNumber++;
+
+                // If we've exhausted all attempts, track and re-throw
+                if ($attemptNumber > $maxAttempts) {
+                    if ($maxAttempts > 1) {
+                        \Pest\Support\FlakyTestTracker::getInstance()->track(
+                            $this->name(),
+                            $maxAttempts,
+                            false
+                        );
+                    }
+
+                    throw $e;
+                }
+
+                // Otherwise, continue to next attempt
+            }
+        }
+
+        // This should never be reached, but satisfies the return type
+        if ($lastException !== null) {
+            throw $lastException;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -47,6 +47,11 @@ final class TestCaseMethodFactory
     public int $repetitions = 1;
 
     /**
+     * The test's maximum number of retry attempts.
+     */
+    public int $attempts = 1;
+
+    /**
      * Determines if the test is a "todo".
      */
     public bool $todo = false;

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -409,6 +409,20 @@ final class TestCall // @phpstan-ignore-line
     }
 
     /**
+     * Sets the maximum number of retry attempts for this test.
+     */
+    public function attempts(int $times): self
+    {
+        if ($times < 1) {
+            throw new InvalidArgumentException('The number of attempts must be greater than 0.');
+        }
+
+        $this->testCaseMethod->attempts = $times;
+
+        return $this;
+    }
+
+    /**
      * Marks the test as "todo".
      */
     public function todo(// @phpstan-ignore-line

--- a/src/Support/FlakyTestTracker.php
+++ b/src/Support/FlakyTestTracker.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+/**
+ * @internal
+ */
+final class FlakyTestTracker
+{
+    /**
+     * The singleton instance.
+     */
+    private static ?FlakyTestTracker $instance = null;
+
+    /**
+     * The tracked flaky tests.
+     *
+     * @var array<string, array{attempts: int, passed: bool}>
+     */
+    private array $flakyTests = [];
+
+    /**
+     * Private constructor to prevent direct instantiation.
+     */
+    private function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the singleton instance.
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self;
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Track a test that required retry attempts.
+     */
+    public function track(string $testName, int $attempts, bool $passed): void
+    {
+        // Only track if the test required more than 1 attempt
+        if ($attempts > 1) {
+            $this->flakyTests[$testName] = [
+                'attempts' => $attempts,
+                'passed' => $passed,
+            ];
+        }
+    }
+
+    /**
+     * Get all tracked flaky tests.
+     *
+     * @return array<string, array{attempts: int, passed: bool}>
+     */
+    public function getFlakyTests(): array
+    {
+        return $this->flakyTests;
+    }
+
+    /**
+     * Check if there are any tracked flaky tests.
+     */
+    public function hasFlakyTests(): bool
+    {
+        return count($this->flakyTests) > 0;
+    }
+
+    /**
+     * Clear all tracked tests.
+     */
+    public function clear(): void
+    {
+        $this->flakyTests = [];
+    }
+
+    /**
+     * Reset the singleton instance (useful for testing).
+     */
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+}

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -60,6 +60,11 @@ final class TestSuite
     public string $rootPath;
 
     /**
+     * Holds the global maximum attempts for tests.
+     */
+    public int $attempts = 1;
+
+    /**
      * Holds an instance of the test suite.
      */
     private static ?TestSuite $instance = null;

--- a/tests/Features/Attempts.php
+++ b/tests/Features/Attempts.php
@@ -1,0 +1,16 @@
+<?php
+
+it('succeeds after a few attempts', function () {
+    $path = sys_get_temp_dir().'/pest_attempt.txt';
+    $attempts = 1;
+    if (file_exists($path)) {
+        $attempts = (int) file_get_contents($path);
+    } else {
+        file_put_contents($path, "$attempts");
+    }
+    file_put_contents($path, (string) ($attempts + 1));
+    expect($attempts)->toEqual(2);
+    if ($attempts == 2) {
+        unlink($path);
+    }
+})->attempts(2);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This feature is mostly needed due to the addition of the browser testing API. I would argue in normal testing scenarios you would want to design tests that aren't flakey, however with the browser a lot of stuff is out of your control. This PR adds a new `--attempts=X` cli flag as well as an `->attempts(X)` test method, which will try to run the tests up to X times, marking it as passed the first time it succeeds. If the tries exceeds X then the test is marked as failed.

Something that would be nice that I haven't added yet is some sort of output at the end of the test run which lets you know that a test was attempted a few times. I've created a class to keep track of the tests that were reattempted, but I haven't done anything with the tracked tests yet as I'm not sure the best way to add to the final test output

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
- #1511
