### PR TITLE
[Fix] Pass test dir to worker

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -131,6 +131,7 @@ final class WrapperRunner implements RunnerInterface
         $parameters = $this->handleLaravelHerd($parameters);
 
         $parameters[] = $wrapper;
+        $parameters[] =  '--test-directory='.TestSuite::getInstance()->testPath;
 
         $this->parameters = $parameters;
         $this->codeCoverageFilterRegistry = new CodeCoverageFilterRegistry;


### PR DESCRIPTION
#1444 
Test directory argument is lost when spawning workers, add it again.

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:
The `--test-directory` flag does not work in combination with `--parallel`

### Related:
#1444 
