### PR TITLE
fix: Dockerfile - consolidate build dependencies before PHP extension installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,11 @@
-ARG PHP=8.1
+ARG PHP=8.3
 FROM php:${PHP}-cli-alpine
 
-RUN apk update && apk add \
-    zip libzip-dev icu-dev git
+RUN apk update && apk add --no-cache \
+    zip libzip-dev icu-dev git \
+    linux-headers autoconf build-base
 
-RUN docker-php-ext-install zip intl
-
-RUN apk add --no-cache linux-headers autoconf build-base
+RUN docker-php-ext-install zip intl sockets
 RUN pecl install xdebug
 RUN docker-php-ext-enable xdebug
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## What:

- [x] Bug Fix
- [ ] New Feature

## Description:
### Problem

Pest 4.x requires PHP 8.3+ minimum and the sockets extension. The existing Dockerfile was using PHP 8.1 and didn't include sockets.

### Solution

Reorganize Dockerfile to meet Pest 4 requirements and fix the build order:

- Upgraded PHP from 8.1 to 8.3 (Pest 4 minimum requirement)
- Added sockets extension (Pest 4 requirement)
- Consolidated all `apk add` commands into a single RUN with `--no-cache`
- Moved `linux-headers autoconf build-base` **before** `docker-php-ext-install`

###  Changes

#### Before

Before (PHP 8.1, no sockets, wrong build order)
```dockerfile
ARG PHP=8.1
RUN apk update && apk add zip libzip-dev icu-dev git
RUN docker-php-ext-install zip intl
RUN apk add --no-cache linux-headers autoconf build-base  # Too late!
```
After (PHP 8.3, sockets added, correct build order)
```dockerfile
ARG PHP=8.3
RUN apk update && apk add --no-cache \
    zip libzip-dev icu-dev git \
    linux-headers autoconf build-base  # Available for compilation
RUN docker-php-ext-install zip intl sockets
```

  ### Testing
```
docker compose build 
make install            # Now succeeds
```
