### PR TITLE
add missing classes before toExtend on laravel preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -69,6 +69,7 @@ final class Laravel extends AbstractPreset
             ->toHaveSuffix('Request');
 
         $this->expectations[] = expect('App\Http\Requests')
+            ->classes()
             ->toExtend('Illuminate\Foundation\Http\FormRequest');
 
         $this->expectations[] = expect('App\Http\Requests')
@@ -118,6 +119,7 @@ final class Laravel extends AbstractPreset
             ->toHaveMethod('handle');
 
         $this->expectations[] = expect('App\Notifications')
+            ->classes()
             ->toExtend('Illuminate\Notifications\Notification');
 
         $this->expectations[] = expect('App')
@@ -128,6 +130,7 @@ final class Laravel extends AbstractPreset
             ->toHaveSuffix('ServiceProvider');
 
         $this->expectations[] = expect('App\Providers')
+            ->classes()
             ->toExtend('Illuminate\Support\ServiceProvider');
 
         $this->expectations[] = expect('App\Providers')


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Add missing `->classes()` before `->toExtend()` on the laravel preset for 2 namespaces.

Otherwise you can't use interfaces on theses namespace.

For example, if you create an interface `YourSuperRequestContract` on the `app/Http/Requests` namespace you will get this error:

```
Expecting 'app/Http/Requests/YourSuperRequestContract.php' to extend 'Illuminate\Foundation\Http\FormRequest'.
```
