### PR TITLE
Add Rules to Laravel preset

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -173,5 +173,9 @@ final class Laravel extends AbstractPreset
             ->toImplement('Illuminate\Contracts\Container\ContextualAttribute')
             ->toHaveAttribute('Attribute')
             ->toHaveMethod('resolve');
+
+        $this->expectations[] = expect('App\Rules')
+            ->classes()
+            ->toImplement('Illuminate\Contracts\Validation\ValidationRule');
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces a new expectation in Laravel preset for Rules.

Expect all Rule classes to implement `Illuminate\Contracts\Validation\ValidationRule`.