### PR TITLE
feat: show more useful exception when `intl` extension not found

### DIFF
--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -15,6 +15,7 @@ use Pest\Arch\PendingArchExpectation;
 use Pest\Arch\SingleArchExpectation;
 use Pest\Arch\Support\FileLineFinder;
 use Pest\Exceptions\InvalidExpectation;
+use Pest\Exceptions\MissingDependency;
 use Pest\Expectation;
 use Pest\Support\Arr;
 use Pest\Support\Exporter;
@@ -284,6 +285,10 @@ final readonly class OppositeExpectation
      */
     public function toHaveSuspiciousCharacters(): ArchExpectation
     {
+        if (! class_exists(Spoofchecker::class)) {
+            throw new MissingDependency(__FUNCTION__, 'ext-intl >= 2.0');
+        }
+
         $checker = new Spoofchecker;
 
         /** @var Expectation<array<int, string>|string> $original */


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

This adds a more useful exception message when the `intl` extension does not exist (as it's required for the `Spoofchecker` class).

We should likely instead remove the `toHaveSuspiciousCharacters()` call as a default for the `php()` preset.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
Closes https://github.com/pestphp/pest/issues/1588
Relates to https://github.com/pestphp/pest/issues/1509#issuecomment-3297284804