### PR TITLE
feat: add only function to mark each test in a file as only

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -314,7 +314,7 @@ if (! function_exists('fixture')) {
 
         if ($fileRealPath === false) {
             throw new InvalidArgumentException(
-                'The fixture file [' . $file . '] does not exist.',
+                'The fixture file ['.$file.'] does not exist.',
             );
         }
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -219,6 +219,20 @@ if (! function_exists('afterAll')) {
     }
 }
 
+if (! function_exists('only')) {
+    /**
+     * Marks all tests in the current file to be run exclusively.
+     */
+    function only(): void
+    {
+        $filename = Backtrace::file();
+
+        $beforeEachCall = (new BeforeEachCall(TestSuite::getInstance(), $filename));
+
+        $beforeEachCall->only();
+    }
+}
+
 if (! function_exists('covers')) {
     /**
      * Specifies which classes, or functions, a test case covers.
@@ -300,7 +314,7 @@ if (! function_exists('fixture')) {
 
         if ($fileRealPath === false) {
             throw new InvalidArgumentException(
-                'The fixture file ['.$file.'] does not exist.',
+                'The fixture file [' . $file . '] does not exist.',
             );
         }
 


### PR DESCRIPTION
## Add file-level `only()` function

Adds a new global `only()` function to mark all tests in a file to run exclusively, complementing the existing test-level `->only()` method.

### Usage

```php
<?php

only(); // Mark all tests in this file to run exclusively

test('first test', function () {
    expect(true)->toBeTrue();
});

test('second test', function () {
    expect(1 + 1)->toBe(2);
});
```

### Benefits

- Quickly run all test in a file without having to add the entire path to `pest` cmd
- Avoid chaining `->only()` to every test in a file

### Docs

Related docs pr: https://github.com/pestphp/docs/pull/345