### PR TITLE
feat: add --dirty documentation in --help

### DIFF
--- a/src/Plugins/Help.php
+++ b/src/Plugins/Help.php
@@ -142,6 +142,9 @@ final readonly class Help implements HandlesArguments
         ], [
             'arg' => '--retry',
             'desc' => 'Run non-passing tests first and stop execution upon first error or failure',
+        ], [
+            'arg' => '--dirty',
+            'desc' => 'Only run tests that have uncommitted changes according to Git',
         ], ...$content['Selection']];
 
         $content['Reporting'] = [...$content['Reporting'], ...[


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Add documentation for the `--dirty` flag

### Related:

#1594 
