### PR TITLE
feat: add pest only function to mark each test in a file as only

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -25,7 +25,7 @@ final readonly class Configuration
     public function __construct(
         string $filename,
     ) {
-        $this->filename = str_ends_with($filename, DIRECTORY_SEPARATOR . 'Pest.php') ? dirname($filename) : $filename;
+        $this->filename = str_ends_with($filename, DIRECTORY_SEPARATOR.'Pest.php') ? dirname($filename) : $filename;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest;
 
+use Pest\PendingCalls\BeforeEachCall;
 use Pest\PendingCalls\UsesCall;
 
 /**
@@ -24,7 +25,7 @@ final readonly class Configuration
     public function __construct(
         string $filename,
     ) {
-        $this->filename = str_ends_with($filename, DIRECTORY_SEPARATOR.'Pest.php') ? dirname($filename) : $filename;
+        $this->filename = str_ends_with($filename, DIRECTORY_SEPARATOR . 'Pest.php') ? dirname($filename) : $filename;
     }
 
     /**
@@ -60,6 +61,14 @@ final readonly class Configuration
     public function group(string ...$groups): UsesCall
     {
         return (new UsesCall($this->filename, []))->group(...$groups);
+    }
+
+    /**
+     * Marks all tests in the current file to be run exclusively.
+     */
+    public function only(): void
+    {
+        (new BeforeEachCall(TestSuite::getInstance(), $this->filename))->only();
     }
 
     /**


### PR DESCRIPTION
## Add `pest()->only()` to mark all tests in file as only

Adds a new `only()` method on the `pest()` config class to mark all tests in a file to run exclusively, complementing the existing test-level `->only()` method.

### Usage

```php
<?php

pest()->only(); // Mark all tests in this file to run exclusively

test('first test', function () {
    expect(true)->toBeTrue();
});

test('second test', function () {
    expect(1 + 1)->toBe(2);
});
```

### Benefits

- Quickly run all test in a file without having to add the entire path to `pest` cmd
- Avoid chaining `->only()` to every test in a file

### Docs

Related docs pr: https://github.com/pestphp/docs/pull/346
(Previous pr: https://github.com/pestphp/pest/pull/1592)