### PR TITLE
fix: replace `substr` with `mb_substr` in Str::beforeLast to ensure multibyte string compatibility and correct TeamCity test names for datasets in "describe" blocks

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -79,7 +79,7 @@ final class Str
             return $subject;
         }
 
-        return substr($subject, 0, $pos);
+        return mb_substr($subject, 0, $pos);
     }
 
     /**

--- a/tests/.snapshots/SuccessOnly.php.inc
+++ b/tests/.snapshots/SuccessOnly.php.inc
@@ -1,5 +1,5 @@
 ##teamcity[testSuiteStarted name='Tests/tests/SuccessOnly' locationHint='pest_qn://tests/.tests/SuccessOnly.php' flowId='1234']
-##teamcity[testCount count='3' flowId='1234']
+##teamcity[testCount count='4' flowId='1234']
 ##teamcity[testStarted name='it can pass with comparison' locationHint='pest_qn://tests/.tests/SuccessOnly.php::it can pass with comparison' flowId='1234']
 ##teamcity[testFinished name='it can pass with comparison' duration='100000' flowId='1234']
 ##teamcity[testStarted name='can also pass' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can also pass' flowId='1234']
@@ -8,8 +8,12 @@
 ##teamcity[testStarted name='can pass with dataset with data set "(true)"' locationHint='pest_qn://tests/.tests/SuccessOnly.php::can pass with dataset with data set "(true)"' flowId='1234']
 ##teamcity[testFinished name='can pass with dataset with data set "(true)"' duration='100000' flowId='1234']
 ##teamcity[testSuiteFinished name='can pass with dataset' flowId='1234']
+##teamcity[testSuiteStarted name='`block` → can pass with dataset in describe block' locationHint='pest_qn://tests/.tests/SuccessOnly.php::`block` → can pass with dataset in describe block' flowId='1234']
+##teamcity[testStarted name='`block` → can pass with dataset in describe block with data set "(1)"' locationHint='pest_qn://tests/.tests/SuccessOnly.php::`block` → can pass with dataset in describe block with data set "(1)"' flowId='1234']
+##teamcity[testFinished name='`block` → can pass with dataset in describe block with data set "(1)"' duration='100000' flowId='1234']
+##teamcity[testSuiteFinished name='`block` → can pass with dataset in describe block' flowId='1234']
 ##teamcity[testSuiteFinished name='Tests/tests/SuccessOnly' flowId='1234']
 
-  [90mTests:[39m    [32;1m3 passed[39;22m[90m (3 assertions)[39m
+  [90mTests:[39m    [32;1m4 passed[39;22m[90m (4 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m
 

--- a/tests/.tests/SuccessOnly.php
+++ b/tests/.tests/SuccessOnly.php
@@ -13,3 +13,9 @@ test('can also pass', function () {
 test('can pass with dataset', function ($value) {
     expect($value)->toEqual(true);
 })->with([true]);
+
+describe('block', function () {
+    test('can pass with dataset in describe block', function ($number) {
+        expect($number)->toBeInt();
+    })->with([1]);
+});

--- a/tests/Visual/JUnit.php
+++ b/tests/Visual/JUnit.php
@@ -36,8 +36,8 @@ test('junit output', function () use ($normalizedPath, $run) {
     expect($result['testsuite']['@attributes'])
         ->name->toBe('Tests\tests\SuccessOnly')
         ->file->toBe($normalizedPath('tests/.tests/SuccessOnly.php'))
-        ->tests->toBe('3')
-        ->assertions->toBe('3')
+        ->tests->toBe('4')
+        ->assertions->toBe('4')
         ->errors->toBe('0')
         ->failures->toBe('0')
         ->skipped->toBe('0');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

#### Problem:

When running Pest tests with --teamcity flag inside a describe block with datasets, the last 2 characters of the test suite name are incorrectly cut off.

#### Root Cause: 

The Str::beforeLast() method in src/Support/Str.php has a byte/character position mismatch bug:

``` 
public static function beforeLast(string $subject, string $search): string
{
    // ...
    $pos = mb_strrpos($subject, $search);  // Returns CHARACTER position
    // ...
    return substr($subject, 0, $pos);       // Expects BYTE position
}
```

The describe block format uses the arrow character → (U+2192), which is:
- 1 character in length
- 3 bytes in UTF-8 encoding

When mb_strrpos finds the position of with data set in a string like `my_block` → my_test with data set "1", it returns a character position. But substr interprets this as a byte position, causing a 2-byte offset (3 bytes for → minus 1 character = 2 bytes difference).

Example:
- Input: `my_block` → my_test with data set "1"
- Expected output: `my_block` → my_test
- Actual output: `my_block` → my_te

#### Solution

Change substr to mb_substr in Str::beforeLast() to ensure character-based substring operation matches the character based position from mb_strrpos.

#### Impact

It will allow to support navigation for such tests from the Test Results tool window in PhpStorm to source code in the file.