### PR TITLE
feat: allow filtering uses() by file suffix

### DIFF
--- a/src/PendingCalls/UsesCall.php
+++ b/src/PendingCalls/UsesCall.php
@@ -35,6 +35,11 @@ final class UsesCall
     private array $targets;
 
     /**
+     * Holds the suffix of the uses.
+     */
+    private string $suffix = '';
+
+    /**
      * Holds the groups of the uses.
      *
      * @var array<int, string>
@@ -129,6 +134,16 @@ final class UsesCall
     }
 
     /**
+     * Sets the test suffix.
+     */
+    public function suffix(string $suffix): self
+    {
+        $this->suffix = $suffix;
+
+        return $this;
+    }
+
+    /**
      * Sets the global beforeAll test hook.
      */
     public function beforeAll(Closure $hook): self
@@ -178,6 +193,7 @@ final class UsesCall
             $this->groups,
             $this->targets,
             $this->hooks,
+            $this->suffix,
         );
     }
 }

--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -27,7 +27,7 @@ final class TestRepository
     private array $testCases = [];
 
     /**
-     * @var array<string, array{0: array<int, string>, 1: array<int, string>, 2: array<int, array<int, string|Closure>>}>
+     * @var array<string, array{0: array<int, string>, 1: array<int, string>, 2: array<int, array<int, string|Closure>>, 3: string, 4: string}>
      */
     private array $uses = [];
 
@@ -67,7 +67,7 @@ final class TestRepository
      * @param  array<int, string>  $paths
      * @param  array<int, Closure>  $hooks
      */
-    public function use(array $classOrTraits, array $groups, array $paths, array $hooks): void
+    public function use(array $classOrTraits, array $groups, array $paths, array $hooks, string $suffix): void
     {
         foreach ($classOrTraits as $classOrTrait) {
             if (class_exists($classOrTrait)) {
@@ -82,17 +82,25 @@ final class TestRepository
         $hooks = array_map(fn (Closure $hook): array => [$hook], $hooks);
 
         foreach ($paths as $path) {
-            if (array_key_exists($path, $this->uses)) {
-                $this->uses[$path] = [
-                    [...$this->uses[$path][0], ...$classOrTraits],
-                    [...$this->uses[$path][1], ...$groups],
+            // Using a composite key (path + suffix) allows for specialized configurations such as distinguishing
+            // between UnitTest and FunctionalTest even when tests are within the same directory.
+            $key = $path.':::'.$suffix;
+
+            // If the configuration for this path and suffix already exists, we merge the
+            // incoming settings to ensure that previous configurations are preserved.
+            if (array_key_exists($key, $this->uses)) {
+                $this->uses[$key] = [
+                    [...$this->uses[$key][0], ...$classOrTraits],
+                    [...$this->uses[$key][1], ...$groups],
                     array_map(
-                        fn (int $index): array => [...$this->uses[$path][2][$index] ?? [], ...($hooks[$index] ?? [])],
+                        fn (int $index): array => [...$this->uses[$key][2][$index] ?? [], ...($hooks[$index] ?? [])],
                         range(0, 3),
                     ),
+                    $path,
+                    $suffix,
                 ];
             } else {
-                $this->uses[$path] = [$classOrTraits, $groups, $hooks];
+                $this->uses[$key] = [$classOrTraits, $groups, $hooks, $path, $suffix];
             }
         }
     }
@@ -170,8 +178,12 @@ final class TestRepository
     {
         $startsWith = static fn (string $target, string $directory): bool => Str::startsWith($target, $directory.DIRECTORY_SEPARATOR);
 
-        foreach ($this->uses as $path => $uses) {
-            [$classOrTraits, $groups, $hooks] = $uses;
+        foreach ($this->uses as $uses) {
+            [$classOrTraits, $groups, $hooks, $path, $suffix] = $uses;
+
+            if ($suffix !== '' && ! Str::endsWith($testCase->filename, $suffix)) {
+                continue;
+            }
 
             if ((! is_dir($path) && $testCase->filename === $path) || (is_dir($path) && $startsWith($testCase->filename, $path))) {
                 foreach ($classOrTraits as $class) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1558,6 +1558,12 @@
    PASS  Tests\PHPUnit\GlobPatternTests\SubFolder2\UsesPerFileAsPattern
   ✓ closure was bound to CustomTestCase
 
+   PASS  Tests\PHPUnit\SuffixPatternTests\Deep\Nested\ShouldNotUseCustomTestCase
+  ✓ this file should NOT use CustomTestCase
+
+   PASS  Tests\PHPUnit\SuffixPatternTests\Deep\Nested\UsesPerFileSuffixPattern
+  ✓ closure was bound to SuffixedTest
+
    PASS  Tests\Playground
   ✓ basic
 
@@ -1782,4 +1788,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 35 skipped, 1188 passed (2813 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 35 skipped, 1190 passed (2815 assertions)

--- a/tests/PHPUnit/CustomTestCase/SuffixedTest.php
+++ b/tests/PHPUnit/CustomTestCase/SuffixedTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CustomTestCase;
+
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertTrue;
+
+abstract class SuffixedTest extends TestCase
+{
+    public function assertSuffixedTest()
+    {
+        assertTrue(true);
+    }
+}

--- a/tests/PHPUnit/SuffixPatternTests/Deep/Nested/ShouldNotUseCustomTestCase.php
+++ b/tests/PHPUnit/SuffixPatternTests/Deep/Nested/ShouldNotUseCustomTestCase.php
@@ -1,0 +1,5 @@
+<?php
+
+test('this file should NOT use CustomTestCase', function () {
+    expect($this)->not->toBeInstanceOf(Tests\CustomTestCase\SuffixedTest::class);
+});

--- a/tests/PHPUnit/SuffixPatternTests/Deep/Nested/UsesPerFileSuffixPattern.php
+++ b/tests/PHPUnit/SuffixPatternTests/Deep/Nested/UsesPerFileSuffixPattern.php
@@ -1,0 +1,5 @@
+<?php
+
+test('closure was bound to SuffixedTest', function () {
+    $this->assertSuffixedTest();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Tests\CustomTestCase\CustomTestCase;
+use Tests\CustomTestCase\SuffixedTest;
 use Tests\CustomTestCaseInSubFolders\SubFolder\SubFolder\CustomTestCaseInSubFolder;
 
 error_reporting(E_ALL);
@@ -16,6 +17,9 @@ pest()->in('PHPUnit/GlobPatternTests/SubFolder/*')->extend(CustomTestCase::class
 
 // test case for all the files that end with AsPattern.php inside PHPUnit/GlobPatternTests/SubFolder2/
 pest()->in('PHPUnit/GlobPatternTests/SubFolder2/*AsPattern.php')->use(CustomTestCase::class);
+
+// test case for all the files that end with SuffixPattern.php inside PHPUnit/GlobPatternTests/
+pest()->in('PHPUnit/SuffixPatternTests')->suffix('SuffixPattern.php')->use(SuffixedTest::class);
 
 pest()->in('Visual')->group('integration');
 

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -16,7 +16,7 @@ $run = function () {
 
 test('parallel', function () use ($run) {
     expect($run('--exclude-group=integration'))
-        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1177 passed (2789 assertions)')
+        ->toContain('Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 39 todos, 26 skipped, 1179 passed (2791 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces a `suffix(string $suffix)` method to the `uses()` configuration chain. This allows developers to apply different configurations to different test suites living in the same folder structure.

Example in PHPUnit,

```xml
    <testsuites>
        <testsuite name="Functional">
            <directory suffix="FunctionalTest.php">App</directory>
        </testsuite>
        <testsuite name="Unit">
            <directory suffix="UnitTest.php">App</directory>
        </testsuite>
    </testsuites>
```

Equivalent in Pest (as part of this PR)

```php
Pest()
  ->uses(TestCase::class)
  ->in('App')
  ->beforeEach(...)
  ->suffix('FunctionalTest.php');

Pest()
  ->uses(\PHPUnit\Framework\TestCase)
  ->afterEach(...)
  ->in('App')
  ->suffix('UnitTest.php');
```

This use case is for developers willing to have a testing structure that mirrors their source code structure, so that functional and unit tests live next to each other.

```
└── tests/
    ├── Pest.php
    ├── TestCase.php
    └── App/
        └── Modules/
            └── Users/
                ├── ValueObjects/
                │   └── UserEmailUnitTest.php
                ├── Actions/
                │   └── LoginUserActionFunctionalTest
                └── Models/
                    ├── UserModelAnotherThingUnitTest.php
                    └── UserModelSomethingFunctionalTest.php
```
