### PR TITLE
fix: support running Pest when symlinked

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -119,19 +119,18 @@ use Symfony\Component\Console\Output\ConsoleOutput;
         }
     }
 
-    // Used when Pest is required using composer.
-    $vendorPath = dirname(__DIR__, 4).'/vendor/autoload.php';
+    $autoloadPath = match(true) {
+        // Used when Pest is required using composer.
+        file_exists($vendorPath = dirname(__DIR__, 4).'/vendor/autoload.php') => $vendorPath,
 
-    // Used when Pest maintainers are running Pest tests.
-    $localPath = dirname(__DIR__).'/vendor/autoload.php';
+        // Used when Pest maintainers are running Pest tests as a dependency (E2E).
+        file_exists($localSymlinkPath = getcwd() . '/vendor/autoload.php') => $localSymlinkPath,
 
-    if (file_exists($vendorPath)) {
-        include_once $vendorPath;
-        $autoloadPath = $vendorPath;
-    } else {
-        include_once $localPath;
-        $autoloadPath = $localPath;
-    }
+        // Used when Pest maintainers are running Pest locally (Pest Repo).
+        default => dirname(__DIR__) . '/vendor/autoload.php',
+    };
+
+    include_once $autoloadPath;
 
     // Get $rootPath based on $autoloadPath
     $rootPath = dirname($autoloadPath, 2);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When Pest is installed as a symlinked dependency (e.g., using a Composer path repository), PHP's `__DIR__` constant resolves to the physical path of the Pest package (e.g., /Volumes/Dev/pest/bin). 

This leads to two problems:

1. Pest loads the wrong autoload file, /Volumes/Dev/**pest**/vendor/autoload.php instead of /Volumes/Dev/**{dependantRepo}**/vendor/autoload.php.
2. The repo's `tests/Pest.php` file will not be called. Since the wrong autoloader will load the wrong `TestSuite` instance, the [rootpath](https://github.com/pestphp/pest/blob/dd01229d7b4a8ef54665d1208ff141abb3da8686/src/Bootstrappers/BootFiles.php#L41) will be Pest's rootpath instead of the repo's rootpath.