### PR TITLE
fix: enhance support for --parallel and --teamcity arguments by restoring --teamcity for ParaTest and fixing teamcity output concurrency

### DIFF
--- a/src/Plugins/Parallel.php
+++ b/src/Plugins/Parallel.php
@@ -127,7 +127,9 @@ final class Parallel implements HandlesArguments
             $arguments
         );
 
-        $exitCode = $this->paratestCommand()->run(new ArgvInput($filteredArguments), new CleanConsoleOutput);
+        $filteredArguments = $this->processTeamcityArguments($filteredArguments);
+
+        $exitCode = $this->paratestCommand()->run(new ArgvInput(array_values($filteredArguments)), new CleanConsoleOutput);
 
         return CallsAddsOutput::execute($exitCode);
     }
@@ -196,5 +198,19 @@ final class Parallel implements HandlesArguments
         $arguments = $this->popArgument('--parallel', $arguments);
 
         return $this->popArgument('-p', $arguments);
+    }
+
+    /**
+     * @param  string[]  $arguments
+     * @return string[]
+     */
+    public function processTeamcityArguments(array $arguments): array
+    {
+        $argv = new ArgvInput;
+        if ($argv->hasParameterOption('--teamcity')) {
+            $arguments[] = '--teamcity';
+        }
+
+        return $arguments;
     }
 }

--- a/src/Plugins/Parallel/Paratest/ResultPrinter.php
+++ b/src/Plugins/Parallel/Paratest/ResultPrinter.php
@@ -92,14 +92,13 @@ final class ResultPrinter
         $this->teamcityLogFileHandle = $teamcityLogFileHandle;
     }
 
-    /** @param  list<SplFileInfo>  $teamcityFiles */
     public function printFeedback(
         SplFileInfo $progressFile,
         SplFileInfo $outputFile,
-        array $teamcityFiles
+        ?SplFileInfo $teamcityFile,
     ): void {
-        if ($this->options->needsTeamcity) {
-            $teamcityProgress = $this->tailMultiple($teamcityFiles);
+        if ($this->options->needsTeamcity && $teamcityFile instanceof SplFileInfo) {
+            $teamcityProgress = $this->tailMultiple([$teamcityFile]);
 
             if ($this->teamcityLogFileHandle !== null) {
                 fwrite($this->teamcityLogFileHandle, $teamcityProgress);

--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -225,7 +225,7 @@ final class WrapperRunner implements RunnerInterface
         $this->printer->printFeedback(
             $worker->progressFile,
             $worker->unexpectedOutputFile,
-            $this->teamcityFiles,
+            $worker->teamcityFile ?? null,
         );
         $worker->reset();
     }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The fix addresses 2 issues:
1. A concurrency bug in ParaTest. This issue has been fixed on the ParaTest side, but not yet on the Pest side. https://github.com/paratestphp/paratest/pull/851
2. Proper propagation of the --teamcity flag to ParaTest. Previously, this was handled incorrectly on PhpStorm’s side by forcing PHPUnit to write test results in TeamCity format directly to stdout. 

A corresponding fix on PhpStorm's side will appear in the closest minor release.

### Related:

https://github.com/pestphp/pest/issues/1236#issuecomment-2344339629