### PR TITLE
Fix --parallel dropping options

### DIFF
--- a/src/Plugins/Concerns/HandleArguments.php
+++ b/src/Plugins/Concerns/HandleArguments.php
@@ -44,16 +44,20 @@ trait HandleArguments
 
     /**
      * Pops the given argument from the arguments.
+     * Pops the given argument from the arguments and returns a re-indexed array.
      *
      * @param  array<int, string>  $arguments
      * @return array<int, string>
      */
     public function popArgument(string $argument, array $arguments): array
     {
-        $arguments = array_flip($arguments);
+        $key = array_search($argument, $arguments, true);
 
-        unset($arguments[$argument]);
+        if ($key !== false) {
+            unset($arguments[$key]);
+        }
 
-        return array_values(array_flip($arguments));
+        return array_values($arguments);
+
     }
 }

--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class Coverage implements AddsOutput, HandlesArguments
 {
+    use Concerns\HandleArguments;
+
     private const string COVERAGE_OPTION = 'coverage';
 
     private const string MIN_OPTION = 'min';
@@ -70,11 +72,9 @@ final class Coverage implements AddsOutput, HandlesArguments
             return false;
         }))];
 
-        $originals = array_flip($originals);
         foreach ($arguments as $argument) {
-            unset($originals[$argument]);
+            $originals = $this->popArgument($argument, $originals);
         }
-        $originals = array_flip($originals);
 
         $inputs = [];
         $inputs[] = new InputOption(self::COVERAGE_OPTION, null, InputOption::VALUE_NONE);


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

This PR fixes issue [1437](https://github.com/pestphp/pest/issues/1437) where additional --exlude-group options were ignored when using --parallel flag.
It's a much smaller version of PR [1468](https://github.com/pestphp/pest/pull/1468). This PR doesn't bring the additional tests to avoid changes to Visual test snapshots, but the proof of the problem and fix is available with a single statement given below.

### Problem:

In version 3.x and 4.0, running tests with `--parallel` using multiple `--exclude-group` options, only the first option was used.
This probably applies to other multiple-use options such as `--group`.
This problem is made worse in v4.0 using PHPUnit 12, forcing the use of multiple option vs comma-separated list.

### Root Cause:

Some plugin argument handlers remove an argument from the `$arguments` array by `using array_flip()` twice. They wrongly assume the remaining array is unchanged, but any non-unique value is removed from the array.

This breaks Parallel because long options (`--option=value`) in the argument array appear as two items (`['--option','value']`) causing potential duplicate keys.

#### Why does it work when not using --parallel?
The non-parallel worker avoids duplicate keys in the argument pipeline by keeping option and value together in the array (`['--option=value']`).

### Solution:

Modified `popArgument()` in `HandleArguments` Trait to use `unset()` instead of the double `array_flip()`
Modified `Coverage` plugin to use the Trait method instead of its own double `array_flip()` code.

### Testing:

This PR does not add new tests to avoid changes in "Visual" tests.
The following statement should not fail and simply return null, but it does fail on 4.x branch without this PR 

`PHPUnit\Framework\assertEquals((new class {use Pest\Plugins\Concerns\HandleArguments;})->popArgument('anything',['same', 'same']),['same', 'same']);`

### Related:

Fixes issue [1437](https://github.com/pestphp/pest/issues/1437) 
Better version of PR [1468](https://github.com/pestphp/pest/pull/1468) 