### PR TITLE
Restore support for PHP 8.1 in 2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         symfony: ['6.4', '7.0']
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
         dependency_version: [prefer-stable]
+        exclude:
+          - php: '8.1'
+            symfony: '7.0'
 
     name: PHP ${{ matrix.php }} - Symfony ^${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency_version }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.2.0",
+        "php": "^8.1.0",
         "brianium/paratest": "^7.4.9",
         "nunomaduro/collision": "^7.11.0|^8.5.0",
         "nunomaduro/termwind": "^1.16.0|^2.3.3",


### PR DESCRIPTION
This reverts commit 93b56110590206172db53c72295956ff140cbf21.

### What:

- [ X] Bug Fix
- [ ] New Feature

### Description:

Reverts commit to restore support for PHP 8.1, which is still in LTS support on some Linux distributions

### Related:

#1618
