### PR TITLE
Support PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         "pestphp/pest-plugin-arch": "^4.0.0",
         "pestphp/pest-plugin-mutate": "^4.0.1",
         "pestphp/pest-plugin-profanity": "^4.2.1",
-        "phpunit/phpunit": "^12.5.8",
+        "phpunit/phpunit": "^12.5.8 || ^13.0",
         "symfony/process": "^7.4.4|^8.0.0"
     },
     "conflict": {
         "filp/whoops": "<2.18.3",
-        "phpunit/phpunit": ">12.5.8",
+        "phpunit/phpunit": ">13.1",
         "sebastian/exporter": "<7.0.0",
         "webmozart/assert": "<1.11.0"
     },


### PR DESCRIPTION
## Summary

Widens the PHPUnit version constraint to accept `^13.0` alongside `^12.5.8`, and updates the conflict rule from `>12.5.8` to `>13.1`.

### Code audit

I audited every PHPUnit class/interface that Pest imports across `src/`:

- **Event system**: All event classes (`BeforeFirstTestMethodErrored`, `AfterLastTestMethodErrored`, `Errored`, `Failed`, `Skipped`, `ConsideredRisky`, `MarkedIncomplete`) and their subscriber interfaces retain the same `PHPUnit\Event\Test` namespace and API in PHPUnit 13.
- **`testClassName()`**: Still present on errored hook events — PHPUnit 13 only removed it from "called"/"finished" hook events, which Pest doesn't use.
- **Internal APIs**: `TextUI\Application`, `Configuration\Registry`, `TestResult\Facade`, `CliArguments\Builder`, `XmlConfigurationFileFinder`, `XmlConfiguration\DefaultConfiguration`, `XmlConfiguration\Loader`, `Util\ExcludeList` — all retain their namespaces and method signatures in PHPUnit 13.
- **Removed APIs not used by Pest**: `Assert::isType()`, `assertContainsOnly()`, `containsOnly()`, `#[RunClassInSeparateProcess]`, `--dont-report-useless-tests` — none are used in Pest's source.

### Dependency note

`nunomaduro/collision ^8.8.3` currently conflicts with `phpunit/phpunit >=13.0.0`. [Collision PR #342](https://github.com/nunomaduro/collision/pull/342) tracks adding PHPUnit 13 support there. Once collision updates its conflict list, this constraint will resolve cleanly.

The circular dependency (Pest → Collision → PHPUnit 13 blocked → Pest) needs to be broken — this PR breaks it from the Pest side. Collision can then update independently since Pest is only a dev dependency there.

### PHPUnit 13 key changes (for reference)

PHPUnit 13 requires PHP 8.4+. Removed APIs:
- `Assert::isType()`, `assertContainsOnly()`, `assertNotContainsOnly()`, `containsOnly()`
- `testClassName()` on called/finished hook events (NOT errored events)
- `Configuration::includeTestSuite()` / `excludeTestSuite()`
- `#[RunClassInSeparateProcess]` attribute
- `--dont-report-useless-tests` CLI option
- PHP 8.3 support

None of these affect Pest's runtime code.