### PR TITLE
fix: do not keep the locking of PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
     "conflict": {
         "filp/whoops": "<2.18.3",
-        "phpunit/phpunit": ">12.5.8",
         "sebastian/exporter": "<7.0.0",
         "webmozart/assert": "<1.11.0"
     },


### PR DESCRIPTION
### What:

Bug Fix

### Description:

It seems since https://github.com/pestphp/pest/commit/bb1a0b5e79a2bd80258679afff1ab9aeb49096e4, PestPHP locks the version of PHPUnit. I don't know if it is always useful but I guess we can remove it.

If we can't, so the constraint in "conflict" doesn't seem appropriate. Maybe fix the version in "require":
```json
{
  "require": {
    "phpunit/phpunit": "12.5.8"
  }
}
```
Or accept the patches:
```json
{
  "require": {
    "phpunit/phpunit": "~12.5.8"
  }
}
```

What is the right choice?

Thanks

Mika

### Related:

- https://github.com/pestphp/pest/commit/bb1a0b5e79a2bd80258679afff1ab9aeb49096e4
