### PR TITLE
[Laravel Preset] Allow App\Http to be used in providers

### DIFF
--- a/src/ArchPresets/Laravel.php
+++ b/src/ArchPresets/Laravel.php
@@ -150,7 +150,7 @@ final class Laravel extends AbstractPreset
             ->toHaveSuffix('Controller');
 
         $this->expectations[] = expect('App\Http')
-            ->toOnlyBeUsedIn('App\Http');
+            ->toOnlyBeUsedIn(['App\Http', 'App\Providers']);
 
         $this->expectations[] = expect('App\Http\Controllers')
             ->not->toHavePublicMethodsBesides(['__construct', '__invoke', 'index', 'show', 'create', 'store', 'edit', 'update', 'destroy', 'middleware']);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

There are scenarios where a Laravel application may legitimately reference classes from the `App\Http` namespace outside itself, for example:

- Applying middleware in a Filament app ([see docs](https://filamentphp.com/docs/5.x/panel-configuration#applying-middleware))
- Using the old RouteServiceProvider Laravel came with

Even if neither of these are scenarios a vanilla Laravel application will run into, I believe Filament is a big enough package in the ecosystem to warrant having good preset support out of the box (especially as we can't undo individual rules in the preset)