### PR TITLE
Fix --compact CLI flag not activating compact output

### DIFF
--- a/src/Plugins/Printer.php
+++ b/src/Plugins/Printer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Plugins;
 
+use NunoMaduro\Collision\Adapters\Phpunit\Printers\DefaultPrinter;
 use Pest\Contracts\Plugins\HandlesArguments;
 
 /**
@@ -18,6 +19,12 @@ final class Printer implements HandlesArguments
      */
     public function handleArguments(array $arguments): array
     {
+        if ($this->hasArgument('--compact', $arguments)) {
+            $arguments = $this->popArgument('--compact', $arguments);
+
+            DefaultPrinter::compact(true);
+        }
+
         if (! array_key_exists('COLLISION_PRINTER', $_SERVER)) {
             return $arguments;
         }


### PR DESCRIPTION
Fixes #1632

The `--compact` flag is listed in the help output but was never actually handled by any plugin. Running `pest --compact` had no effect on the output format — tests still displayed in the default verbose style.

This adds handling in the `Printer` plugin to call `DefaultPrinter::compact(true)` when `--compact` is passed as a CLI argument, which is the same thing `pest()->printer()->compact()` does in Pest.php config.