### PR TITLE
Fix typo in Pest.php stubs

### DIFF
--- a/stubs/init-laravel/Pest.php.stub
+++ b/stubs/init-laravel/Pest.php.stub
@@ -9,7 +9,7 @@ use Tests\TestCase;
 |
 | The closure you provide to your test functions is always bound to a specific PHPUnit test
 | case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
+| need to change it using the "pest()" function to bind different classes or traits.
 |
 */
 

--- a/stubs/init/Pest.php.stub
+++ b/stubs/init/Pest.php.stub
@@ -9,7 +9,7 @@ use Tests\TestCase;
 |
 | The closure you provide to your test functions is always bound to a specific PHPUnit test
 | case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
+| need to change it using the "pest()" function to bind different classes or traits.
 |
 */
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Removes incorrect indefinite article in the Pest.php stub comment.                 

"bind a different classes or traits" → "bind different classes or traits"

