### PR TITLE
Laravel Pint default formatting applied to Pest.php.stub

### DIFF
--- a/stubs/init-laravel/Pest.php.stub
+++ b/stubs/init-laravel/Pest.php.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 /*
@@ -14,7 +15,7 @@ use Tests\TestCase;
 */
 
 pest()->extend(TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+ // ->use(RefreshDatabase::class)
     ->in('Feature');
 
 /*


### PR DESCRIPTION
### What:

- [x] Bug Fix (more of a paper cut, really)
- [ ] New Feature

### Description:

Dear @nunomaduro,

I just installed a new Laravel project using Pest. After the installation, I ran `.vendor/bin/pint` with the `"preset": "laravel"`and noticed that some fixes are applied to the default Pest stub.

```bash
FIXED
...
✓ tests/Pest.php                            fully_qualified_strict_types, ordered_imports
```

I consider this a very small issue, but since Laravel, Pest and Pint have raised the DX bar very high over the years, I believe it was worth a few minutes to submit this PR to you.

All the changes applied are exactly the same as the changes applied by Pint.

Hope you will consider merging this PR.

Have a nice day and kind regards,
g
