### PR TITLE
fix: preserve full error message in not() expectation failures

### DIFF
--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -798,13 +798,11 @@ final readonly class OppositeExpectation
 
         $exporter = Exporter::default();
 
-        $toString = fn (mixed $argument): string => $exporter->shortenedExport($argument);
-
         throw new ExpectationFailedException(sprintf(
             'Expecting %s not %s %s.',
-            $toString($this->original->value),
+            $exporter->shortenedExport($this->original->value),
             strtolower((string) preg_replace('/(?<!\ )[A-Z]/', ' $0', $name)),
-            implode(' ', array_map(fn (mixed $argument): string => $toString($argument), $arguments)),
+            implode(' ', array_map(fn (mixed $argument): string => $exporter->export($argument), $arguments)),
         ));
     }
 

--- a/src/Support/Exporter.php
+++ b/src/Support/Exporter.php
@@ -86,4 +86,17 @@ final readonly class Exporter
 
         return (string) preg_replace(array_keys($map), array_values($map), $this->exporter->shortenedExport($value));
     }
+
+    /**
+     * Exports a value into a full single-line string without truncation.
+     */
+    public function export(mixed $value): string
+    {
+        $map = [
+            '#\\\n\s*#' => '',
+            '# Object \(\.{3}\)#' => '',
+        ];
+
+        return (string) preg_replace(array_keys($map), array_values($map), $this->exporter->export($value));
+    }
 }

--- a/tests/Unit/Expectations/OppositeExpectation.php
+++ b/tests/Unit/Expectations/OppositeExpectation.php
@@ -14,3 +14,17 @@ it('throw expectation failed exception with array argument', function (): void {
 
     $expectation->throwExpectationFailedException('toBe', ['bar']);
 })->throws(ExpectationFailedException::class, "Expecting 'foo' not to be 'bar'.");
+
+it('does not truncate long string arguments in error message', function (): void {
+    $expectation = new OppositeExpectation(expect('foo'));
+
+    $longMessage = 'Very long error message. Very long error message. Very long error message.';
+
+    $expectation->throwExpectationFailedException('toBe', [$longMessage]);
+})->throws(ExpectationFailedException::class, 'Very long error message. Very long error message. Very long error message.');
+
+it('does not truncate custom error message when using not()', function (): void {
+    $longMessage = 'This is a very detailed custom error message that should not be truncated in the output.';
+
+    expect(true)->not()->toBeTrue($longMessage);
+})->throws(ExpectationFailedException::class, 'This is a very detailed custom error message that should not be truncated in the output.');


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When using `not()` expectations with custom error messages, the output is truncated:

```php
// Shows truncated message ❌
expect(true)->not()->toBeTrue('Very long error message. Very long error message. Very long error message.');
// Output: "Expecting true not to be true 'Very long error message. Very…ssage.'"

// Shows full message ✅ (without not())
expect(false)->toBeTrue('Very long error message. Very long error message. Very long error message.');
```

**Root cause:** `OppositeExpectation::throwExpectationFailedException()` passes all arguments through `Exporter::shortenedExport()`, which truncates strings longer than ~40 characters via PHPUnit's `SebastianBergmann\Exporter\Exporter::shortenedExport()`.

**Fix:** Uses `Exporter::export()` (full export, no truncation) instead of `shortenedExport()` for the arguments in the error message. The expectation value itself still uses `shortenedExport()` to keep it concise. Added the `export()` method to `Pest\Support\Exporter` as a counterpart to the existing `shortenedExport()`.

All existing tests pass unchanged. PHPStan clean. Pint clean.

### Related:

Fixes #1533