### PR TITLE
[4.x] Add dependsExternal (depend on tests in external test files)

### DIFF
--- a/overrides/Runner/TestSuiteLoader.php
+++ b/overrides/Runner/TestSuiteLoader.php
@@ -179,7 +179,6 @@ final class TestSuiteLoader
         if (! class_exists($suiteClassName, false)) {
             return $this->exceptionFor($suiteClassName, $suiteClassFile);
         }
-
         // @codeCoverageIgnoreEnd
 
         if ($class->isSubclassOf(TestCase::class) && ! $class->isAbstract()) {

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -15,6 +15,7 @@ use Pest\TestSuite;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DependsExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
@@ -103,6 +104,19 @@ final class TestCaseMethodFactory
     public array $depends = [];
 
     /**
+     * The test's external dependencies (tests in other Pest test files).
+     *
+     * Example:
+     * [
+     *  'testCase' => 'Tests\Features\Depends',
+     *  'test' => 'first',
+     * ]
+     *
+     * @var array<int, array{testCase: string, depend: string}>
+     */
+    public array $dependsExternal = [];
+
+    /**
      * The test's groups.
      *
      * @var array<int, string>
@@ -183,7 +197,7 @@ final class TestCaseMethodFactory
      */
     public function receivesArguments(): bool
     {
-        return $this->datasets !== [] || $this->depends !== [] || $this->repetitions > 1;
+        return $this->datasets !== [] || $this->depends !== [] || $this->dependsExternal !== [] || $this->repetitions > 1;
     }
 
     /**
@@ -217,6 +231,20 @@ final class TestCaseMethodFactory
             $this->attributes[] = new Attribute(
                 Depends::class,
                 [$depend],
+            );
+        }
+
+        foreach ($this->dependsExternal as $externalDepend) {
+            $depend = Str::evaluable(
+                $this->describing === []
+                    ? $externalDepend['test']
+                    : Str::describe($this->describing, $externalDepend['test'])
+            );
+
+            $className = 'P\\'.$externalDepend['testCase'];
+            $this->attributes[] = new Attribute(
+                DependsExternal::class,
+                [$className, $depend],
             );
         }
 

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -112,7 +112,7 @@ final class TestCaseMethodFactory
      *  'test' => 'first',
      * ]
      *
-     * @var array<int, array{testCase: string, depend: string}>
+     * @var array<int, array{testCase: string, test: string}>
      */
     public array $dependsExternal = [];
 

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -211,8 +211,8 @@ final class TestCall // @phpstan-ignore-line
     /**
      * Sets external test dependencies from another Pest test file reference.
      *
-     * @param string $testCase The Pest test reference (e.g. "Tests\Features\Depends")
-     * @param string ...$depends One or more test descriptions to depend on
+     * @param  string  $testCase  The Pest test reference (e.g. "Tests\Features\Depends")
+     * @param  string  ...$depends  One or more test descriptions to depend on
      */
     public function dependsExternal(string $testCase, string ...$depends): self
     {

--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -209,6 +209,24 @@ final class TestCall // @phpstan-ignore-line
     }
 
     /**
+     * Sets external test dependencies from another Pest test file reference.
+     *
+     * @param string $testCase The Pest test reference (e.g. "Tests\Features\Depends")
+     * @param string ...$depends One or more test descriptions to depend on
+     */
+    public function dependsExternal(string $testCase, string ...$depends): self
+    {
+        foreach ($depends as $depend) {
+            $this->testCaseMethod->dependsExternal[] = [
+                'testCase' => $testCase,
+                'test' => $depend,
+            ];
+        }
+
+        return $this;
+    }
+
+    /**
      * Sets the test group(s).
      */
     public function group(string ...$groups): self

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -291,6 +291,8 @@
 
    PASS  Tests\Features\DependsExternal
   ✓ dependsExternal
+  ✓ dependsExternal chained
+  ✓ dependsExternal chained, reversed
   ✓ depends on tests in an external file
   ✓ depends on tests in an external file with spread arguments
   ✓ depends on tests in an external file with defined arguments
@@ -1907,4 +1909,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1298 passed (2978 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1300 passed (2980 assertions)

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -289,6 +289,12 @@
   ✓ describe block → nested describe → third in nested describe
   ✓ depends on test after describe block
 
+   PASS  Tests\Features\DependsExternal
+  ✓ dependsExternal
+  ✓ depends on tests in an external file
+  ✓ depends on tests in an external file with spread arguments
+  ✓ depends on tests in an external file with defined arguments
+
    PASS  Tests\Features\DependsInheritance
   ✓ it is a test
   ✓ it uses correct parent class
@@ -1901,4 +1907,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1294 passed (2971 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1298 passed (2978 assertions)

--- a/tests/Features/DependsExternal.php
+++ b/tests/Features/DependsExternal.php
@@ -4,6 +4,16 @@ test('dependsExternal', function () {
     expect(func_get_args())->toBe(['first', 'second']);
 })->dependsExternal('Tests\Features\Depends', 'first', 'second');
 
+test('dependsExternal chained', function () {
+    expect(func_get_args())->toBe(['first', 'second']);
+})->dependsExternal('Tests\Features\Depends', 'first')
+    ->dependsExternal('Tests\Features\Depends', 'second');
+
+test('dependsExternal chained, reversed', function () {
+    expect(func_get_args())->toBe(['second', 'first']);
+})->dependsExternal('Tests\Features\Depends', 'second')
+    ->dependsExternal('Tests\Features\Depends', 'first');
+
 test('depends on tests in an external file', function (string $first, string $second) {
     expect($first)->toBe('first');
     expect($second)->toBe('second');

--- a/tests/Features/DependsExternal.php
+++ b/tests/Features/DependsExternal.php
@@ -1,6 +1,20 @@
 <?php
 
-test('depends on test in an an external file', function (string $first, string $second) {
+test('dependsExternal', function () {
+    expect(func_get_args())->toBe(['first', 'second']);
+})->dependsExternal('Tests\Features\Depends', 'first', 'second');
+
+test('depends on tests in an external file', function (string $first, string $second) {
+    expect($first)->toBe('first');
+    expect($second)->toBe('second');
+})->dependsExternal('Tests\Features\Depends', 'first', 'second');
+
+test('depends on tests in an external file with spread arguments', function (string ...$params) {
+    expect(func_get_args())->toBe($params);
+    expect($params)->toBe(['first', 'second']);
+})->dependsExternal('Tests\Features\Depends', 'first', 'second');
+
+test('depends on tests in an external file with defined arguments', function (string $first, string $second) {
     expect($first)->toBe('first');
     expect($second)->toBe('second');
 })->dependsExternal('Tests\Features\Depends', 'first', 'second');

--- a/tests/Features/DependsExternal.php
+++ b/tests/Features/DependsExternal.php
@@ -1,0 +1,6 @@
+<?php
+
+test('depends on test in an an external file', function (string $first, string $second) {
+    expect($first)->toBe('first');
+    expect($second)->toBe('second');
+})->dependsExternal('Tests\Features\Depends', 'first', 'second');

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -23,13 +23,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1282 passed (2927 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1284 passed (2929 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1282 passed (2927 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1284 passed (2929 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -23,13 +23,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1278 passed (2920 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1282 passed (2927 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1278 passed (2920 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1282 passed (2927 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What

- [ ] Bug Fix
- [x] New Feature

### Description

The existing `depends()` method does not support dependencies across test files. In larger test suites, it can be useful to reuse values returned by tests defined in other test cases.

This PR introduces a chainable `dependsExternal()` method, which allows a test to depend on tests defined in another test file. It accepts the target test file as the first argument, followed by one or more dependency test names as variadic arguments.

Example usage:

```php
test('depends on tests in an external file', function (string $first, string $second) {
    expect($first)->toBe('first');
    expect($second)->toBe('second');
})->dependsExternal('Tests\\Features\\Depends', 'first', 'second');
```

### Related:
https://github.com/pestphp/pest/issues/969
https://github.com/pestphp/pest/pull/1059
https://github.com/pestphp/pest/issues/1054
