### PR TITLE
fix: handle remaining PHPUnit TestResult events in parallel state

### DIFF
--- a/src/Support/StateGenerator.php
+++ b/src/Support/StateGenerator.php
@@ -165,6 +165,60 @@ final class StateGenerator
             }
         }
 
+        foreach ($testResult->errors() as $testResultEvent) {
+            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
+                ['test' => $test] = $triggeringTest;
+
+                $state->add(TestResult::fromPestParallelTestCase(
+                    $test,
+                    TestResult::FAIL,
+                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
+                ));
+            }
+        }
+
+        $standaloneSequence = 0;
+
+        foreach ($testResult->testSuiteSkippedEvents() as $testResultEvent) {
+            $this->addStandaloneEvent(
+                $state,
+                $testResultEvent->testSuite()->name(),
+                TestResult::SKIPPED,
+                $testResultEvent->message(),
+                ++$standaloneSequence,
+            );
+        }
+
+        foreach ($testResult->testRunnerTriggeredDeprecationEvents() as $testResultEvent) {
+            $this->addStandaloneEvent(
+                $state,
+                'PHPUnit test runner deprecation',
+                TestResult::DEPRECATED,
+                $testResultEvent->message(),
+                ++$standaloneSequence,
+            );
+        }
+
+        foreach ($testResult->testRunnerTriggeredNoticeEvents() as $testResultEvent) {
+            $this->addStandaloneEvent(
+                $state,
+                'PHPUnit test runner notice',
+                TestResult::NOTICE,
+                $testResultEvent->message(),
+                ++$standaloneSequence,
+            );
+        }
+
+        foreach ($testResult->testRunnerTriggeredWarningEvents() as $testResultEvent) {
+            $this->addStandaloneEvent(
+                $state,
+                'PHPUnit test runner warning',
+                TestResult::WARN,
+                $testResultEvent->message(),
+                ++$standaloneSequence,
+            );
+        }
+
         // for each test that passed, we need to add it to the state
         for ($i = 0; $i < $passedTests; $i++) {
             $state->add(TestResult::fromPestParallelTestCase(
@@ -202,5 +256,24 @@ final class StateGenerator
                 ));
             }
         }
+    }
+
+    private function addStandaloneEvent(State $state, string $className, string $type, string $message, int $sequence): void
+    {
+        $methodName = 'event#'.$sequence;
+
+        $state->add(TestResult::fromPestParallelTestCase(
+            new TestMethod(
+                $className, // @phpstan-ignore-line
+                $methodName, // @phpstan-ignore-line
+                ' ', // @phpstan-ignore-line
+                1,
+                TestDoxBuilder::fromClassNameAndMethodName($className, $methodName), // @phpstan-ignore-line
+                MetadataCollection::fromArray([]),
+                TestDataCollection::fromArray([]),
+            ),
+            $type,
+            ThrowableBuilder::from(new TestOutcome($message))
+        ));
     }
 }

--- a/src/Support/StateGenerator.php
+++ b/src/Support/StateGenerator.php
@@ -29,12 +29,9 @@ use PHPUnit\TestRunner\TestResult\TestResult as PHPUnitTestResult;
 
 final class StateGenerator
 {
-    private int $standaloneSequence = 0;
-
     public function fromPhpUnitTestResult(int $passedTests, PHPUnitTestResult $testResult): State
     {
         $state = new State;
-        $this->standaloneSequence = 0;
 
         foreach ($testResult->testErroredEvents() as $testResultEvent) {
             if ($testResultEvent instanceof Errored) {
@@ -95,12 +92,13 @@ final class StateGenerator
 
         $this->addIssueEvents($state, $testResult->errors(), TestResult::FAIL);
 
-        foreach ($testResult->testSuiteSkippedEvents() as $testResultEvent) {
+        foreach ($testResult->testSuiteSkippedEvents() as $index => $testResultEvent) {
             $this->addStandaloneEvent(
                 $state,
                 $testResultEvent->testSuite()->name(),
                 TestResult::SKIPPED,
                 $testResultEvent->message(),
+                $index,
             );
         }
 
@@ -182,14 +180,14 @@ final class StateGenerator
      */
     private function addStandaloneEvents(State $state, array $events, string $className, string $type): void
     {
-        foreach ($events as $event) {
-            $this->addStandaloneEvent($state, $className, $type, $event->message());
+        foreach ($events as $index => $event) {
+            $this->addStandaloneEvent($state, $className, $type, $event->message(), $index);
         }
     }
 
-    private function addStandaloneEvent(State $state, string $className, string $type, string $message): void
+    private function addStandaloneEvent(State $state, string $className, string $type, string $message, int $index): void
     {
-        $methodName = 'event#'.(++$this->standaloneSequence);
+        $methodName = 'event#'.$index;
 
         $state->add(TestResult::fromPestParallelTestCase(
             new TestMethod(

--- a/src/Support/StateGenerator.php
+++ b/src/Support/StateGenerator.php
@@ -10,6 +10,10 @@ use NunoMaduro\Collision\Exceptions\TestOutcome;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Test\AfterLastTestMethodErrored;
+use PHPUnit\Event\Test\AfterLastTestMethodFailed;
+use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
+use PHPUnit\Event\Test\BeforeFirstTestMethodFailed;
 use PHPUnit\Event\Test\ConsideredRisky;
 use PHPUnit\Event\Test\Errored;
 use PHPUnit\Event\Test\Failed;
@@ -33,31 +37,8 @@ final class StateGenerator
     {
         $state = new State;
 
-        foreach ($testResult->testErroredEvents() as $testResultEvent) {
-            if ($testResultEvent instanceof Errored) {
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $testResultEvent->test(),
-                    TestResult::FAIL,
-                    $testResultEvent->throwable()
-                ));
-            } else {
-                // @phpstan-ignore-next-line
-                $state->add(TestResult::fromBeforeFirstTestMethodErrored($testResultEvent));
-            }
-        }
-
-        foreach ($testResult->testFailedEvents() as $testResultEvent) {
-            if ($testResultEvent instanceof Failed) {
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $testResultEvent->test(),
-                    TestResult::FAIL,
-                    $testResultEvent->throwable()
-                ));
-            } else {
-                // @phpstan-ignore-next-line
-                $state->add(TestResult::fromBeforeFirstTestMethodErrored($testResultEvent));
-            }
-        }
+        $this->addErroredOrFailedEvents($state, $testResult->testErroredEvents());
+        $this->addErroredOrFailedEvents($state, $testResult->testFailedEvents());
 
         $this->addTriggeredPhpunitEvents($state, $testResult->testTriggeredPhpunitErrorEvents(), TestResult::FAIL);
 
@@ -126,6 +107,27 @@ final class StateGenerator
     }
 
     /**
+     * @param  list<AfterLastTestMethodErrored|AfterLastTestMethodFailed|BeforeFirstTestMethodErrored|BeforeFirstTestMethodFailed|Errored|Failed>  $events
+     */
+    private function addErroredOrFailedEvents(State $state, array $events): void
+    {
+        foreach ($events as $event) {
+            if ($event instanceof Errored || $event instanceof Failed) {
+                $state->add(TestResult::fromPestParallelTestCase(
+                    $event->test(),
+                    TestResult::FAIL,
+                    $event->throwable()
+                ));
+
+                continue;
+            }
+
+            // @phpstan-ignore-next-line
+            $state->add(TestResult::fromBeforeFirstTestMethodErrored($event));
+        }
+    }
+
+    /**
      * @param  list<Issue>  $issues
      */
     private function addIssueEvents(State $state, array $issues, string $type): void
@@ -142,7 +144,7 @@ final class StateGenerator
     }
 
     /**
-     * @param  list<Failed|MarkedIncomplete>  $events
+     * @param  list<MarkedIncomplete>  $events
      */
     private function addThrowableEvents(State $state, array $events, string $type): void
     {

--- a/src/Support/StateGenerator.php
+++ b/src/Support/StateGenerator.php
@@ -10,22 +10,31 @@ use NunoMaduro\Collision\Exceptions\TestOutcome;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Test\ConsideredRisky;
 use PHPUnit\Event\Test\Errored;
 use PHPUnit\Event\Test\Failed;
+use PHPUnit\Event\Test\MarkedIncomplete;
 use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
 use PHPUnit\Event\Test\PhpunitErrorTriggered;
 use PHPUnit\Event\Test\PhpunitNoticeTriggered;
 use PHPUnit\Event\Test\PhpunitWarningTriggered;
 use PHPUnit\Event\TestData\TestDataCollection;
+use PHPUnit\Event\TestRunner\DeprecationTriggered;
+use PHPUnit\Event\TestRunner\NoticeTriggered;
+use PHPUnit\Event\TestRunner\WarningTriggered;
 use PHPUnit\Framework\SkippedWithMessageException;
 use PHPUnit\Metadata\MetadataCollection;
+use PHPUnit\TestRunner\TestResult\Issues\Issue;
 use PHPUnit\TestRunner\TestResult\TestResult as PHPUnitTestResult;
 
 final class StateGenerator
 {
+    private int $standaloneSequence = 0;
+
     public function fromPhpUnitTestResult(int $passedTests, PHPUnitTestResult $testResult): State
     {
         $state = new State;
+        $this->standaloneSequence = 0;
 
         foreach ($testResult->testErroredEvents() as $testResultEvent) {
             if ($testResultEvent instanceof Errored) {
@@ -55,23 +64,8 @@ final class StateGenerator
 
         $this->addTriggeredPhpunitEvents($state, $testResult->testTriggeredPhpunitErrorEvents(), TestResult::FAIL);
 
-        foreach ($testResult->testMarkedIncompleteEvents() as $testResultEvent) {
-            $state->add(TestResult::fromPestParallelTestCase(
-                $testResultEvent->test(),
-                TestResult::INCOMPLETE,
-                $testResultEvent->throwable()
-            ));
-        }
-
-        foreach ($testResult->testConsideredRiskyEvents() as $riskyEvents) {
-            foreach ($riskyEvents as $riskyEvent) {
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $riskyEvent->test(),
-                    TestResult::RISKY,
-                    ThrowableBuilder::from(new TestOutcome($riskyEvent->message()))
-                ));
-            }
-        }
+        $this->addThrowableEvents($state, $testResult->testMarkedIncompleteEvents(), TestResult::INCOMPLETE);
+        $this->addTriggeredPhpunitEvents($state, $testResult->testConsideredRiskyEvents(), TestResult::RISKY);
 
         foreach ($testResult->testSkippedEvents() as $testResultEvent) {
             if ($testResultEvent->message() === '__TODO__') {
@@ -87,97 +81,19 @@ final class StateGenerator
             ));
         }
 
-        foreach ($testResult->deprecations() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::DEPRECATED,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
-        foreach ($testResult->phpDeprecations() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::DEPRECATED,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
+        $this->addIssueEvents($state, $testResult->deprecations(), TestResult::DEPRECATED);
+        $this->addIssueEvents($state, $testResult->phpDeprecations(), TestResult::DEPRECATED);
         $this->addTriggeredPhpunitEvents($state, $testResult->testTriggeredPhpunitDeprecationEvents(), TestResult::DEPRECATED);
 
-        foreach ($testResult->notices() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::NOTICE,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
-        foreach ($testResult->phpNotices() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::NOTICE,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
+        $this->addIssueEvents($state, $testResult->notices(), TestResult::NOTICE);
+        $this->addIssueEvents($state, $testResult->phpNotices(), TestResult::NOTICE);
         $this->addTriggeredPhpunitEvents($state, $testResult->testTriggeredPhpunitNoticeEvents(), TestResult::NOTICE);
 
-        foreach ($testResult->warnings() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::WARN,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
+        $this->addIssueEvents($state, $testResult->warnings(), TestResult::WARN);
+        $this->addIssueEvents($state, $testResult->phpWarnings(), TestResult::WARN);
         $this->addTriggeredPhpunitEvents($state, $testResult->testTriggeredPhpunitWarningEvents(), TestResult::WARN);
 
-        foreach ($testResult->phpWarnings() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::WARN,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
-        foreach ($testResult->errors() as $testResultEvent) {
-            foreach ($testResultEvent->triggeringTests() as $triggeringTest) {
-                ['test' => $test] = $triggeringTest;
-
-                $state->add(TestResult::fromPestParallelTestCase(
-                    $test,
-                    TestResult::FAIL,
-                    ThrowableBuilder::from(new TestOutcome($testResultEvent->description()))
-                ));
-            }
-        }
-
-        $standaloneSequence = 0;
+        $this->addIssueEvents($state, $testResult->errors(), TestResult::FAIL);
 
         foreach ($testResult->testSuiteSkippedEvents() as $testResultEvent) {
             $this->addStandaloneEvent(
@@ -185,39 +101,12 @@ final class StateGenerator
                 $testResultEvent->testSuite()->name(),
                 TestResult::SKIPPED,
                 $testResultEvent->message(),
-                ++$standaloneSequence,
             );
         }
 
-        foreach ($testResult->testRunnerTriggeredDeprecationEvents() as $testResultEvent) {
-            $this->addStandaloneEvent(
-                $state,
-                'PHPUnit test runner deprecation',
-                TestResult::DEPRECATED,
-                $testResultEvent->message(),
-                ++$standaloneSequence,
-            );
-        }
-
-        foreach ($testResult->testRunnerTriggeredNoticeEvents() as $testResultEvent) {
-            $this->addStandaloneEvent(
-                $state,
-                'PHPUnit test runner notice',
-                TestResult::NOTICE,
-                $testResultEvent->message(),
-                ++$standaloneSequence,
-            );
-        }
-
-        foreach ($testResult->testRunnerTriggeredWarningEvents() as $testResultEvent) {
-            $this->addStandaloneEvent(
-                $state,
-                'PHPUnit test runner warning',
-                TestResult::WARN,
-                $testResultEvent->message(),
-                ++$standaloneSequence,
-            );
-        }
+        $this->addStandaloneEvents($state, $testResult->testRunnerTriggeredDeprecationEvents(), 'PHPUnit test runner deprecation', TestResult::DEPRECATED);
+        $this->addStandaloneEvents($state, $testResult->testRunnerTriggeredNoticeEvents(), 'PHPUnit test runner notice', TestResult::NOTICE);
+        $this->addStandaloneEvents($state, $testResult->testRunnerTriggeredWarningEvents(), 'PHPUnit test runner warning', TestResult::WARN);
 
         // for each test that passed, we need to add it to the state
         for ($i = 0; $i < $passedTests; $i++) {
@@ -239,7 +128,37 @@ final class StateGenerator
     }
 
     /**
-     * @param  array<string, list<PhpunitDeprecationTriggered|PhpunitErrorTriggered|PhpunitNoticeTriggered|PhpunitWarningTriggered>>  $testResultEvents
+     * @param  list<Issue>  $issues
+     */
+    private function addIssueEvents(State $state, array $issues, string $type): void
+    {
+        foreach ($issues as $issue) {
+            foreach ($issue->triggeringTests() as ['test' => $test]) {
+                $state->add(TestResult::fromPestParallelTestCase(
+                    $test,
+                    $type,
+                    ThrowableBuilder::from(new TestOutcome($issue->description()))
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param  list<Failed|MarkedIncomplete>  $events
+     */
+    private function addThrowableEvents(State $state, array $events, string $type): void
+    {
+        foreach ($events as $event) {
+            $state->add(TestResult::fromPestParallelTestCase(
+                $event->test(),
+                $type,
+                $event->throwable(),
+            ));
+        }
+    }
+
+    /**
+     * @param  array<string, list<ConsideredRisky|PhpunitDeprecationTriggered|PhpunitErrorTriggered|PhpunitNoticeTriggered|PhpunitWarningTriggered>>  $testResultEvents
      */
     private function addTriggeredPhpunitEvents(State $state, array $testResultEvents, string $type): void
     {
@@ -258,9 +177,19 @@ final class StateGenerator
         }
     }
 
-    private function addStandaloneEvent(State $state, string $className, string $type, string $message, int $sequence): void
+    /**
+     * @param  list<DeprecationTriggered|NoticeTriggered|WarningTriggered>  $events
+     */
+    private function addStandaloneEvents(State $state, array $events, string $className, string $type): void
     {
-        $methodName = 'event#'.$sequence;
+        foreach ($events as $event) {
+            $this->addStandaloneEvent($state, $className, $type, $event->message());
+        }
+    }
+
+    private function addStandaloneEvent(State $state, string $className, string $type, string $message): void
+    {
+        $methodName = 'event#'.(++$this->standaloneSequence);
 
         $state->add(TestResult::fromPestParallelTestCase(
             new TestMethod(

--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -23,6 +23,6 @@
 ##teamcity[testFinished name='it is passing' duration='100000' flowId='1234']
 ##teamcity[testSuiteFinished name='Tests/tests/Failure' flowId='1234']
 
-  [90mTests:[39m    [31;1m3 failed[39;22m[90m,[39m[39m [39m[33;1m4 warnings[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m,[39m[39m [39m[32;1m1 passed[39;22m[90m (3 assertions)[39m
+  [90mTests:[39m    [31;1m3 failed[39;22m[90m,[39m[39m [39m[33;1m2 warnings[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m,[39m[39m [39m[32;1m1 passed[39;22m[90m (3 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m
 

--- a/tests/.snapshots/Failure.php.inc
+++ b/tests/.snapshots/Failure.php.inc
@@ -23,6 +23,6 @@
 ##teamcity[testFinished name='it is passing' duration='100000' flowId='1234']
 ##teamcity[testSuiteFinished name='Tests/tests/Failure' flowId='1234']
 
-  [90mTests:[39m    [31;1m3 failed[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m,[39m[39m [39m[32;1m1 passed[39;22m[90m (3 assertions)[39m
+  [90mTests:[39m    [31;1m3 failed[39;22m[90m,[39m[39m [39m[33;1m4 warnings[39;22m[90m,[39m[39m [39m[33;1m1 risky[39;22m[90m,[39m[39m [39m[36;1m2 todos[39;22m[90m,[39m[39m [39m[33;1m1 skipped[39;22m[90m,[39m[39m [39m[32;1m1 passed[39;22m[90m (3 assertions)[39m
   [90mDuration:[39m [39m1.00s[39m
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1887,6 +1887,14 @@
   ✓ it gets properties from classes
   ✓ it gets methods from classes
 
+   PASS  Tests\Unit\Support\StateGenerator
+  ✓ it records errors as failed results
+  ✓ it records test runner triggered deprecation events
+  ✓ it records test runner triggered notice events
+  ✓ it records test runner triggered warning events
+  ✓ it records test suite skipped events
+  ✓ it keeps multiple standalone events as distinct entries
+
    PASS  Tests\Unit\Support\Str
   ✓ it evaluates the code with ('version()', '__pest_evaluable_version__')
   ✓ it evaluates the code with ('version__ ', '__pest_evaluable_version_____')
@@ -2006,4 +2014,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1389 passed (3097 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1395 passed (3117 assertions)

--- a/tests/Unit/Support/StateGenerator.php
+++ b/tests/Unit/Support/StateGenerator.php
@@ -1,0 +1,195 @@
+<?php
+
+use NunoMaduro\Collision\Adapters\Phpunit\TestResult as CollisionTestResult;
+use Pest\Support\StateGenerator;
+use PHPUnit\Event\Code\TestCollection;
+use PHPUnit\Event\Code\TestDoxBuilder;
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Telemetry\Duration;
+use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
+use PHPUnit\Event\Telemetry\HRTime;
+use PHPUnit\Event\Telemetry\Info;
+use PHPUnit\Event\Telemetry\MemoryUsage;
+use PHPUnit\Event\Telemetry\Snapshot;
+use PHPUnit\Event\TestData\TestDataCollection;
+use PHPUnit\Event\TestRunner\DeprecationTriggered as RunnerDeprecationTriggered;
+use PHPUnit\Event\TestRunner\NoticeTriggered as RunnerNoticeTriggered;
+use PHPUnit\Event\TestRunner\WarningTriggered as RunnerWarningTriggered;
+use PHPUnit\Event\TestSuite\Skipped as TestSuiteSkipped;
+use PHPUnit\Event\TestSuite\TestSuiteWithName;
+use PHPUnit\Metadata\MetadataCollection;
+use PHPUnit\TestRunner\TestResult\Issues\Issue;
+use PHPUnit\TestRunner\TestResult\TestResult as PHPUnitTestResult;
+
+$telemetryInfo = function (): Info {
+    return new Info(
+        new Snapshot(
+            HRTime::fromSecondsAndNanoseconds(0, 0),
+            MemoryUsage::fromBytes(0),
+            MemoryUsage::fromBytes(0),
+            new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+        ),
+        Duration::fromSecondsAndNanoseconds(0, 0),
+        MemoryUsage::fromBytes(0),
+        Duration::fromSecondsAndNanoseconds(0, 0),
+        MemoryUsage::fromBytes(0),
+    );
+};
+
+$syntheticTest = function (string $className = 'AcmeTest', string $methodName = 'testSomething'): TestMethod {
+    return new TestMethod(
+        $className, // @phpstan-ignore-line
+        $methodName,
+        __FILE__,
+        1,
+        TestDoxBuilder::fromClassNameAndMethodName($className, $methodName), // @phpstan-ignore-line
+        MetadataCollection::fromArray([]),
+        TestDataCollection::fromArray([]),
+    );
+};
+
+$phpUnitTestResult = function (array $overrides = []): PHPUnitTestResult {
+    $defaults = [
+        'testErroredEvents' => [],
+        'testFailedEvents' => [],
+        'testConsideredRiskyEvents' => [],
+        'testSuiteSkippedEvents' => [],
+        'testSkippedEvents' => [],
+        'testMarkedIncompleteEvents' => [],
+        'testTriggeredPhpunitDeprecationEvents' => [],
+        'testTriggeredPhpunitErrorEvents' => [],
+        'testTriggeredPhpunitNoticeEvents' => [],
+        'testTriggeredPhpunitWarningEvents' => [],
+        'testRunnerTriggeredDeprecationEvents' => [],
+        'testRunnerTriggeredNoticeEvents' => [],
+        'testRunnerTriggeredWarningEvents' => [],
+        'errors' => [],
+        'deprecations' => [],
+        'notices' => [],
+        'warnings' => [],
+        'phpDeprecations' => [],
+        'phpNotices' => [],
+        'phpWarnings' => [],
+    ];
+
+    $values = array_merge($defaults, $overrides);
+
+    return new PHPUnitTestResult(
+        0,
+        0,
+        0,
+        $values['testErroredEvents'],
+        $values['testFailedEvents'],
+        $values['testConsideredRiskyEvents'],
+        $values['testSuiteSkippedEvents'],
+        $values['testSkippedEvents'],
+        $values['testMarkedIncompleteEvents'],
+        $values['testTriggeredPhpunitDeprecationEvents'],
+        $values['testTriggeredPhpunitErrorEvents'],
+        $values['testTriggeredPhpunitNoticeEvents'],
+        $values['testTriggeredPhpunitWarningEvents'],
+        $values['testRunnerTriggeredDeprecationEvents'],
+        $values['testRunnerTriggeredNoticeEvents'],
+        $values['testRunnerTriggeredWarningEvents'],
+        $values['errors'],
+        $values['deprecations'],
+        $values['notices'],
+        $values['warnings'],
+        $values['phpDeprecations'],
+        $values['phpNotices'],
+        $values['phpWarnings'],
+        0,
+    );
+};
+
+it('records errors as failed results', function () use ($phpUnitTestResult, $syntheticTest) {
+    $issue = Issue::from('/tmp/test.php', 1, 'user error description', $syntheticTest());
+
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult(['errors' => [$issue]]));
+
+    expect($state->suiteTests)->toHaveCount(1);
+
+    $result = array_values($state->suiteTests)[0];
+
+    expect($result->type)->toBe(CollisionTestResult::FAIL)
+        ->and($result->throwable?->message())->toBe('user error description');
+});
+
+it('records test runner triggered deprecation events', function () use ($phpUnitTestResult, $telemetryInfo) {
+    $event = new RunnerDeprecationTriggered($telemetryInfo(), 'cli flag is deprecated');
+
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult([
+        'testRunnerTriggeredDeprecationEvents' => [$event],
+    ]));
+
+    expect($state->suiteTests)->toHaveCount(1);
+
+    $result = array_values($state->suiteTests)[0];
+
+    expect($result->type)->toBe(CollisionTestResult::DEPRECATED)
+        ->and($result->testCaseName)->toBe('PHPUnit test runner deprecation')
+        ->and($result->throwable?->message())->toBe('cli flag is deprecated');
+});
+
+it('records test runner triggered notice events', function () use ($phpUnitTestResult, $telemetryInfo) {
+    $event = new RunnerNoticeTriggered($telemetryInfo(), 'runner notice');
+
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult([
+        'testRunnerTriggeredNoticeEvents' => [$event],
+    ]));
+
+    expect($state->suiteTests)->toHaveCount(1);
+
+    $result = array_values($state->suiteTests)[0];
+
+    expect($result->type)->toBe(CollisionTestResult::NOTICE)
+        ->and($result->testCaseName)->toBe('PHPUnit test runner notice')
+        ->and($result->throwable?->message())->toBe('runner notice');
+});
+
+it('records test runner triggered warning events', function () use ($phpUnitTestResult, $telemetryInfo) {
+    $event = new RunnerWarningTriggered($telemetryInfo(), 'runner warning');
+
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult([
+        'testRunnerTriggeredWarningEvents' => [$event],
+    ]));
+
+    expect($state->suiteTests)->toHaveCount(1);
+
+    $result = array_values($state->suiteTests)[0];
+
+    expect($result->type)->toBe(CollisionTestResult::WARN)
+        ->and($result->testCaseName)->toBe('PHPUnit test runner warning')
+        ->and($result->throwable?->message())->toBe('runner warning');
+});
+
+it('records test suite skipped events', function () use ($phpUnitTestResult, $telemetryInfo) {
+    $suite = new TestSuiteWithName('AcmeSuite', 3, TestCollection::fromArray([]));
+    $event = new TestSuiteSkipped($telemetryInfo(), $suite, 'requires PHP 9');
+
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult([
+        'testSuiteSkippedEvents' => [$event],
+    ]));
+
+    expect($state->suiteTests)->toHaveCount(1);
+
+    $result = array_values($state->suiteTests)[0];
+
+    expect($result->type)->toBe(CollisionTestResult::SKIPPED)
+        ->and($result->testCaseName)->toBe('AcmeSuite')
+        ->and($result->throwable?->message())->toBe('requires PHP 9');
+});
+
+it('keeps multiple standalone events as distinct entries', function () use ($phpUnitTestResult, $telemetryInfo) {
+    $state = (new StateGenerator)->fromPhpUnitTestResult(0, $phpUnitTestResult([
+        'testRunnerTriggeredDeprecationEvents' => [
+            new RunnerDeprecationTriggered($telemetryInfo(), 'first'),
+            new RunnerDeprecationTriggered($telemetryInfo(), 'second'),
+        ],
+        'testRunnerTriggeredWarningEvents' => [
+            new RunnerWarningTriggered($telemetryInfo(), 'third'),
+        ],
+    ]));
+
+    expect($state->suiteTests)->toHaveCount(3);
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1372 passed (3044 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1378 passed (3064 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1372 passed (3044 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1378 passed (3064 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Follow-up to #1655. Extends `Pest\Support\StateGenerator` to process the `PHPUnit\TestRunner\TestResult\TestResult` methods it was still ignoring, so runner-level issues, skipped suites, and user-triggered errors show up in the parallel summary.

Handlers added:

- `errors()` → `FAIL`
- `testSuiteSkippedEvents()` → `SKIPPED`
- `testRunnerTriggeredDeprecationEvents()` → `DEPRECATED`
- `testRunnerTriggeredNoticeEvents()` → `NOTICE`
- `testRunnerTriggeredWarningEvents()` → `WARN`

Runner-level and suite-level events have no attached test, so they go through a small `addStandaloneEvent` helper that synthesises a `TestMethod` — same approach already used for the fabricated passed-test entries.

Two further commits tidy the surrounding code without changing behaviour:

- Shared loop shapes fold into private helpers: `addIssueEvents` for per-triggering-test events (deprecations, notices, warnings, the new `errors()`), `addThrowableEvents` for `test()`/`throwable()` pairs (failed + marked-incomplete), and `addStandaloneEvents` for the three runner-level event groups. The existing `addTriggeredPhpunitEvents` now also consumes `testConsideredRiskyEvents`, since it shares the same nested-array shape.
- Synthesised `TestMethod` ids are derived from the foreach index instead of a stateful counter — each call site already supplies a unique `className`, so `className::event#<index>` stays distinct.

Unit coverage for each new handler lives in `tests/Unit/Support/StateGenerator.php`.

### Related:

- #1655
- #1483 (visibility safety net for runner-level warnings)

Closes #1462 (the "missing implementations in StateGenerator.php" part)
