### PR TITLE
fix: honor all stop-on-* flags in parallel mode

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -33,12 +33,15 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use function array_merge;
 use function array_merge_recursive;
 use function array_shift;
+use function array_unique;
+use function array_values;
 use function assert;
 use function count;
 use function dirname;
 use function file_get_contents;
 use function max;
 use function realpath;
+use function str_contains;
 use function str_starts_with;
 use function unlink;
 use function unserialize;
@@ -106,6 +109,11 @@ final class WrapperRunner implements RunnerInterface
 
     /** @var non-empty-string[] */
     private readonly array $parameters;
+
+    /** @var list<string>|null */
+    private ?array $stopOutcomeChars = null;
+
+    private bool $stopRequested = false;
 
     /**
      * The code coverage filter registry.
@@ -210,10 +218,7 @@ final class WrapperRunner implements RunnerInterface
                     $worker = $this->startWorker($token);
                 }
 
-                if (
-                    $this->exitcode > 0
-                    && $this->options->configuration->stopOnFailure()
-                ) {
+                if ($this->shouldStop()) {
                     $this->pending = [];
                 } elseif (($pending = array_shift($this->pending)) !== null) {
                     $worker->assign($pending);
@@ -223,6 +228,80 @@ final class WrapperRunner implements RunnerInterface
 
             usleep(self::CYCLE_SLEEP);
         }
+    }
+
+    private function shouldStop(): bool
+    {
+        if ($this->stopRequested) {
+            return true;
+        }
+
+        $outcomes = $this->stopOutcomeChars();
+        if ($outcomes === []) {
+            return false;
+        }
+
+        foreach ($this->workers as $worker) {
+            $progress = file_get_contents($worker->progressFile->getPathname());
+            if ($progress === false || $progress === '') {
+                continue;
+            }
+
+            foreach ($outcomes as $outcome) {
+                if (str_contains($progress, $outcome)) {
+                    return $this->stopRequested = true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stopOutcomeChars(): array
+    {
+        if ($this->stopOutcomeChars !== null) {
+            return $this->stopOutcomeChars;
+        }
+
+        $configuration = $this->options->configuration;
+        $outcomes = [];
+
+        if ($configuration->stopOnFailure() || $configuration->stopOnDefect()) {
+            $outcomes[] = 'F';
+        }
+
+        if ($configuration->stopOnError() || $configuration->stopOnDefect()) {
+            $outcomes[] = 'E';
+        }
+
+        if ($configuration->stopOnRisky() || $configuration->stopOnDefect()) {
+            $outcomes[] = 'R';
+        }
+
+        if ($configuration->stopOnIncomplete() || $configuration->stopOnDefect()) {
+            $outcomes[] = 'I';
+        }
+
+        if ($configuration->stopOnWarning()) {
+            $outcomes[] = 'W';
+        }
+
+        if ($configuration->stopOnNotice()) {
+            $outcomes[] = 'N';
+        }
+
+        if ($configuration->stopOnDeprecation()) {
+            $outcomes[] = 'D';
+        }
+
+        if ($configuration->stopOnSkipped()) {
+            $outcomes[] = 'S';
+        }
+
+        return $this->stopOutcomeChars = array_values(array_unique($outcomes));
     }
 
     private function flushWorker(WrapperWorker $worker): void

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1908,6 +1908,23 @@
   ✓ parallel
   ✓ a parallel test can extend another test with same name
   ✓ parallel reports invalid datasets as failures
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('fails')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('errors')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('is risky')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('is incomplete')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('warns')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('notices')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('deprecates')
+  ✓ parallel stop-on-* fixture runs every case without a stop flag with ('is skipped')
+  ✓ parallel honors --stop-on-* with dataset "failure"
+  ✓ parallel honors --stop-on-* with dataset "defect"
+  ✓ parallel honors --stop-on-* with dataset "error"
+  ✓ parallel honors --stop-on-* with dataset "risky"
+  ✓ parallel honors --stop-on-* with dataset "incomplete"
+  ✓ parallel honors --stop-on-* with dataset "warning"
+  ✓ parallel honors --stop-on-* with dataset "notice"
+  ✓ parallel honors --stop-on-* with dataset "deprecation"
+  ✓ parallel honors --stop-on-* with dataset "skipped"
 
    PASS  Tests\Visual\ParallelNestedDatasets
   ✓ parallel loads nested datasets from nested directories
@@ -1941,4 +1958,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1330 passed (3010 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1347 passed (3027 assertions)

--- a/tests/.tests/ParallelStopOn/HasDeprecationTest.php
+++ b/tests/.tests/ParallelStopOn/HasDeprecationTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('deprecates', function () {
+    trigger_error('user deprecation', E_USER_DEPRECATED);
+
+    expect(true)->toBeTrue();
+});

--- a/tests/.tests/ParallelStopOn/HasErrorTest.php
+++ b/tests/.tests/ParallelStopOn/HasErrorTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('errors', function () {
+    throw new RuntimeException('boom');
+});

--- a/tests/.tests/ParallelStopOn/HasFailureTest.php
+++ b/tests/.tests/ParallelStopOn/HasFailureTest.php
@@ -1,0 +1,3 @@
+<?php
+
+it('fails')->assertTrue(false);

--- a/tests/.tests/ParallelStopOn/HasIncompleteTest.php
+++ b/tests/.tests/ParallelStopOn/HasIncompleteTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('is incomplete', function () {
+    $this->markTestIncomplete('work in progress');
+});

--- a/tests/.tests/ParallelStopOn/HasNoticeTest.php
+++ b/tests/.tests/ParallelStopOn/HasNoticeTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('notices', function () {
+    trigger_error('user notice', E_USER_NOTICE);
+
+    expect(true)->toBeTrue();
+});

--- a/tests/.tests/ParallelStopOn/HasRiskyTest.php
+++ b/tests/.tests/ParallelStopOn/HasRiskyTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('is risky', function () {
+    // no assertions
+});

--- a/tests/.tests/ParallelStopOn/HasSkippedTest.php
+++ b/tests/.tests/ParallelStopOn/HasSkippedTest.php
@@ -1,0 +1,3 @@
+<?php
+
+it('is skipped')->skip('skipping');

--- a/tests/.tests/ParallelStopOn/HasWarningTest.php
+++ b/tests/.tests/ParallelStopOn/HasWarningTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('warns', function () {
+    trigger_error('user warning', E_USER_WARNING);
+
+    expect(true)->toBeTrue();
+});

--- a/tests/.tests/ParallelStopOn/Passing/Passing01Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing01Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 01')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing02Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing02Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 02')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing03Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing03Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 03')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing04Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing04Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 04')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing05Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing05Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 05')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing06Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing06Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 06')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing07Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing07Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 07')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing08Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing08Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 08')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing09Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing09Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 09')->assertTrue(true);

--- a/tests/.tests/ParallelStopOn/Passing/Passing10Test.php
+++ b/tests/.tests/ParallelStopOn/Passing/Passing10Test.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes 10')->assertTrue(true);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -47,3 +47,33 @@ test('parallel reports invalid datasets as failures', function () use ($run) {
         ->toContain('Tests:    1 failed, 1 passed (1 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
+
+test('parallel stop-on-* fixture runs every case without a stop flag', function (string $testName) use ($run) {
+    $output = $run('--filter', "($testName|passes)", 'tests/.tests/ParallelStopOn');
+    expect($output)->toContain('10 passed');
+})->with([
+    'fails',
+    'errors',
+    'is risky',
+    'is incomplete',
+    'warns',
+    'notices',
+    'deprecates',
+    'is skipped',
+])->skipOnWindows();
+
+test('parallel honors --stop-on-*', function (string $flag, string $testName) use ($run) {
+    $output = $run('--filter', "($testName|passes)", $flag, 'tests/.tests/ParallelStopOn');
+    preg_match('/(\d+) passed/', $output, $matches);
+    expect((int) ($matches[1] ?? 0))->toBeLessThan(10);
+})->with([
+    'failure' => ['--stop-on-failure', 'fails'],
+    'defect' => ['--stop-on-defect', 'fails'],
+    'error' => ['--stop-on-error', 'errors'],
+    'risky' => ['--stop-on-risky', 'is risky'],
+    'incomplete' => ['--stop-on-incomplete', 'is incomplete'],
+    'warning' => ['--stop-on-warning', 'warns'],
+    'notice' => ['--stop-on-notice', 'notices'],
+    'deprecation' => ['--stop-on-deprecation', 'deprecates'],
+    'skipped' => ['--stop-on-skipped', 'is skipped'],
+])->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

In parallel mode only `--stop-on-failure` was honored, and only when a worker exited with a non-zero code. The seven other stop-on-* flags (`--stop-on-defect`, `--stop-on-error`, `--stop-on-risky`, `--stop-on-incomplete`, `--stop-on-warning`, `--stop-on-notice`, `--stop-on-deprecation`, `--stop-on-skipped`) were silently ignored - the test suite carried on to completion regardless.

`WrapperRunner` now precomputes the set of progress-file characters that should trigger a stop (`F`, `E`, `R`, `I`, `W`, `N`, `D`, `S`) from the configured flags, and scans each worker's progress file for them after every cycle. Once any matching outcome is seen, the pending queue is cleared so no further tests are dispatched.

**Known limitation:** up to `N - 1` in-flight tests (where `N` is `--processes`) can still complete after the first stop-worthy outcome. Interrupting them mid-run would risk corrupting shared state (databases, fixtures, temp files), so they are allowed to finish.

Integration coverage lives in `tests/Visual/Parallel.php` with a shared fixture at `tests/.tests/ParallelStopOn/` — one `Has*Test.php` trigger per outcome type plus a `Passing/` subdir of ten passing fixtures. A `--filter` regex selects exactly one trigger alongside the passing set per scenario, keeping the fixture DRY.

### Related:

Closes #1463.
