### PR TITLE
fix: bootstrap `<extensions>` before sealing the event facade in `--parallel` mode

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -16,7 +16,6 @@ use ParaTest\WrapperRunner\SuiteLoader;
 use ParaTest\WrapperRunner\WrapperWorker;
 use Pest\Result;
 use Pest\TestSuite;
-use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Event\Test\AfterLastTestMethodFailed;
 use PHPUnit\Event\TestRunner\WarningTriggered;
 use PHPUnit\Runner\CodeCoverage;
@@ -147,8 +146,6 @@ final class WrapperRunner implements RunnerInterface
     {
         $directory = dirname(__DIR__);
         ExcludeList::addDirectory($directory);
-        TestResultFacade::init();
-        EventFacade::instance()->seal();
         $suiteLoader = new SuiteLoader(
             $this->options,
             $this->output,

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1912,6 +1912,9 @@
    PASS  Tests\Visual\ParallelNestedDatasets
   ✓ parallel loads nested datasets from nested directories
 
+   PASS  Tests\Visual\ParallelRunnerWarning
+  ✓ parallel bootstraps extensions that register subscribers the same way sequential does
+
    PASS  Tests\Visual\SingleTestOrDirectory
   ✓ allows to run a single test
   ✓ allows to run a directory
@@ -1941,4 +1944,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1330 passed (3010 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1331 passed (3015 assertions)

--- a/tests/.tests/ParallelRunnerWarning/PassingTest.php
+++ b/tests/.tests/ParallelRunnerWarning/PassingTest.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes')->assertTrue(true);

--- a/tests/.tests/ParallelRunnerWarning/SubscribingExtension.php
+++ b/tests/.tests/ParallelRunnerWarning/SubscribingExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Tests\ParallelRunnerWarning;
+
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PreparedSubscriber;
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade as ExtensionFacade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class SubscribingExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, ExtensionFacade $facade, ParameterCollection $parameters): void
+    {
+        EventFacade::instance()->registerSubscriber(new class implements PreparedSubscriber {
+            public function notify(Prepared $event): void
+            {
+            }
+        });
+    }
+}

--- a/tests/.tests/ParallelRunnerWarning/bootstrap.php
+++ b/tests/.tests/ParallelRunnerWarning/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/../../../vendor/autoload.php';
+require_once __DIR__.'/SubscribingExtension.php';

--- a/tests/.tests/ParallelRunnerWarning/phpunit.xml
+++ b/tests/.tests/ParallelRunnerWarning/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+         bootstrap="./bootstrap.php"
+         failOnPhpunitWarning="true"
+         colors="true"
+>
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">.</directory>
+    </testsuite>
+  </testsuites>
+  <extensions>
+    <bootstrap class="Pest\Tests\ParallelRunnerWarning\SubscribingExtension"/>
+  </extensions>
+</phpunit>

--- a/tests/Visual/ParallelRunnerWarning.php
+++ b/tests/Visual/ParallelRunnerWarning.php
@@ -1,0 +1,30 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+$run = function (string ...$args) {
+    $process = new Process(
+        array_merge(['php', 'bin/pest', '--parallel', '--processes=2'], $args),
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true'],
+    );
+
+    $process->run();
+
+    return [
+        'output' => removeAnsiEscapeSequences($process->getOutput()),
+        'exitCode' => $process->getExitCode(),
+    ];
+};
+
+test('parallel bootstraps extensions that register subscribers the same way sequential does', function () use ($run) {
+    $result = $run('-c', 'tests/.tests/ParallelRunnerWarning/phpunit.xml');
+
+    expect($result['output'])
+        ->toContain('2 passed')
+        ->toContain('Parallel: 2 processes')
+        ->not->toContain('warning')
+        ->not->toContain('Bootstrapping of extension');
+
+    expect($result['exitCode'])->toBe(0);
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

In `--parallel` mode, `WrapperRunner` sealed the event facade before `SuiteLoader` bootstrapped the configured `<extensions>`. Any extension that called `EventFacade::registerSubscriber()` in its `bootstrap()` therefore hit `EventFacadeIsSealedException`; `ExtensionBootstrapper` caught it and emitted a silent `testRunnerTriggeredPhpunitWarning` - which, with PHPUnit 12's `failOnPhpunitWarning=true` default, flipped the exit code to 1 despite all tests passing.

`SuiteLoader` already calls `init` + `seal` after bootstrapping extensions (matching upstream Paratest), so the calls in `WrapperRunner::run()` were redundant. Removing them lets extensions register subscribers in parallel, the same way they do sequentially.

Added a visual test with a fixture extension that reproduces the silent-warning / exit-1 behavior on `4.x`.

### Related:

Closes #1483.