### PR TITLE
chore: increase parallel verbosity to allow line wrapping

### DIFF
--- a/src/Plugins/Parallel/Paratest/ResultPrinter.php
+++ b/src/Plugins/Parallel/Paratest/ResultPrinter.php
@@ -12,6 +12,7 @@ use PHPUnit\TextUI\Output\Printer;
 use SebastianBergmann\Timer\Duration;
 use SplFileInfo;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function assert;
@@ -83,6 +84,7 @@ final class ResultPrinter
 
         $this->compactPrinter = CompactPrinter::default(
             decorated: ! in_array('--colors=never', $_SERVER['argv'] ?? [], true),
+            verbosity: ConsoleOutput::VERBOSITY_VERBOSE,
         );
 
         if (! $this->options->configuration->hasLogfileTeamcity()) {

--- a/src/Plugins/Parallel/Support/CompactPrinter.php
+++ b/src/Plugins/Parallel/Support/CompactPrinter.php
@@ -62,12 +62,17 @@ final class CompactPrinter
     /**
      * Creates a new instance of the Compact Printer.
      */
-    public static function default(bool $decorated = true): self
-    {
+    public static function default(
+        bool $decorated = true,
+        int $verbosity = ConsoleOutput::VERBOSITY_NORMAL,
+    ): self {
         return new self(
             terminal(),
             new ConsoleOutput(decorated: $decorated),
-            new Style(new ConsoleOutput(decorated: $decorated)),
+            new Style(new ConsoleOutput(
+                verbosity: $verbosity,
+                decorated: $decorated,
+            )),
             terminal()->width() - 4,
         );
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

The parallel runner always uses the `ResultPrinter` to print any errors. This uses the `CompactPrinter` in turn. This results in test names and provider names being cut of when your terminal is not big enough. This is an issue when you run tests in parallel (especially in CI), as you cannot see what test or data provider is failing. 

As far as I can see, there is no flag available to change this behavior. If there is, please let me know! I think increasing the default verbosity in the usage of the `CompactPrinter` used in the `ResultPrinter` is a decent default when there is no flag available. The only actual change I can see is that the test name is not being cut off, but wrapped to the next line.

If you want me to change this differently, please let me now how!

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
https://github.com/pestphp/pest/issues/828
https://github.com/pestphp/pest/discussions/792