### PR TITLE
mudandstars:fix/include-modules-tests-directories-in-update-shards

### DIFF
--- a/modules/Example/tests/ShardModuleExample.php
+++ b/modules/Example/tests/ShardModuleExample.php
@@ -1,0 +1,5 @@
+<?php
+
+test('module test is listed', function () {
+    expect(true)->toBeTrue();
+});

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -193,7 +193,7 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             '--list-tests',
         ]))->setTimeout(120)->mustRun()->getOutput();
 
-        preg_match_all('/ - (?:P\\\\)?(Tests\\\\[^:]+)::/', $output, $matches);
+        preg_match_all('/ - (?:P\\\\)?([^:]+)::/', $output, $matches);
 
         return array_values(array_unique($matches[1]));
     }

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -1,0 +1,13 @@
+<?php
+
+use Pest\Plugins\Shard as ShardPlugin;
+use Symfony\Component\Console\Output\OutputInterface;
+
+test('shard includes module tests returned by list-tests', function () {
+    $plugin = new ShardPlugin($this->createMock(OutputInterface::class));
+
+    $allTests = \Closure::bind(fn (array $arguments): array => $this->allTests($arguments), $plugin, ShardPlugin::class);
+
+    expect($allTests(['bin/pest', 'modules/Example/tests/ShardModuleExample.php']))
+        ->toContain('Modules\\Example\\tests\\ShardModuleExample');
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The Bug: 
When creating the shards.json file via ./vendor/bin/pest --update-shards, it only includes files under root/Tests, but excludes other files that are listed via ./vendor/bin/pest --list-tests but live in another directory, for example under root/modules/Example/Tests/

### Related:

https://github.com/pestphp/pest/issues/1688
