### PR TITLE
Fix: dd

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -112,7 +112,7 @@ final class Expectation
         if (function_exists('dump')) {
             dump($this->value, ...$arguments);
         } else {
-            var_dump($this->value);
+            var_dump($this->value, ...$arguments);
         }
 
         return $this;
@@ -129,7 +129,7 @@ final class Expectation
             dd($this->value, ...$arguments);
         }
 
-        var_dump($this->value);
+        var_dump($this->value, ...$arguments);
 
         exit(1);
     }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -129,9 +129,17 @@ final class Expectation
             dd($this->value, ...$arguments);
         }
 
+        if (getenv('PARATEST') !== false || isset($_SERVER['COLLISION_PRINTER'])) {
+            ob_start();
+            var_dump($this->value, ...$arguments);
+            $output = (string) ob_get_clean();
+
+            throw new ExpectationFailedException($output);
+        }
+
         var_dump($this->value, ...$arguments);
 
-        exit(1);
+        exit(0);
     }
 
     /**

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -123,7 +123,7 @@ final class Expectation
      *
      * @return never
      */
-    public function dd(mixed ...$arguments): void
+    public function dd(mixed ...$arguments): never
     {
         if (function_exists('dd')) {
             dd($this->value, ...$arguments);

--- a/tests/Features/Expect/dd.php
+++ b/tests/Features/Expect/dd.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('dd throws ExpectationFailedException with dumped value in parallel mode', function () {
+    putenv('PARATEST=1');
+
+    try {
+        expect(42)->dd();
+    } catch (ExpectationFailedException $e) {
+        expect($e->getMessage())->toContain('42');
+    } finally {
+        putenv('PARATEST');
+    }
+});
+
+it('dd throws ExpectationFailedException with all dumped arguments in parallel mode', function () {
+    putenv('PARATEST=1');
+
+    try {
+        expect('hello')->dd('extra');
+    } catch (ExpectationFailedException $e) {
+        expect($e->getMessage())
+            ->toContain('hello')
+            ->toContain('extra');
+    } finally {
+        putenv('PARATEST');
+    }
+});
+
+it('dd throws ExpectationFailedException with dumped value when running under pest', function () {
+    expect($_SERVER['COLLISION_PRINTER'])->toBe('DefaultPrinter');
+
+    try {
+        expect(42)->dd();
+    } catch (ExpectationFailedException $e) {
+        expect($e->getMessage())->toContain('42');
+    }
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [x] New Feature

### Description:

fixes: https://github.com/pestphp/pest/issues/1654, and add argument support when dd or dump functions do not exist.

code exmaple
```php
it('displays something', function () {
    expect('Hello')->toBeString();
    expect(42)->dd('test');
});
```

# Without Parallel
## Before
<img width="1210" height="44" alt="image" src="https://github.com/user-attachments/assets/c16fe53d-f25e-43ac-88ca-5156a4b22bd7" />
## After
<img width="1225" height="460" alt="image" src="https://github.com/user-attachments/assets/643dd6b1-3f47-4d61-9299-250f39828c3d" />

# With Parallel
## Before
<img width="1245" height="637" alt="image" src="https://github.com/user-attachments/assets/ccc3d8ce-af74-41a8-b549-363bdc5d23f1" />
## After 
<img width="1064" height="460" alt="image" src="https://github.com/user-attachments/assets/f4170262-b260-47d0-bde1-6e4675aa205e" />


