### PR TITLE
Add the ability to extend `TestCall`

### DIFF
--- a/src/PendingCalls/TestCall.php
+++ b/src/PendingCalls/TestCall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\PendingCalls;
 
 use Closure;
+use Pest\Concerns\Extendable;
 use Pest\Concerns\Testable;
 use Pest\Exceptions\InvalidArgumentException;
 use Pest\Exceptions\TestDescriptionMissing;
@@ -36,6 +37,11 @@ use PHPUnit\Framework\TestCase;
 final class TestCall // @phpstan-ignore-line
 {
     use Describable;
+
+    /** @use Extendable<TestCall> */
+    use Extendable {
+        extend as traitExtend;
+    }
 
     /**
      * The list of test case factory attributes.
@@ -727,7 +733,23 @@ final class TestCall // @phpstan-ignore-line
      */
     public function __call(string $name, array $arguments): self
     {
+        if (self::hasExtend($name)) {
+            $extend = self::$extends[$name]->bindTo($this, TestCall::class);
+
+            if ($extend != false) { // @pest-arch-ignore-line
+                return $extend(...$arguments);
+            }
+        }
+
         return $this->addChain(Backtrace::file(), Backtrace::line(), $name, $arguments);
+    }
+
+    public function extend(string $name, Closure $extend): void
+    {
+        $this->traitExtend($name, $extend);
+
+        $this->description = "extend: $name";
+        $this->testCaseMethod->closure = fn (): null => null;
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1492,6 +1492,10 @@
   ✓ a test
   ✓ higher order message test
 
+   PASS  Tests\Features\TestCallExtend
+  ✓ it uses fooBar extension with ('foo')
+  ✓ it uses fooBar extension with ('bar')
+
    PASS  Tests\Features\ThrowsNoExceptions
   ✓ it allows access to the underlying expectNotToPerformAssertions method
   ✓ it allows performing no expectations without being risky
@@ -1938,4 +1942,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1329 passed (3010 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1331 passed (3012 assertions)

--- a/tests/Features/TestCallExtend.php
+++ b/tests/Features/TestCallExtend.php
@@ -1,0 +1,17 @@
+<?php
+
+use function PHPUnit\Framework\assertTrue;
+
+test()->extend('fooBar', function () {
+    return $this->with([
+        'foo',
+        'bar',
+    ]);
+});
+
+it('uses fooBar extension', function ($value) {
+    assertTrue(in_array($value, [
+        'foo',
+        'bar',
+    ]));
+})->fooBar();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1313 passed (2959 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1315 passed (2961 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1313 passed (2959 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1315 passed (2961 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

This is another go at the change in #126. I know you closed that getting ready for V4.

This feels like the missing piece of enabling making really powerful Pest extensions that can just be chained off of existing tests.

Adds the ability to `->extend(...)` `TestCall` in the same fashion that expectations are extendable.

```php
test()->extend('fooBar', function () {
    return $this->with([
        'foo',
        'bar',
    ]);
});
```

If this is something you want to add, I can PR the docs repo wherever makes sense.

If you don't think you'll ever have an appetite for this let me know and I won't PR again.
