### PR TITLE
chore: enable Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "3.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "5.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` configuring weekly grouped `github-actions` version updates for:

- `4.x` (default branch)
- `1.x` (release branch)
- `2.x` (release branch)
- `3.x` (release branch)
- `5.x` (release branch)

This keeps pinned action SHAs fresh on every actively-maintained branch, mitigating drift from upstream action security patches. PRs are grouped so all action bumps on a branch land as a single PR per week.