### PR TITLE
feat: convert namespace-style arguments to file paths in pest binary

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -128,6 +128,38 @@ use Symfony\Component\Console\Output\ConsoleOutput;
         }
     }
 
+    // Convert namespace-style arguments (e.g. Tests\Unit\TestName) to file paths.
+    foreach ($arguments as $key => $value) {
+        if (str_starts_with($value, '-')) {
+            continue;
+        }
+
+        if (! str_contains($value, '\\')) {
+            continue;
+        }
+
+        $path = str_replace('\\', DIRECTORY_SEPARATOR, $value);
+
+        if (! str_ends_with($path, '.php')) {
+            $path .= '.php';
+        }
+
+        if (file_exists($path)) {
+            $arguments[$key] = $path;
+
+            continue;
+        }
+
+        // Try lowercasing the first directory segment (e.g. Tests -> tests).
+        $segments = explode(DIRECTORY_SEPARATOR, $path);
+        $segments[0] = lcfirst($segments[0]);
+        $lowercasedPath = implode(DIRECTORY_SEPARATOR, $segments);
+
+        if (file_exists($lowercasedPath)) {
+            $arguments[$key] = $lowercasedPath;
+        }
+    }
+
     // Used when Pest is required using composer.
     $vendorPath = dirname(__DIR__, 4).'/vendor/autoload.php';
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Allow namespaces to be accepted as path arguments in the binary.

**Why would we want this?**
When running the full test suite and a single test fails, you naturally want to re-run that test in isolation to debug it. The problem is that the test output shows namespaces (e.g. `Tests\Unit\TestName`), not file paths. Currently, you can't just copy and paste that namespace into the pest command -- you have to manually convert it into a path first.

<img width="1009" height="528" alt="image" src="https://github.com/user-attachments/assets/951cf7a5-c6d7-440b-a8af-b7fa69e479b4" />

  
**What does this PR do?**
When an argument contains a backslash (`\`), it is treated as a namespace and converted into a file path by:
1. Replacing backslashes with `DIRECTORY_SEPARATOR`
2. Appending a `.php` suffix
3. Lowercasing the first path segment (e.g. `Tests` to `tests`)

The conversion only kicks in if the argument doesn't already resolve as a valid path, so existing behavior is unaffected.

<img width="889" height="437" alt="image" src="https://github.com/user-attachments/assets/cb219f6b-3961-4b3e-b68d-7d40761b6a58" />

*(Sorry for the somewhat bloated terminal output and docker command, also not quite sure why the output is different when running the test in isolation)* 