### PR TITLE
[4.x] Fix Checks

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install Dependencies
       env:
-          COMPOSER_ROOT_VERSION: 4.x-dev
+        COMPOSER_ROOT_VERSION: 4.x-dev
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Profanity Check

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -53,6 +53,8 @@ jobs:
           static-php-8.3-composer-
 
     - name: Install Dependencies
+      env:
+          COMPOSER_ROOT_VERSION: 4.x-dev
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Profanity Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,8 @@ jobs:
 
     - name: Install PHP dependencies
       shell: bash
+      env:
+        COMPOSER_ROOT_VERSION: 4.x-dev
       run: composer update --${{ matrix.dependency_version }} --no-interaction --no-progress --ansi --with="symfony/console:^${{ matrix.symfony }}"
 
     - name: Unit Tests

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "pestphp/pest",
     "description": "The elegant PHP Testing Framework.",
-    "version": "4.7.0",
     "keywords": [
         "php",
         "framework",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pestphp/pest",
     "description": "The elegant PHP Testing Framework.",
+    "version": "4.7.0",
     "keywords": [
         "php",
         "framework",


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

After pest-plugin-browser was raised to `^4.3.1` ([e766825f](https://github.com/pestphp/pest/commit/e766825f5b49e11561ce87f62155d6ae2615e319)), PRs from branches not named `4.x` fail at composer update because the root package is inferred as `dev-<branch>`, which does not satisfy pest `^4.4.5`. Setting the root version unblocks CI for all PRs targeting `4.x`.