### PR TITLE
consistent sharding logic when no shards file

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -132,7 +132,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             self::$timeBalanced = true;
             self::$shardsOutdated = $newTests !== [];
         } else {
-            $testsToRun = (array_chunk($tests, max(1, (int) ceil(count($tests) / $total))))[$index - 1] ?? [];
+            $isInCurrentShard = fn (int $key) => $key % $total === ($index - 1);
+            $testsToRun = array_values(array_filter(array_values($tests), $isInCurrentShard, ARRAY_FILTER_USE_KEY));
         }
 
         self::$shard = [


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->
without the file: `1/3 = a,b,c`; `2/3 = d,e,f`; `3/3 = g,h,i`
with the file (empty): `1/3 = a,d,g`; `2/3 = b,e,h`; `3/3 = c,f,i`
this PR makes the logic consistent so that without the file will work similar to an empty file (the second option above). this also helps balance the shards out of the box on standard projects as generally projects will have longer tests grouped together and shorter tests grouped together. for example when `a,b,c,d,e,f,g,h,i`, usually it will be something like `a,b,c` are faster, `d,e,f,g` are normal, `h,i` are slower.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
