### PR TITLE
fix: add tests without explicit group to 'default' group

### DIFF
--- a/src/Repositories/TestRepository.php
+++ b/src/Repositories/TestRepository.php
@@ -209,6 +209,18 @@ final class TestRepository
                     $method->groups = [...$groups, ...$method->groups];
                 }
 
+                if ($groups === []) {
+                    foreach ($testCase->methods as $method) {
+                        if ($method->groups === []) {
+                            $method->groups[] = 'default';
+                            $method->attributes[] = new Attribute(
+                                Group::class,
+                                ['default'],
+                            );
+                        }
+                    }
+                }
+
                 foreach (['__addBeforeAll', '__addBeforeEach', '__addAfterEach', '__addAfterAll'] as $index => $name) {
                     foreach ($hooks[$index] ?? [null] as $hook) {
                         $testCase->factoryProxies->add($testCase->filename, 0, $name, [$hook]);


### PR DESCRIPTION
Fixes #1602 - Running pest --group=default now correctly runs Pest tests that don't have an explicit group, matching PHPUnit's behavior.

## What happened
When running `./vendor/bin/pest --group=default`, zero tests were executed, even though there were Pest tests without explicit groups.

## Root cause
PHPUnit treats tests without an explicit @group annotation as being in the "default" group. However, Pest tests created with `test()` or `it()` didn't have any group assigned, so --group=default found nothing.

## Solution
Add tests without an explicit group to the "default" group in TestRepository, matching PHPUnit's behavior.