### PR TITLE
Bugfix/sharding module fix

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -94,8 +94,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         if (Parallel::isWorker() && Parallel::getGlobal('UPDATE_SHARDS') === true) {
             self::$updateShards = true;
 
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted);
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished);
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted());
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished());
 
             return $arguments;
         }
@@ -172,8 +172,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             Parallel::setGlobal('UPDATE_SHARDS', true);
             Parallel::setGlobal('SHARD_RUN_ID', uniqid('pest-shard-', true));
         } else {
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted);
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished);
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted());
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished());
         }
 
         return $arguments;

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -94,8 +94,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         if (Parallel::isWorker() && Parallel::getGlobal('UPDATE_SHARDS') === true) {
             self::$updateShards = true;
 
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted());
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished());
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted);
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished);
 
             return $arguments;
         }
@@ -172,8 +172,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             Parallel::setGlobal('UPDATE_SHARDS', true);
             Parallel::setGlobal('SHARD_RUN_ID', uniqid('pest-shard-', true));
         } else {
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted());
-            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished());
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingStarted);
+            Event\Facade::instance()->registerSubscriber(new EnsureShardTimingFinished);
         }
 
         return $arguments;

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -193,7 +193,7 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             '--list-tests',
         ]))->setTimeout(120)->mustRun()->getOutput();
 
-        preg_match_all('/ - (?:P\\\\)?(Tests\\\\[^:]+)::/', $output, $matches);
+        preg_match_all('/ - (?:P\\\\)?([^:]+)::/', $output, $matches);
 
         return array_values(array_unique($matches[1]));
     }

--- a/tests-external/Shard/modules/billing/InvoiceTest.php
+++ b/tests-external/Shard/modules/billing/InvoiceTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('creates invoice')->assertTrue(true);
+
+it('sends invoice')->assertTrue(true);

--- a/tests-external/Shard/standard/UnitTest.php
+++ b/tests-external/Shard/standard/UnitTest.php
@@ -1,0 +1,3 @@
+<?php
+
+it('passes')->assertTrue(true);

--- a/tests/Plugins/Shard.php
+++ b/tests/Plugins/Shard.php
@@ -2,9 +2,9 @@
 
 use Symfony\Component\Process\Process;
 
-$pest = function (array $extraArgs = []): Process {
+$pest = function (string $path, array $extraArgs = []): Process {
     $process = new Process(
-        ['php', 'bin/pest', 'tests-external/Shard/', ...$extraArgs],
+        ['php', 'bin/pest', $path, ...$extraArgs],
         dirname(__DIR__, 2),
     );
     $process->run();
@@ -20,8 +20,60 @@ afterAll(function () use ($shardsPath) {
     }
 });
 
+test('shard discovers tests in standard directories', function () use ($pest) {
+    $process = $pest('tests/Fixtures/DirectoryWithTests/', ['--list-tests']);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = $process->getOutput();
+
+    expect($output)->toContain('ExampleTest::')
+        ->toContain(' - P\Tests\\');
+})->skipOnWindows();
+
+test('shard includes standard directory tests in shard count', function () use ($pest) {
+    $process = $pest('tests/Fixtures/DirectoryWithTests/', ['--shard=1/1']);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = $process->getOutput();
+
+    expect($output)->toContain('1 file ran, out of 1');
+})->skipOnWindows();
+
+test('shard distributes standard directory tests across shards', function () use ($pest) {
+    $process1 = $pest('tests/Fixtures/DirectoryWithTests/', ['--shard=1/2']);
+    $process2 = $pest('tests/Fixtures/DirectoryWithTests/', ['--shard=2/2']);
+
+    expect($process1->getExitCode())->toBe(0)
+        ->and($process2->getExitCode())->toBe(0);
+
+    $output1 = $process1->getOutput();
+    $output2 = $process2->getOutput();
+
+    // 1 file total — first shard gets it, second gets 0
+    expect($output1)->toContain('1 file ran, out of 1')
+        ->and($output2)->toContain('0 files ran, out of 1');
+})->skipOnWindows();
+
+test('update-shards records timings for standard directory tests', function () use ($pest, $shardsPath) {
+    $process = $pest('tests/Fixtures/DirectoryWithTests/', ['--update-shards']);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = $process->getOutput();
+
+    expect($output)->toContain('shards.json updated with timings for 1 test class');
+
+    expect($shardsPath)->toBeFile();
+    $data = json_decode(file_get_contents($shardsPath), true);
+    $keys = array_keys($data['timings']);
+
+    expect($keys)->each->toStartWith('Tests\\');
+})->skipOnWindows();
+
 test('shard discovers tests in non-standard directories', function () use ($pest) {
-    $process = $pest(['--list-tests']);
+    $process = $pest('tests-external/Shard/', ['--list-tests']);
 
     expect($process->getExitCode())->toBe(0);
 
@@ -34,7 +86,7 @@ test('shard discovers tests in non-standard directories', function () use ($pest
 })->skipOnWindows();
 
 test('shard includes non-standard directory tests in shard count', function () use ($pest) {
-    $process = $pest(['--shard=1/1']);
+    $process = $pest('tests-external/Shard/', ['--shard=1/1']);
 
     expect($process->getExitCode())->toBe(0);
 
@@ -45,8 +97,8 @@ test('shard includes non-standard directory tests in shard count', function () u
 })->skipOnWindows();
 
 test('shard distributes non-standard directory tests across shards', function () use ($pest) {
-    $process1 = $pest(['--shard=1/2']);
-    $process2 = $pest(['--shard=2/2']);
+    $process1 = $pest('tests-external/Shard/', ['--shard=1/2']);
+    $process2 = $pest('tests-external/Shard/', ['--shard=2/2']);
 
     expect($process1->getExitCode())->toBe(0)
         ->and($process2->getExitCode())->toBe(0);
@@ -60,7 +112,7 @@ test('shard distributes non-standard directory tests across shards', function ()
 })->skipOnWindows();
 
 test('update-shards records timings for non-standard directory tests', function () use ($pest, $shardsPath) {
-    $process = $pest(['--update-shards']);
+    $process = $pest('tests-external/Shard/', ['--update-shards']);
 
     expect($process->getExitCode())->toBe(0);
 

--- a/tests/Plugins/Shard.php
+++ b/tests/Plugins/Shard.php
@@ -1,0 +1,121 @@
+<?php
+
+$extractTests = function (string $listTestsOutput): array {
+    preg_match_all('/ - (?:P\\\\)?([^:]+)::/', $listTestsOutput, $matches);
+
+    return array_values(array_unique($matches[1]));
+};
+
+$buildFilter = function (array $testsToRun): string {
+    return addslashes(implode('|', $testsToRun));
+};
+
+test('allTests regex captures standard Tests-namespaced identifiers', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+ - P\Tests\Unit\ExampleTest::it_works
+ - P\Tests\Feature\AuthTest::it_logs_in
+ - P\Tests\Unit\ExampleTest::it_does_something_else
+OUTPUT;
+
+    $tests = $extractTests($output);
+
+    expect($tests)->toBe([
+        'Tests\Unit\ExampleTest',
+        'Tests\Feature\AuthTest',
+    ]);
+});
+
+test('allTests regex captures non-standard directory identifiers', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+ - P\Appmodules\Billing\tests\InvoiceTest::it_creates_invoice
+ - P\Appmodules\Billing\tests\InvoiceTest::it_sends_invoice
+ - P\Modules\Auth\tests\LoginTest::it_authenticates
+OUTPUT;
+
+    $tests = $extractTests($output);
+
+    expect($tests)->toBe([
+        'Appmodules\Billing\tests\InvoiceTest',
+        'Modules\Auth\tests\LoginTest',
+    ]);
+});
+
+test('allTests regex captures identifiers without P prefix', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+ - Tests\Feature\BarTest::test_bar
+ - App\Tests\BazTest::test_baz
+OUTPUT;
+
+    $tests = $extractTests($output);
+
+    expect($tests)->toBe([
+        'Tests\Feature\BarTest',
+        'App\Tests\BazTest',
+    ]);
+});
+
+test('allTests regex handles mixed standard and non-standard identifiers', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+ - P\Tests\Unit\ExampleTest::it_works
+ - P\Appmodules\Foo\tests\FooTest::it_works
+ - Tests\Feature\BarTest::test_bar
+ - P\Modules\Core\tests\CoreTest::it_boots
+OUTPUT;
+
+    $tests = $extractTests($output);
+
+    expect($tests)->toBe([
+        'Tests\Unit\ExampleTest',
+        'Appmodules\Foo\tests\FooTest',
+        'Tests\Feature\BarTest',
+        'Modules\Core\tests\CoreTest',
+    ]);
+});
+
+test('allTests regex does not match non-test lines', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+
+ - P\Tests\Unit\ExampleTest::it_works
+Some random output line
+OUTPUT;
+
+    $tests = $extractTests($output);
+
+    expect($tests)->toBe([
+        'Tests\Unit\ExampleTest',
+    ]);
+});
+
+test('buildFilterArgument correctly escapes non-standard identifiers', function () use ($buildFilter) {
+    $tests = [
+        'Appmodules\Billing\tests\InvoiceTest',
+        'Modules\Auth\tests\LoginTest',
+    ];
+
+    $filter = $buildFilter($tests);
+
+    expect($filter)->toBe('Appmodules\\\\Billing\\\\tests\\\\InvoiceTest|Modules\\\\Auth\\\\tests\\\\LoginTest');
+});
+
+test('sharding distributes non-standard identifiers across shards', function () use ($extractTests) {
+    $output = <<<'OUTPUT'
+Available test(s):
+ - P\Tests\Unit\ATest::it_works
+ - P\Appmodules\Foo\tests\BTest::it_works
+ - P\Modules\Bar\tests\CTest::it_works
+ - P\Tests\Feature\DTest::it_works
+OUTPUT;
+
+    $tests = $extractTests($output);
+    $total = 2;
+    $chunks = array_chunk($tests, max(1, (int) ceil(count($tests) / $total)));
+
+    expect($chunks)->toHaveCount(2)
+        ->and($chunks[0])->toBe(['Tests\Unit\ATest', 'Appmodules\Foo\tests\BTest'])
+        ->and($chunks[1])->toBe(['Modules\Bar\tests\CTest', 'Tests\Feature\DTest']);
+});

--- a/tests/Plugins/Shard.php
+++ b/tests/Plugins/Shard.php
@@ -1,121 +1,77 @@
 <?php
 
-$extractTests = function (string $listTestsOutput): array {
-    preg_match_all('/ - (?:P\\\\)?([^:]+)::/', $listTestsOutput, $matches);
+use Symfony\Component\Process\Process;
 
-    return array_values(array_unique($matches[1]));
+$pest = function (array $extraArgs = []): Process {
+    $process = new Process(
+        ['php', 'bin/pest', 'tests-external/Shard/', ...$extraArgs],
+        dirname(__DIR__, 2),
+    );
+    $process->run();
+
+    return $process;
 };
 
-$buildFilter = function (array $testsToRun): string {
-    return addslashes(implode('|', $testsToRun));
-};
+$shardsPath = dirname(__DIR__).'/.pest/shards.json';
 
-test('allTests regex captures standard Tests-namespaced identifiers', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
- - P\Tests\Unit\ExampleTest::it_works
- - P\Tests\Feature\AuthTest::it_logs_in
- - P\Tests\Unit\ExampleTest::it_does_something_else
-OUTPUT;
-
-    $tests = $extractTests($output);
-
-    expect($tests)->toBe([
-        'Tests\Unit\ExampleTest',
-        'Tests\Feature\AuthTest',
-    ]);
+afterAll(function () use ($shardsPath) {
+    if (file_exists($shardsPath)) {
+        unlink($shardsPath);
+    }
 });
 
-test('allTests regex captures non-standard directory identifiers', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
- - P\Appmodules\Billing\tests\InvoiceTest::it_creates_invoice
- - P\Appmodules\Billing\tests\InvoiceTest::it_sends_invoice
- - P\Modules\Auth\tests\LoginTest::it_authenticates
-OUTPUT;
+test('shard discovers tests in non-standard directories', function () use ($pest) {
+    $process = $pest(['--list-tests']);
 
-    $tests = $extractTests($output);
+    expect($process->getExitCode())->toBe(0);
 
-    expect($tests)->toBe([
-        'Appmodules\Billing\tests\InvoiceTest',
-        'Modules\Auth\tests\LoginTest',
-    ]);
-});
+    $output = $process->getOutput();
 
-test('allTests regex captures identifiers without P prefix', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
- - Tests\Feature\BarTest::test_bar
- - App\Tests\BazTest::test_baz
-OUTPUT;
+    // Identifiers must NOT start with Tests\ since fixtures are in tests-external/
+    expect($output)->toContain('InvoiceTest::')
+        ->toContain('UnitTest::')
+        ->not->toContain(' - P\Tests\\');
+})->skipOnWindows();
 
-    $tests = $extractTests($output);
+test('shard includes non-standard directory tests in shard count', function () use ($pest) {
+    $process = $pest(['--shard=1/1']);
 
-    expect($tests)->toBe([
-        'Tests\Feature\BarTest',
-        'App\Tests\BazTest',
-    ]);
-});
+    expect($process->getExitCode())->toBe(0);
 
-test('allTests regex handles mixed standard and non-standard identifiers', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
- - P\Tests\Unit\ExampleTest::it_works
- - P\Appmodules\Foo\tests\FooTest::it_works
- - Tests\Feature\BarTest::test_bar
- - P\Modules\Core\tests\CoreTest::it_boots
-OUTPUT;
+    $output = $process->getOutput();
 
-    $tests = $extractTests($output);
+    // Both test files must be discovered and sharded
+    expect($output)->toContain('2 files ran, out of 2');
+})->skipOnWindows();
 
-    expect($tests)->toBe([
-        'Tests\Unit\ExampleTest',
-        'Appmodules\Foo\tests\FooTest',
-        'Tests\Feature\BarTest',
-        'Modules\Core\tests\CoreTest',
-    ]);
-});
+test('shard distributes non-standard directory tests across shards', function () use ($pest) {
+    $process1 = $pest(['--shard=1/2']);
+    $process2 = $pest(['--shard=2/2']);
 
-test('allTests regex does not match non-test lines', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
+    expect($process1->getExitCode())->toBe(0)
+        ->and($process2->getExitCode())->toBe(0);
 
- - P\Tests\Unit\ExampleTest::it_works
-Some random output line
-OUTPUT;
+    $output1 = $process1->getOutput();
+    $output2 = $process2->getOutput();
 
-    $tests = $extractTests($output);
+    // Each shard gets 1 file, total is 2
+    expect($output1)->toContain('1 file ran, out of 2')
+        ->and($output2)->toContain('1 file ran, out of 2');
+})->skipOnWindows();
 
-    expect($tests)->toBe([
-        'Tests\Unit\ExampleTest',
-    ]);
-});
+test('update-shards records timings for non-standard directory tests', function () use ($pest, $shardsPath) {
+    $process = $pest(['--update-shards']);
 
-test('buildFilterArgument correctly escapes non-standard identifiers', function () use ($buildFilter) {
-    $tests = [
-        'Appmodules\Billing\tests\InvoiceTest',
-        'Modules\Auth\tests\LoginTest',
-    ];
+    expect($process->getExitCode())->toBe(0);
 
-    $filter = $buildFilter($tests);
+    $output = $process->getOutput();
 
-    expect($filter)->toBe('Appmodules\\\\Billing\\\\tests\\\\InvoiceTest|Modules\\\\Auth\\\\tests\\\\LoginTest');
-});
+    expect($output)->toContain('shards.json updated with timings for 2 test class');
 
-test('sharding distributes non-standard identifiers across shards', function () use ($extractTests) {
-    $output = <<<'OUTPUT'
-Available test(s):
- - P\Tests\Unit\ATest::it_works
- - P\Appmodules\Foo\tests\BTest::it_works
- - P\Modules\Bar\tests\CTest::it_works
- - P\Tests\Feature\DTest::it_works
-OUTPUT;
+    // Verify the shards.json contains the non-standard identifiers
+    expect($shardsPath)->toBeFile();
+    $data = json_decode(file_get_contents($shardsPath), true);
+    $keys = array_keys($data['timings']);
 
-    $tests = $extractTests($output);
-    $total = 2;
-    $chunks = array_chunk($tests, max(1, (int) ceil(count($tests) / $total)));
-
-    expect($chunks)->toHaveCount(2)
-        ->and($chunks[0])->toBe(['Tests\Unit\ATest', 'Appmodules\Foo\tests\BTest'])
-        ->and($chunks[1])->toBe(['Modules\Bar\tests\CTest', 'Tests\Feature\DTest']);
-});
+    expect($keys)->each->not->toStartWith('Tests\\');
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Resolve an issue with sharding tests in a repo that has tests in non-standard tests directories (such as a repo using modular approaches, more details in the related issue)

In my tests I actually test the sharding functionality to make sure it is all working so it ends up actually generating a `tests/.pest/shards.json` file. Which is why during the `afterAll` of the test I `unlink` it.
This is fine now, but will be problematic and weird if Pest itself ever wants to shard it's own tests.
So I just wanted to ask if this was acceptable for now? If not, my thought was I could also add to this PR a new option to override the path `shards.json` is written to.
As maybe someone at some point would want that and it would allow us to point these tests to generate the file somewhere we can `.gitignore` it.

### Related:

https://github.com/pestphp/pest/issues/1711
