### PR TITLE
fix: support tests outside Tests\ namespace in sharding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
     "require-dev": {
         "mrpunyapal/peststan": "^0.2.10",
         "pestphp/pest-dev-tools": "^4.1.0",
-        "pestphp/pest-plugin-browser": "^4.3.1",
         "pestphp/pest-plugin-type-coverage": "^4.0.4",
         "psy/psysh": "^0.12.22"
     },

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -193,7 +193,7 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             '--list-tests',
         ]))->setTimeout(120)->mustRun()->getOutput();
 
-        preg_match_all('/ - (?:P\\\\)?(Tests\\\\[^:]+)::/', $output, $matches);
+        preg_match_all('/ - (?:P\\\\)?(.+?)::/', $output, $matches);
 
         return array_values(array_unique($matches[1]));
     }

--- a/src/Support/StateGenerator.php
+++ b/src/Support/StateGenerator.php
@@ -10,6 +10,7 @@ use NunoMaduro\Collision\Exceptions\TestOutcome;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
 use PHPUnit\Event\Test\Errored;
 use PHPUnit\Event\Test\Failed;
 use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
@@ -34,8 +35,7 @@ final class StateGenerator
                     TestResult::FAIL,
                     $testResultEvent->throwable()
                 ));
-            } else {
-                // @phpstan-ignore-next-line
+            } elseif ($testResultEvent instanceof BeforeFirstTestMethodErrored) {
                 $state->add(TestResult::fromBeforeFirstTestMethodErrored($testResultEvent));
             }
         }


### PR DESCRIPTION
When running tests in parallel mode (`--parallel`), `testErroredEvents()` can return `AfterLastTestMethodErrored` events. The existing code assumed all non-Errored events were `BeforeFirstTestMethodErrored`, causing a `TypeError` when an `AfterLastTestMethodErrored` event was passed to `fromBeforeFirstTestMethodErrored()`.

The fix adds an explicit `instanceof` check for `BeforeFirstTestMethodErrored` instead of the catch-all `else`, allowing `AfterLastTestMethodErrored` events to be safely skipped.

Fixes #1623