### PR TITLE
feat: add ignorePaths method to exclude specified paths from arch ana…

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -435,6 +435,39 @@ final class Expectation
     }
 
     /**
+     * Excludes files whose paths contain any of the given path fragments from arch analysis.
+     *
+     * @param  list<string>  $paths
+     */
+    public function ignorePaths(array $paths): PendingArchExpectation
+    {
+        $normalizedPaths = array_values(array_filter(array_map(
+            static fn (string $path): string => trim(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR),
+            $paths,
+        ), static fn (string $path): bool => $path !== ''));
+
+        return new PendingArchExpectation($this, [
+            static function (ObjectDescription $object) use ($normalizedPaths): bool {
+                if (isset($object->path)) {
+                    $normalizedObjectPath = trim(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $object->path), DIRECTORY_SEPARATOR);
+                } else {
+                    // Fallback for objects without an initialized path (e.g., vendor objects);
+                    // use the class name as a path approximation.
+                    $normalizedObjectPath = trim(str_replace('\\', DIRECTORY_SEPARATOR, $object->name), DIRECTORY_SEPARATOR);
+                }
+
+                foreach ($normalizedPaths as $path) {
+                    if (str_contains($normalizedObjectPath, $path)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
+        ]);
+    }
+
+    /**
      * Asserts that the given expectation target use the given dependencies.
      *
      * @param  array<int, string>|string  $targets

--- a/tests/Features/Expect/ignorePaths.php
+++ b/tests/Features/Expect/ignorePaths.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+
+test('single ignored path', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->ignorePaths(['database/migrations'])
+        ->toUseStrictTypes();
+});
+
+test('multiple ignored paths', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Multiple')
+        ->ignorePaths(['database/migrations', 'vendor'])
+        ->toUseStrictTypes();
+});
+
+test('nested directory ignored', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->ignorePaths(['database'])
+        ->toUseStrictTypes();
+});
+
+test('partial path matching', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->ignorePaths(['migrations'])
+        ->toUseStrictTypes();
+});
+
+test('windows path separators', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->ignorePaths(['database\\migrations'])
+        ->toUseStrictTypes();
+});
+
+test('non-ignored files still analyzed', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Dirty')
+        ->ignorePaths(['database/migrations'])
+        ->toUseStrictTypes();
+})->throws(ArchExpectationFailedException::class);
+
+test('violations caught in all paths without ignorePaths', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->toUseStrictTypes();
+})->throws(ArchExpectationFailedException::class);
+
+test('chainable with not', function () {
+    expect('Tests\Fixtures\Arch\IgnorePaths\Single')
+        ->ignorePaths(['database/migrations'])
+        ->not->toBeAbstract();
+});

--- a/tests/Fixtures/Arch/IgnorePaths/Dirty/DirtyService.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Dirty/DirtyService.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Dirty;
+
+class DirtyService {}

--- a/tests/Fixtures/Arch/IgnorePaths/Dirty/database/migrations/CreateUsersTable.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Dirty/database/migrations/CreateUsersTable.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Dirty\database\migrations;
+
+class CreateUsersTable {}

--- a/tests/Fixtures/Arch/IgnorePaths/Multiple/Service.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Multiple/Service.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Multiple;
+
+class Service {}

--- a/tests/Fixtures/Arch/IgnorePaths/Multiple/database/migrations/CreateUsersTable.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Multiple/database/migrations/CreateUsersTable.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Multiple\database\migrations;
+
+class CreateUsersTable {}

--- a/tests/Fixtures/Arch/IgnorePaths/Multiple/vendor/Library.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Multiple/vendor/Library.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Multiple\vendor;
+
+class Library {}

--- a/tests/Fixtures/Arch/IgnorePaths/Single/Service.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Single/Service.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Single;
+
+class Service {}

--- a/tests/Fixtures/Arch/IgnorePaths/Single/database/migrations/AbstractMigration.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Single/database/migrations/AbstractMigration.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Single\database\migrations;
+
+abstract class AbstractMigration {}

--- a/tests/Fixtures/Arch/IgnorePaths/Single/database/migrations/CreateUsersTable.php
+++ b/tests/Fixtures/Arch/IgnorePaths/Single/database/migrations/CreateUsersTable.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures\Arch\IgnorePaths\Single\database\migrations;
+
+class CreateUsersTable {}


### PR DESCRIPTION
## Summary

This PR introduces a minimal `ignorePaths()` API for architecture expectations to reduce noise during architecture analysis.

In larger projects, architecture rules may unintentionally analyze generated, infrastructure, or third-party files (for example migrations, vendor code, cache, or generated artifacts), which can create false positives unrelated to application boundaries.

Example:

```php
arch()
    ->expect('App')
    ->ignorePaths([
        'vendor',
        'database/migrations',
    ])
    ->not->toUse(['dd', 'dump']);
```

## Why

Architecture tests are typically intended to validate application boundaries and conventions.

In practice, projects often contain directories that are:

* generated
* infrastructure-related
* historical (e.g. migrations)
* third-party

These may not be desirable targets for architecture expectations and can introduce noise into otherwise intentional rules.

This PR adds a small, framework-agnostic API to selectively exclude paths from architecture analysis.

## Design

The implementation intentionally keeps the API minimal:

* single fluent API: `ignorePaths(array $paths)`
* framework agnostic
* chainable with existing expectations
* cross-platform path normalization
* no additional configuration
* no framework-specific helpers

## Tests

Added coverage for:

* single ignored path
* multiple ignored paths
* nested directory matching
* partial path matching
* Windows path separators
* non-ignored files remaining analysable
* chaining with existing expectations