### PR TITLE
feat: add toBeUlid assertion and isUlid validation method

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1143,6 +1143,22 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is a ULID.
+     *
+     * @return self<TValue>
+     */
+    public function toBeUlid(string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(Str::isUlid($this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is between 2 specified values
      *
      * @return self<TValue>

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -99,6 +99,14 @@ final class Str
     }
 
     /**
+     * Determine if a given value is a valid ULID.
+     */
+    public static function isUlid(string $value): bool
+    {
+        return preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/', $value) > 0;
+    }
+
+    /**
      * Creates a describe block as `$describeDescription` → `$testDescription` format.
      *
      * @param  array<int, Description>  $describeDescriptions

--- a/tests/Features/Expect/toBeUlid.php
+++ b/tests/Features/Expect/toBeUlid.php
@@ -1,0 +1,26 @@
+<?php
+
+use Pest\Exceptions\InvalidExpectationValue;
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('failures with wrong type', function () {
+    expect([])->toBeUlid();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
+
+test('pass', function () {
+    expect('01ARZ3NDEKTSV4RRFFQ69G5FAV')->toBeUlid();
+    expect('01BX5ZZKBKACTAV9WEVGEMMVRE')->toBeUlid();
+    expect('7ZZZZZZZZZ0000000000000000')->toBeUlid();
+});
+
+test('failures', function () {
+    expect('foo')->toBeUlid();
+})->throws(ExpectationFailedException::class);
+
+test('failures with message', function () {
+    expect('bar')->toBeUlid('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    expect('foo')->not->toBeUlid();
+});


### PR DESCRIPTION
## What
Adds `toBeUlid()` (and `not->toBeUlid()`) expectation for validating
26-character Crockford Base32 strings (ULIDs).

## Why
ULIDs are a common sortable UUID alternative used in Laravel, Symfony,
and standalone PHP projects. `toBeUuid()` already exists; this fills
the obvious gap.

## How
- `Str::isUlid()` added to `Support/Str.php` — pure regex, no deps
- `toBeUlid()` added to `Mixins/Expectation.php` — mirrors `toBeUuid()` exactly
- Test file mirrors `toBeUuid.php` structure

## Notes
- No new dependencies
- PHP 8.3+, PHPUnit 13-compatible
- Regex: `/^[0-9A-HJKMNP-TV-Z]{26}$/` (strict uppercase, per Crockford spec)