### PR TITLE
fix: update gitlab urls for issues and prs to match new format

### DIFF
--- a/src/Configuration/Project.php
+++ b/src/Configuration/Project.php
@@ -59,12 +59,12 @@ final class Project
     /**
      * Sets the test project to GitLab.
      */
-    public function gitlab(string $project): self
+    public function gitlab(string $project, string $host = 'gitlab.com'): self
     {
-        $this->issues = "https://gitlab.com/{$project}/issues/%s";
-        $this->prs = "https://gitlab.com/{$project}/merge_requests/%s";
+        $this->issues = "https://{$host}/{$project}/-/work_items/%s";
+        $this->prs = "https://{$host}/{$project}/-/merge_requests/%s";
 
-        $this->assignees = 'https://gitlab.com/%s';
+        $this->assignees = "https://{$host}/%s";
 
         return $this;
     }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [x] New Feature

### Description:

This pull request updates the `gitlab` method in the `Project.php` configuration to improve flexibility and align with current GitLab URL structures. The method now supports custom GitLab hosts and updates the URL patterns for issues and merge requests.

Key changes:

**GitLab configuration improvements:**

* The `gitlab` method now accepts an optional `$host` parameter (defaulting to `gitlab.com`), allowing configuration for self-hosted GitLab instances.
* Updated the URL formats for issues and merge requests to use the new `/-/work_items/%s` and `/-/merge_requests/%s` patterns, which are consistent with recent GitLab conventions.
* The `assignees` URL now uses the specified `$host` instead of being hardcoded to `gitlab.com`.

### Related:
https://gitlab.com/gitlab-org/gitlab/-/work_items/273668
