### PR TITLE
feat: add toBeEmail expectation

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -1156,6 +1156,22 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is an email address.
+     *
+     * @return self<TValue>
+     */
+    public function toBeEmail(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is an email address.";
+        }
+
+        Assert::assertTrue(Str::isEmail((string) $this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is a url
      *
      * @return self<TValue>

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -111,6 +111,14 @@ final class Str
     }
 
     /**
+     * Determine if a given value is a valid email address.
+     */
+    public static function isEmail(string $value): bool
+    {
+        return (bool) filter_var($value, FILTER_VALIDATE_EMAIL);
+    }
+
+    /**
      * Determine if a given value is a valid URL.
      */
     public static function isUrl(string $value): bool

--- a/tests/Features/Expect/toBeEmail.php
+++ b/tests/Features/Expect/toBeEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect('user@example.com')->toBeEmail()
+        ->and('notanemail')->not->toBeEmail();
+});
+
+test('failures', function () {
+    expect('notanemail')->toBeEmail();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    expect('notanemail')->toBeEmail('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with default message', function () {
+    expect('notanemail')->toBeEmail();
+})->throws(ExpectationFailedException::class, 'Failed asserting that notanemail is an email address.');
+
+test('not failures', function () {
+    expect('user@example.com')->not->toBeEmail();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds `toBeEmail()` expectation backed by PHP's native `filter_var(FILTER_VALIDATE_EMAIL)` — no new dependencies. Mirrors the existing `toBeUrl()` pattern: adds `Str::isEmail()` helper in `Support/Str.php`, the expectation method in `Mixins/Expectation.php` (inserted alphabetically before `toBeUrl`), and a full test file covering pass, fail, custom message, default message, and negation cases.