### PR TITLE
fix: guard Tia argv scanning against non-string args (integer --random-order-seed under --parallel)

### DIFF
--- a/src/Plugins/Tia.php
+++ b/src/Plugins/Tia.php
@@ -251,7 +251,7 @@ final class Tia implements AddsOutput, HandlesArguments, Terminable
                 return true;
             }
 
-            if (str_starts_with($arg, "$argument=")) {
+            if (str_starts_with((string) $arg, "$argument=")) { // @phpstan-ignore-line
                 return true;
             }
         }
@@ -1489,6 +1489,8 @@ final class Tia implements AddsOutput, HandlesArguments, Terminable
         }
 
         foreach ($arguments as $index => $arg) {
+            $arg = (string) $arg; // @phpstan-ignore-line
+
             if ($arg === '') {
                 continue;
             }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1752,6 +1752,10 @@
   ✓ output format → it returns a 32-character hex xxh128 hash
   ✓ output format → it returns a stable hash for empty content
 
+   PASS  Tests\Unit\Plugins\Tia\IsEnabledForRun
+  ✓ does not throw when an integer --random-order-seed is passed as a separate argv element
+  ✓ still detects --tia when an integer argument is present
+
    PASS  Tests\Unit\Preset
   ✓ preset invalid name
   ✓ preset → myFramework
@@ -1937,4 +1941,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1328 passed (3008 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1330 passed (3010 assertions)

--- a/tests/Unit/Plugins/Tia/IsEnabledForRun.php
+++ b/tests/Unit/Plugins/Tia/IsEnabledForRun.php
@@ -1,0 +1,20 @@
+<?php
+
+use Pest\Plugins\Tia;
+
+test('does not throw when an integer --random-order-seed is passed as a separate argv element', function () {
+    // Mirrors the parallel worker argv (see bin/worker.php), where
+    // `--random-order-seed` and its value arrive as separate items and the
+    // seed value is an int rather than a string. Regression test for the
+    // str_starts_with() TypeError in Tia::argumentPresent() — the same class
+    // of bug as #1206, which was only fixed in HandleArguments.
+    $arguments = ['--order-by=random', '--random-order-seed', 1782350398];
+
+    expect(Tia::isEnabledForRun($arguments))->toBeFalse();
+});
+
+test('still detects --tia when an integer argument is present', function () {
+    $arguments = ['--tia', '--random-order-seed', 1782350398];
+
+    expect(Tia::isEnabledForRun($arguments))->toBeTrue();
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1312 passed (2957 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1314 passed (2959 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1312 passed (2957 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1314 passed (2959 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

The `Tia` plugin scans the raw argv with `str_starts_with()` in `argumentPresent()` and `hasExplicitPathArgument()`. In the parallel worker path (`bin/worker.php`), the unserialized argv can contain an integer `--random-order-seed` value as a *separate* element, which makes `str_starts_with()` throw before any test runs:

```
Uncaught TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, int given
in src/Plugins/Tia.php:254
```

Reproduce with:

```
pest --parallel --processes=4 --order-by=random --random-order-seed=1782350398
```

Single-process mode is unaffected because the argument arrives as a single `--random-order-seed=N` string.

This is the same class of bug as #1206, which was only fixed in `HandleArguments`; it resurfaced in the newer `Tia` plugin and is still unguarded as of v4.7.3. Each argv element is now cast to string before scanning, mirroring the #1206 fix. A regression test asserting an integer `--random-order-seed` under `--parallel` no longer throws is included (with the parallel count assertion and success snapshot updated accordingly).

### Related:

- #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)