### PR TITLE
fix: strip `--processes` from `--list-tests` when sharding in parallel

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -204,7 +204,34 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
      */
     private function removeParallelArguments(array $arguments): array
     {
-        return array_filter($arguments, fn (string $argument): bool => ! in_array($argument, ['--parallel', '-p'], strict: true));
+        $filtered = [];
+        $skipNext = false;
+
+        foreach ($arguments as $argument) {
+            if ($skipNext) {
+                $skipNext = false;
+
+                continue;
+            }
+
+            if (in_array($argument, ['--parallel', '-p'], strict: true)) {
+                continue;
+            }
+
+            if ($argument === '--processes') {
+                $skipNext = true;
+
+                continue;
+            }
+
+            if (str_starts_with($argument, '--processes=')) {
+                continue;
+            }
+
+            $filtered[] = $argument;
+        }
+
+        return $filtered;
     }
 
     /**

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -41,6 +41,12 @@ test('a parallel test can extend another test with same name', function () use (
     expect($run('tests/Fixtures/Inheritance'))->toContain('Tests:    1 skipped, 1 passed (1 assertions)');
 })->skipOnWindows();
 
+test('a count-based shard runs in parallel when no shards file exists', function () use ($run) {
+    expect($run('tests/Fixtures/Inheritance', '--shard=1/1'))
+        ->toContain('Tests:    1 skipped, 1 passed (1 assertions)')
+        ->toContain('Parallel: 3 processes');
+})->skipOnWindows();
+
 test('parallel reports invalid datasets as failures', function () use ($run) {
     expect($run('tests/.tests/ParallelInvalidDataset'))
         ->toContain("A dataset with the name `missing.dataset` does not exist. You can create it using `dataset('missing.dataset', ['a', 'b']);`.")


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

When `--shard` is used with `--parallel` and there's no usable `tests/.pest/shards.json`, Pest builds the shard's `--filter` by spawning an internal `--list-tests` run. `Shard::removeParallelArguments()` only stripped `--parallel`/`-p` from that sub-process, so it still received `--processes`, which `--list-tests` rejects — `mustRun()` then threw `ProcessFailedException` and the whole run exited non-zero even though every test passed. This strips `--processes` from that sub-invocation too, alongside the existing `--parallel` removal.

### Related:

Closes #1731 (same root cause as #1454).
