### PR TITLE
fix: prevent false "empty test suite" when merging parallel results

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -323,9 +323,11 @@ final class WrapperRunner implements RunnerInterface
             /** @var list<AfterLastTestMethodFailed> $failedEvents */
             $failedEvents = array_merge_recursive($testResultSum->testFailedEvents(), $testResult->testFailedEvents());
 
+            $numberOfTestsRun = $testResultSum->numberOfTestsRun() + $testResult->numberOfTestsRun();
+
             $testResultSum = new TestResult(
-                (int) $testResultSum->hasTests() + (int) $testResult->hasTests(),
-                $testResultSum->numberOfTestsRun() + $testResult->numberOfTestsRun(),
+                $numberOfTestsRun,
+                $numberOfTestsRun,
                 $testResultSum->numberOfAssertions() + $testResult->numberOfAssertions(),
                 array_merge_recursive($testResultSum->testErroredEvents(), $testResult->testErroredEvents()),
                 $failedEvents,


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

When parallel results are merged in `WrapperRunner::complete()`, the merged `numberOfTests` was built by summing each worker's `hasTests()` boolean. A streaming worker can report `numberOfTests = 0` even after running tests (only `numberOfTestsRun` is reliable), so when every worker reports `hasTests() === false` the merged result looks empty — and with `failOnEmptyTestSuite` on, the run exits non-zero despite all tests passing. This sums the reliable `numberOfTestsRun` instead.

### Related:

Closes #1738
