### PR TITLE
fix: preserve the global afterAll hook until class teardown

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -118,6 +118,11 @@ trait Testable
     private static ?Closure $__afterAll = null;
 
     /**
+     * The test's after all closure, preserved for the class teardown.
+     */
+    private static ?Closure $__afterAllForClass = null;
+
+    /**
      * The list of snapshot changes, if any.
      */
     private array $__snapshotChanges = [];
@@ -214,6 +219,8 @@ trait Testable
             $beforeAll = ChainableClosure::boundStatically(self::$__beforeAll, $beforeAll);
         }
 
+        self::$__afterAllForClass = self::$__afterAll;
+
         try {
             call_user_func(Closure::bind($beforeAll, null, self::class));
         } catch (Throwable $e) {
@@ -228,8 +235,8 @@ trait Testable
     {
         $afterAll = TestSuite::getInstance()->afterAll->get(self::$__filename);
 
-        if (self::$__afterAll instanceof Closure) {
-            $afterAll = ChainableClosure::boundStatically(self::$__afterAll, $afterAll);
+        if (self::$__afterAllForClass instanceof Closure) {
+            $afterAll = ChainableClosure::boundStatically(self::$__afterAllForClass, $afterAll);
         }
 
         call_user_func(Closure::bind($afterAll, null, self::class));

--- a/tests/.tests/GlobalAfterAll/GlobalAfterAllTest.php
+++ b/tests/.tests/GlobalAfterAll/GlobalAfterAllTest.php
@@ -1,0 +1,13 @@
+<?php
+
+pest()->afterAll(function () {
+    $marker = getenv('PEST_AFTERALL_MARKER');
+
+    if (is_string($marker) && $marker !== '') {
+        file_put_contents($marker, '1');
+    }
+});
+
+test('first', fn () => expect(true)->toBeTrue());
+
+test('second', fn () => expect(true)->toBeTrue());

--- a/tests/Visual/AfterAll.php
+++ b/tests/Visual/AfterAll.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+test('global afterAll hook runs after the suite', function () {
+    $marker = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pest-afterall-'.uniqid();
+
+    $process = new Process(
+        ['php', 'bin/pest', 'tests/.tests/GlobalAfterAll'],
+        dirname(__DIR__, 2),
+        ['PEST_AFTERALL_MARKER' => $marker],
+    );
+
+    $process->run();
+
+    expect(file_exists($marker))->toBeTrue();
+
+    if (file_exists($marker)) {
+        unlink($marker);
+    }
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

A global `afterAll()` hook (registered via `uses()`/`pest()`) never runs, while `beforeAll`, `beforeEach` and `afterEach` work. `beforeAll` is consumed in `setUpBeforeClass` before any test runs, but the last test's `tearDown` flushes the static `$__afterAll` before `tearDownAfterClass` reads it, so the global afterAll silently no-ops. This captures the hook in `setUpBeforeClass` while it's still set and uses that copy at teardown.

### Related:

Closes #1694
