### PR TITLE
fix: report dataset provider errors as failing tests

### DIFF
--- a/src/Exceptions/DatasetProviderError.php
+++ b/src/Exceptions/DatasetProviderError.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class DatasetProviderError extends RuntimeException
+{
+    public function __construct(Throwable $previous)
+    {
+        parent::__construct($previous->getMessage(), (int) $previous->getCode(), $previous);
+    }
+}

--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -158,6 +158,7 @@ final class TestCaseFactory
             $classCode = <<<PHP
             namespace $namespace;
 
+            use Pest\Exceptions\DatasetProviderError as __PestDatasetProviderError;
             use Pest\Repositories\DatasetsRepository as __PestDatasets;
             use Pest\TestSuite as __PestTestSuite;
 

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -235,6 +235,10 @@ final class TestCaseMethodFactory
             $attributesCode
                 public function $methodName(...\$arguments)
                 {
+                    if (count(\$arguments) === 1 && \$arguments[0] instanceof __PestDatasetProviderError) {
+                        throw \$arguments[0]->getPrevious() ?? \$arguments[0];
+                    }
+
                     return \$this->__runTest(
                         \$this->__test,
                         ...\$arguments,
@@ -261,7 +265,11 @@ final class TestCaseMethodFactory
 
                 public static function $dataProviderName()
                 {
-                    return __PestDatasets::get(self::\$__filename, "$methodName");
+                    try {
+                        return __PestDatasets::get(self::\$__filename, "$methodName");
+                    } catch (\Throwable \$throwable) {
+                        return [[new __PestDatasetProviderError(\$throwable)]];
+                    }
                 }
 
         EOF;

--- a/tests/.tests/DatasetClosureThrows.php
+++ b/tests/.tests/DatasetClosureThrows.php
@@ -1,0 +1,9 @@
+<?php
+
+dataset('throws', function () {
+    throw new RuntimeException('boom from dataset');
+});
+
+it('x', function ($a) {
+    expect($a)->toBeTrue();
+})->with('throws');

--- a/tests/.tests/IssueOnly.php
+++ b/tests/.tests/IssueOnly.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+it('references a missing dataset', function ($value) {
+    expect($value)->toBeTruthy();
+})->with('missing');

--- a/tests/.tests/IssueWithPassing.php
+++ b/tests/.tests/IssueWithPassing.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+it('passes normally', function () {
+    expect(true)->toBeTrue();
+});
+
+it('references a missing dataset', function ($value) {
+    expect($value)->toBeTruthy();
+})->with('missing');

--- a/tests/Features/DatasetProviderErrors.php
+++ b/tests/Features/DatasetProviderErrors.php
@@ -1,0 +1,49 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+$run = function (string $target): array {
+    $process = new Process(
+        ['php', 'bin/pest', $target],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true'],
+    );
+
+    $process->run();
+
+    return [
+        'output' => removeAnsiEscapeSequences($process->getOutput().$process->getErrorOutput()),
+        'code' => $process->getExitCode(),
+    ];
+};
+
+test('reports missing datasets as errors for a single file run', function () use ($run) {
+    $result = $run('tests/.tests/IssueOnly.php');
+
+    expect($result['output'])
+        ->toContain("A dataset with the name `missing` does not exist. You can create it using `dataset('missing', ['a', 'b']);`.")
+        ->toContain('FAILED')
+        ->toContain('Tests:    1 failed');
+
+    expect($result['code'])->not->toBe(0);
+})->skipOnWindows();
+
+test('reports missing datasets as errors alongside passing tests', function () use ($run) {
+    $result = $run('tests/.tests/IssueWithPassing.php');
+
+    expect($result['output'])
+        ->toContain("A dataset with the name `missing` does not exist. You can create it using `dataset('missing', ['a', 'b']);`.")
+        ->toContain('1 passed')
+        ->toContain('1 failed');
+
+    expect($result['code'])->not->toBe(0);
+})->skipOnWindows();
+
+test('reports dataset closure exceptions as errors', function () use ($run) {
+    $result = $run('tests/.tests/DatasetClosureThrows.php');
+
+    expect($result['output'])
+        ->toContain('boom from dataset');
+
+    expect($result['code'])->not->toBe(0);
+})->skipOnWindows();


### PR DESCRIPTION
## What

Errors raised while resolving a test's dataset previously crashed the entire run instead of being reported as a normal test failure. This affects:

- referencing a **missing named dataset** (e.g. `->with('missing')`)
- a **dataset closure that throws** during resolution

## How

- The generated data provider now wraps any throwable from `DatasetsRepository::get()` in a new internal `DatasetProviderError`.
- The generated test method detects that single-argument error case and rethrows the original throwable.

Result: the affected test fails cleanly with its real error message and a non-zero exit code, while the rest of the suite keeps running.

## Tests

Added `tests/Features/DatasetProviderErrors.php` covering:
- missing dataset in a single-file run
- missing dataset alongside a passing test
- a throwing dataset closure