### PR TITLE
fix: remove strict phpunit conflict constraint to allow patch updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "conflict": {
         "filp/whoops": "<2.18.3",
-        "phpunit/phpunit": ">12.5.30",
         "sebastian/exporter": "<7.0.0",
         "webmozart/assert": "<1.11.0"
     },


### PR DESCRIPTION
## Description

This PR resolves an issue where `phpunit/phpunit` was effectively locked to an exact patch version, preventing users from receiving critical security updates. 

**Changes introduced:**
- Removed the `phpunit/phpunit` constraint from the `conflict` block in `composer.json`.
- The `require` block already correctly utilizes the caret (`^`) constraint for `phpunit/phpunit`, which safely allows non-breaking minor and patch updates. Removing the strict conflict allows Composer to resolve these security patches naturally.

## Related Issues

Resolves #1679