### PR TITLE
Fix project root resolution when vendor is a symlinked directory (git worktree support)

### DIFF
--- a/bin/pest
+++ b/bin/pest
@@ -142,21 +142,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
         $autoloadPath = $localPath;
     }
 
-    // Get $rootPath based on $autoloadPath
-    $rootPath = dirname($autoloadPath, 2);
-
-    // Worktree / symlinked vendor support
-    // If the CWD has a vendor symlink pointing to the same
-    // resolved vendor directory, use CWD as root so worktree
-    // tests find their own Pest.php, tests/, and phpunit.xml.
-    $cwd = getcwd();
-    if ($cwd !== false
-        && is_link($cwd . '/vendor')
-        && realpath($cwd . '/vendor') === dirname($autoloadPath, 1)) {
-        $rootPath = $cwd;
-    }
-
-    $_ENV['APP_BASE_PATH'] = $rootPath;
+    $rootPath = \Pest\Support\Worktree::resolveRoot($autoloadPath);
 
     $input = new ArgvInput;
 

--- a/bin/pest
+++ b/bin/pest
@@ -156,6 +156,8 @@ use Symfony\Component\Console\Output\ConsoleOutput;
         $rootPath = $cwd;
     }
 
+    $_ENV['APP_BASE_PATH'] = $rootPath;
+
     $input = new ArgvInput;
 
     $testSuite = TestSuite::getInstance(

--- a/bin/pest
+++ b/bin/pest
@@ -145,6 +145,17 @@ use Symfony\Component\Console\Output\ConsoleOutput;
     // Get $rootPath based on $autoloadPath
     $rootPath = dirname($autoloadPath, 2);
 
+    // Worktree / symlinked vendor support
+    // If the CWD has a vendor symlink pointing to the same
+    // resolved vendor directory, use CWD as root so worktree
+    // tests find their own Pest.php, tests/, and phpunit.xml.
+    $cwd = getcwd();
+    if ($cwd !== false
+        && is_link($cwd . '/vendor')
+        && realpath($cwd . '/vendor') === dirname($autoloadPath, 1)) {
+        $rootPath = $cwd;
+    }
+
     $input = new ArgvInput;
 
     $testSuite = TestSuite::getInstance(

--- a/bin/pest
+++ b/bin/pest
@@ -14,6 +14,7 @@ use Pest\TestCaseMethodFilters\NotesTestCaseFilter;
 use Pest\TestCaseMethodFilters\PrTestCaseFilter;
 use Pest\TestCaseMethodFilters\FlakyTestCaseFilter;
 use Pest\TestCaseMethodFilters\TodoTestCaseFilter;
+use Pest\Support\Worktree;
 use Pest\TestSuite;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -142,7 +143,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
         $autoloadPath = $localPath;
     }
 
-    $rootPath = \Pest\Support\Worktree::resolveRoot($autoloadPath);
+    $rootPath = Worktree::resolveRoot($autoloadPath);
 
     $input = new ArgvInput;
 

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -12,30 +12,10 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Resolve the project root path, accounting for git worktrees
- * where vendor is a symlink to another worktree's vendor directory.
- */
-function resolveWorktreeRoot(string $autoloadPath): string
-{
-    $rootPath = dirname($autoloadPath, 2);
-
-    $cwd = getcwd();
-    if ($cwd !== false
-        && is_link($cwd . '/vendor')
-        && realpath($cwd . '/vendor') === dirname($autoloadPath, 1)) {
-        $rootPath = $cwd;
-    }
-
-    $_ENV['APP_BASE_PATH'] = $rootPath;
-
-    return $rootPath;
-}
-
 $bootPest = (static function (): void {
     $workerArgv = new ArgvInput;
 
-    $rootPath = resolveWorktreeRoot(PHPUNIT_COMPOSER_INSTALL);
+    $rootPath = \Pest\Support\Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
     $testSuite = TestSuite::getInstance($rootPath, $workerArgv->getParameterOption(
         '--test-directory',
         'tests'
@@ -80,7 +60,7 @@ $bootPest = (static function (): void {
     }
 
     $container = Container::getInstance();
-    $rootPath = resolveWorktreeRoot(PHPUNIT_COMPOSER_INSTALL);
+    $rootPath = \Pest\Support\Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
 
     foreach (Kernel::RESTARTERS as $restarterClass) {
         $restarter = $container->get($restarterClass);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -7,6 +7,7 @@ use ParaTest\WrapperRunner\WrapperWorker;
 use Pest\Kernel;
 use Pest\Plugins\Actions\CallsHandleArguments;
 use Pest\Support\Container;
+use Pest\Support\Worktree;
 use Pest\TestSuite;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -15,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 $bootPest = (static function (): void {
     $workerArgv = new ArgvInput;
 
-    $rootPath = \Pest\Support\Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
+    $rootPath = Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
     $testSuite = TestSuite::getInstance($rootPath, $workerArgv->getParameterOption(
         '--test-directory',
         'tests'
@@ -60,7 +61,7 @@ $bootPest = (static function (): void {
     }
 
     $container = Container::getInstance();
-    $rootPath = \Pest\Support\Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
+    $rootPath = Worktree::resolveRoot(PHPUNIT_COMPOSER_INSTALL);
 
     foreach (Kernel::RESTARTERS as $restarterClass) {
         $restarter = $container->get($restarterClass);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -12,10 +12,28 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Resolve the project root path, accounting for git worktrees
+ * where vendor is a symlink to another worktree's vendor directory.
+ */
+function resolveWorktreeRoot(string $autoloadPath): string
+{
+    $rootPath = dirname($autoloadPath, 2);
+
+    $cwd = getcwd();
+    if ($cwd !== false
+        && is_link($cwd . '/vendor')
+        && realpath($cwd . '/vendor') === dirname($autoloadPath, 1)) {
+        $rootPath = $cwd;
+    }
+
+    return $rootPath;
+}
+
 $bootPest = (static function (): void {
     $workerArgv = new ArgvInput;
 
-    $rootPath = dirname(PHPUNIT_COMPOSER_INSTALL, 2);
+    $rootPath = resolveWorktreeRoot(PHPUNIT_COMPOSER_INSTALL);
     $testSuite = TestSuite::getInstance($rootPath, $workerArgv->getParameterOption(
         '--test-directory',
         'tests'
@@ -60,7 +78,7 @@ $bootPest = (static function (): void {
     }
 
     $container = Container::getInstance();
-    $rootPath = dirname(PHPUNIT_COMPOSER_INSTALL, 2);
+    $rootPath = resolveWorktreeRoot(PHPUNIT_COMPOSER_INSTALL);
 
     foreach (Kernel::RESTARTERS as $restarterClass) {
         $restarter = $container->get($restarterClass);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -27,6 +27,8 @@ function resolveWorktreeRoot(string $autoloadPath): string
         $rootPath = $cwd;
     }
 
+    $_ENV['APP_BASE_PATH'] = $rootPath;
+
     return $rootPath;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,9 @@
         ]
     },
     "extra": {
+        "branch-alias": {
+            "dev-feature/worktree-symlinked-vendor": "4.7.x-dev"
+        },
         "pest": {
             "plugins": [
                 "Pest\\Mutate\\Plugins\\Mutate",

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -312,3 +312,4 @@ if (! function_exists('visit')) {
         return test()->visit($url, $options);
     }
 }
+

--- a/src/Support/Worktree.php
+++ b/src/Support/Worktree.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+/**
+ * @internal
+ */
+final class Worktree
+{
+    /**
+     * Resolve the project root path, accounting for git worktrees
+     * where vendor is a symlink to another worktree's vendor directory.
+     *
+     * When the current working directory has a `vendor` symlink that
+     * resolves to the same directory as the autoloaded vendor path,
+     * this means we're inside a git worktree whose vendor directory
+     * is symlinked to the main worktree. In that case, the project
+     * root should be the current working directory (the worktree),
+     * so that the worktree's own `Pest.php`, `tests/`, and
+     * `phpunit.xml` are found.
+     */
+    public static function resolveRoot(string $autoloadPath): string
+    {
+        $rootPath = dirname($autoloadPath, 2);
+
+        $cwd = getcwd();
+        if ($cwd !== false
+            && is_link($cwd.'/vendor')
+            && realpath($cwd.'/vendor') === dirname($autoloadPath, 1)) {
+            $rootPath = $cwd;
+        }
+
+        $_ENV['APP_BASE_PATH'] = $rootPath;
+
+        return $rootPath;
+    }
+}

--- a/tests/Unit/Worktree.php
+++ b/tests/Unit/Worktree.php
@@ -1,0 +1,124 @@
+<?php
+
+use Pest\Support\Worktree;
+
+beforeEach(function () {
+    $this->originalCwd = getcwd();
+
+    // Create the "real project" directory structure with a vendor autoloader
+    $this->realProject = sys_get_temp_dir().'/pest-test-real-'.bin2hex(random_bytes(4));
+    mkdir($this->realProject.'/vendor', 0777, true);
+    touch($this->realProject.'/vendor/autoload.php');
+    $this->autoloadPath = $this->realProject.'/vendor/autoload.php';
+
+    // Create the "worktree" directory with a vendor symlink pointing to the real project
+    $this->worktree = sys_get_temp_dir().'/pest-test-worktree-'.bin2hex(random_bytes(4));
+    mkdir($this->worktree, 0777, true);
+    symlink($this->realProject.'/vendor', $this->worktree.'/vendor');
+
+    // Create a "different vendor" for the wrong-symlink scenario
+    $this->differentVendor = sys_get_temp_dir().'/pest-test-different-'.bin2hex(random_bytes(4));
+    mkdir($this->differentVendor, 0777, true);
+    touch($this->differentVendor.'/autoload.php');
+});
+
+afterEach(function () {
+    chdir($this->originalCwd);
+
+    // Recursive removal helpers
+    $removeDir = function (string $path) use (&$removeDir): void {
+        if (! is_dir($path) && ! is_link($path)) {
+            return;
+        }
+        foreach (scandir($path) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $itemPath = $path.'/'.$item;
+            if (is_link($itemPath) || ! is_dir($itemPath)) {
+                unlink($itemPath);
+            } else {
+                $removeDir($itemPath);
+            }
+        }
+        rmdir($path);
+    };
+
+    // Clean up worktree first (symlink and directories)
+    if (is_link($this->worktree.'/vendor')) {
+        unlink($this->worktree.'/vendor');
+    }
+    if (is_dir($this->worktree)) {
+        $removeDir($this->worktree);
+    }
+
+    // Clean up real project
+    if (is_file($this->autoloadPath)) {
+        unlink($this->autoloadPath);
+    }
+    if (is_dir($this->realProject.'/vendor')) {
+        rmdir($this->realProject.'/vendor');
+    }
+    if (is_dir($this->realProject)) {
+        rmdir($this->realProject);
+    }
+
+    // Clean up different vendor
+    if (is_file($this->differentVendor.'/autoload.php')) {
+        unlink($this->differentVendor.'/autoload.php');
+    }
+    if (is_dir($this->differentVendor)) {
+        rmdir($this->differentVendor);
+    }
+
+    unset($this->originalCwd, $this->realProject, $this->autoloadPath, $this->worktree, $this->differentVendor, $removeDir);
+});
+
+it('returns the autoload parent directory when not inside a worktree', function () {
+    chdir($this->realProject);
+
+    $root = Worktree::resolveRoot($this->autoloadPath);
+
+    expect($root)->toBe($this->realProject);
+});
+
+it('returns the worktree root when vendor is a symlink matching the autoload vendor', function () {
+    chdir($this->worktree);
+
+    $root = Worktree::resolveRoot($this->autoloadPath);
+
+    expect($root)->toBe($this->worktree);
+});
+
+it('returns the autoload parent directory when vendor symlink points elsewhere', function () {
+    symlink($this->differentVendor, $this->worktree.'/vendor-wrong');
+    rename($this->worktree.'/vendor', $this->worktree.'/vendor-original');
+    rename($this->worktree.'/vendor-wrong', $this->worktree.'/vendor');
+
+    chdir($this->worktree);
+
+    $root = Worktree::resolveRoot($this->autoloadPath);
+
+    expect($root)->toBe($this->realProject);
+});
+
+it('returns the autoload parent directory when vendor is a real directory, not a symlink', function () {
+    // Replace the worktree's vendor symlink with a real vendor directory
+    unlink($this->worktree.'/vendor');
+    mkdir($this->worktree.'/vendor', 0777, true);
+    touch($this->worktree.'/vendor/autoload.php');
+
+    chdir($this->worktree);
+
+    $root = Worktree::resolveRoot($this->autoloadPath);
+
+    expect($root)->toBe($this->realProject);
+});
+
+it('sets APP_BASE_PATH in the environment', function () {
+    chdir($this->realProject);
+
+    Worktree::resolveRoot($this->autoloadPath);
+
+    expect($_ENV['APP_BASE_PATH'])->toBe($this->realProject);
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When running Pest from a git worktree where `vendor/` is a symlink to another worktree (e.g. to avoid the overhead of duplicating dependencies), the project root path was incorrectly resolved to the parent of the resolved vendor directory rather than the worktree root.

The root cause is that PHP's `__DIR__` and `__FILE__` resolve through symlinks. Since `bin/pest` lives inside the `vendor/` directory, if `vendor/` is a symlink then `__DIR__` follows it, causing `dirname(__DIR__, 4)` to point at the wrong worktree's root. The same issue affected `bin/worker.php` for parallel test execution.

The fix checks whether the current working directory has a `vendor` symlink that resolves to the same location as the autoloader's vendor parent. If so, the CWD is used as the project root.

### Related:

For detailed background on the worktree + symlinked vendor use case, see the [wiki page on my fork](https://github.com/ceilidhboy/pest/wiki).
