### PR TITLE
fix: run `pest()->afterAll()` hooks by flushing statics after `tearDownAfterClass()`

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -232,7 +232,11 @@ trait Testable
             $afterAll = ChainableClosure::boundStatically(self::$__afterAll, $afterAll);
         }
 
-        call_user_func(Closure::bind($afterAll, null, self::class));
+        try {
+            call_user_func(Closure::bind($afterAll, null, self::class));
+        } finally {
+            self::flush();
+        }
 
         parent::tearDownAfterClass();
     }
@@ -371,9 +375,6 @@ trait Testable
             parent::tearDown();
 
             TestSuite::getInstance()->test = null;
-
-            $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
-            $method->tearDown($this);
         }
     }
 

--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -147,14 +147,6 @@ final class TestCaseMethodFactory
     }
 
     /**
-     * Flushes the test case.
-     */
-    public function tearDown(TestCase $concrete): void
-    {
-        $concrete::flush(); // @phpstan-ignore-line
-    }
-
-    /**
      * Creates the test's closure.
      */
     public function getClosure(): Closure

--- a/tests/Hooks/AfterAllTest.php
+++ b/tests/Hooks/AfterAllTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use function PHPUnit\Framework\assertSame;
+
+$_SERVER['globalHook']->calls->afterAllInFile = 0;
+$_SERVER['globalHook']->calls->afterAllTestsRan = 0;
+
+pest()->afterAll(function () {
+    $_SERVER['globalHook']->calls->afterAllInFile++;
+});
+
+it('does not get called before all tests 1', function () {
+    $_SERVER['globalHook']->calls->afterAllTestsRan++;
+    expect($_SERVER['globalHook']->calls->afterAllInFile)->toBe(0);
+})->repeat(2);
+
+it('does not get called before all tests 2', function () {
+    $_SERVER['globalHook']->calls->afterAllTestsRan++;
+    expect($_SERVER['globalHook']->calls->afterAllInFile)->toBe(0);
+});
+
+register_shutdown_function(function () {
+    // Under --parallel, Pest also evaluates this file in the parent process to
+    // build the suite; the tests (and therefore afterAll) only run in the worker.
+    // Skip the assertion in any process where no test of this file actually ran.
+    if ($_SERVER['globalHook']->calls->afterAllTestsRan === 0) {
+        return;
+    }
+
+    assertSame(1, $_SERVER['globalHook']->calls->afterAllInFile, 'Expected the [pest()->afterAll()] hook to have been called exactly once.');
+});


### PR DESCRIPTION
fix: run `pest()->afterAll()` hooks by flushing statics after `tearDownAfterClass()`

Fixes #1694

## What was happening

Hooks registered via `pest()->afterAll()` silently never executed. The reporter
observed the hook closure showing up as a `NullClosure` inside
`tearDownAfterClass()`.

## Root cause

`Testable::tearDown()`'s `finally` block called `$method->tearDown($this)` → `TestCaseMethodFactory::tearDown()` →`$concrete::flush()`, which nulls the static `self::$__afterAll` after
**every** test. PHPUnit calls `tearDownAfterClass()` *after* the last test's
`tearDown()`, so by the time it runs, the static holding the `afterAll` hook
had already been wiped — leaving the `NullClosure` the reporter saw.

`beforeAll` doesn't have this problem because statics are populated at
instance initialization, which happens before `setUpBeforeClass()` ever
consumes them — there's no intervening per-test flush in that direction.

The per-test flush was also redundant: `TestCaseMethodFactory::setUp()`
already flushes statics before re-applying the `Uses`-level hook proxies for
the next test, which is what actually prevents hooks from chaining
duplicates across tests, datasets, and repetitions.

## The fix

- Remove the redundant per-test flush (`TestCaseMethodFactory::tearDown()`
  and its call site in `Testable::tearDown()`) — `setUp()`'s pre-proxy flush
  already covers hygiene between tests.
- Move the flush into `tearDownAfterClass()`'s `finally` block, after the
  `afterAll` hook chain runs, so the static resets at the correct point even
  if a hook throws. Hook ordering (uses-hooks chained before the file-level
  `afterAll`, then `parent::tearDownAfterClass()`) is unchanged.

## Tests

`tests/Hooks/` had `BeforeAllTest.php`, `BeforeEachTest.php`, and
`AfterEachTest.php`, but no `AfterAllTest.php` — that gap is why this
regression went unnoticed. Added `tests/Hooks/AfterAllTest.php`.

A conventional in-test `expect()` assertion can't verify this hook actually
ran, because `afterAll` only executes after every test in the class has
finished — there's no later test to observe it from. The test instead mirrors
the shutdown-assertion pattern used in `tests/Features/TestCycle.php`:
`register_shutdown_function()` asserts the hook fired exactly once, after the
whole process (including `tearDownAfterClass()`) has completed.

## Evidence

**On 4.x HEAD (test only, source unpatched):**
```
   PASS  Tests\Hooks\AfterAllTest
  ✓ it does not get called before all tests 1 @ repetition 1 of 2        0.01s
  ✓ it does not get called before all tests 1 @ repetition 2 of 2
  ✓ it does not get called before all tests 2

   PASS  Tests\Hooks\AfterEachTest
  ✓ nested → nested afterEach execution order                            0.06s
  ✓ global afterEach execution order

   PASS  Tests\Hooks\BeforeAllTest
  ✓ it gets called before all tests 1 @ repetition 1 of 2                0.03s
  ✓ it gets called before all tests 1 @ repetition 2 of 2
  ✓ it gets called before all tests 2

   PASS  Tests\Hooks\BeforeEachTest
  ✓ global beforeEach execution order                                    0.06s

  Tests:    9 passed (84 assertions)
  Duration: 0.94s

EXIT: 255
```
Pest's own reporter shows green (the per-test assertions genuinely pass — the
bug is that `afterAll` never runs, so there's nothing in-test to fail on).
The process still exits `255`: PHPUnit's `register_shutdown_function`
assertion fails after the runner has already printed its summary, because
`afterAllInFile` stayed `0` — the hook was never invoked.

**With this fix:**
```
   PASS  Tests\Hooks\AfterAllTest
  ✓ it does not get called before all tests 1 @ repetition 1 of 2        0.01s
  ✓ it does not get called before all tests 1 @ repetition 2 of 2
  ✓ it does not get called before all tests 2

   PASS  Tests\Hooks\AfterEachTest
  ✓ nested → nested afterEach execution order                            0.03s
  ✓ global afterEach execution order

   PASS  Tests\Hooks\BeforeAllTest
  ✓ it gets called before all tests 1 @ repetition 1 of 2                0.01s
  ✓ it gets called before all tests 1 @ repetition 2 of 2
  ✓ it gets called before all tests 2

   PASS  Tests\Hooks\BeforeEachTest
  ✓ global beforeEach execution order                                    0.01s

  Tests:    9 passed (84 assertions)
  Duration: 0.22s

EXIT: 0
```

As a side effect, the two `pest()->in('Hooks')->afterAll()` hooks declared in
`tests/Pest.php` (which target every file in this directory, including the
new one) now actually execute for the first time — their internal
`expect()` assertions pass under this fix.
