### PR TITLE
fix: parallel runs with group filters no longer exit 1 despite green tests

### DIFF
--- a/src/Plugins/Parallel/Paratest/WrapperRunner.php
+++ b/src/Plugins/Parallel/Paratest/WrapperRunner.php
@@ -323,8 +323,18 @@ final class WrapperRunner implements RunnerInterface
             /** @var list<AfterLastTestMethodFailed> $failedEvents */
             $failedEvents = array_merge_recursive($testResultSum->testFailedEvents(), $testResult->testFailedEvents());
 
+            // A worker's `hasTests()` only reflects the *last* file it executed:
+            // PHPUnit's Collector overwrites `numberOfTests` on every
+            // `executionStarted` event. When a worker's final file has all of
+            // its tests excluded by `--group`/`--exclude-group`, that worker
+            // reports `hasTests() === false` even though it ran plenty of
+            // tests. If every worker happens to end on such a file, the merged
+            // result claims the whole suite was empty and the run exits 1
+            // (PHPUnit enables `failOnEmptyTestSuite` implicitly for explicit
+            // test selections) — despite a fully green summary. Treating a
+            // worker with executed tests as "has tests" restores the truth.
             $testResultSum = new TestResult(
-                (int) $testResultSum->hasTests() + (int) $testResult->hasTests(),
+                (int) ($testResultSum->hasTests() || $testResult->hasTests() || $testResult->numberOfTestsRun() > 0),
                 $testResultSum->numberOfTestsRun() + $testResult->numberOfTestsRun(),
                 $testResultSum->numberOfAssertions() + $testResult->numberOfAssertions(),
                 array_merge_recursive($testResultSum->testErroredEvents(), $testResult->testErroredEvents()),

--- a/tests/.tests/ParallelGroupFilteredLastFile/ATest.php
+++ b/tests/.tests/ParallelGroupFilteredLastFile/ATest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('a test inside the filtered group', function () {
+    expect(true)->toBeTrue();
+})->group('filtered-group');

--- a/tests/.tests/ParallelGroupFilteredLastFile/ZTest.php
+++ b/tests/.tests/ParallelGroupFilteredLastFile/ZTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('a test outside the filtered group', function () {
+    expect(true)->toBeTrue();
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -47,3 +47,38 @@ test('parallel reports invalid datasets as failures', function () use ($run) {
         ->toContain('Tests:    1 failed, 1 passed (1 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
+
+test('parallel group-filtered run is not considered empty when workers end on fully filtered files', function () {
+    // Regression: a worker's TestResult only carries `numberOfTests` of its
+    // LAST executed file (PHPUnit's Collector overwrites it per execution).
+    // With `--processes=1` the single worker deterministically ends on
+    // ZTest.php, whose only test is excluded by the group filter — before the
+    // fix the merged result claimed "no tests" and exited 1 despite the green
+    // summary (PHPUnit enables failOnEmptyTestSuite implicitly for --group).
+    $process = new Process(
+        ['php', 'bin/pest', '--parallel', '--processes=1', '--group=filtered-group', 'tests/.tests/ParallelGroupFilteredLastFile'],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true'],
+    );
+
+    $process->run();
+
+    expect(removeAnsiEscapeSequences($process->getOutput()))
+        ->toContain('Tests:    1 passed (1 assertions)');
+
+    expect($process->getExitCode())->toBe(0);
+})->skipOnWindows();
+
+test('parallel group-filtered run still fails when the selection matches no tests at all', function () {
+    // Companion guard: a genuinely empty selection must keep exiting non-zero
+    // (failOnEmptyTestSuite) — the fix must not mask real "0 tests" runs.
+    $process = new Process(
+        ['php', 'bin/pest', '--parallel', '--processes=3', '--group=group-that-does-not-exist', 'tests/.tests/ParallelGroupFilteredLastFile'],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true'],
+    );
+
+    $process->run();
+
+    expect($process->getExitCode())->not->toBe(0);
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`--parallel` runs that use `--group`/`--exclude-group` can exit 1 with a fully green summary and no error output.

Cause: a wrapper worker's serialized `TestResult` only carries the `numberOfTests` of the **last** file it executed (PHPUnit's `Collector` overwrites the counter on every `executionStarted`). If a worker's final file has all tests excluded by the group filter, it reports `hasTests() === false` despite having run tests. When every worker ends on such a file — a timing lottery, hence flaky — the merged result in `WrapperRunner::complete()` claims the suite was empty, and since PHPUnit 12 enables `failOnEmptyTestSuite` implicitly for explicit selections, the run exits 1. The "No tests found" runner warnings are already filtered from the output, so nothing is printed.

Deterministic repro (fails before this fix, passes after — added as a test):

```bash
php bin/pest --parallel --processes=1 --group=filtered-group tests/.tests/ParallelGroupFilteredLastFile
# "Tests: 1 passed (1 assertions)" — exit code 1
```

Fix: while merging worker results, treat a worker with `numberOfTestsRun() > 0` as having tests. A companion test ensures genuinely empty selections still exit non-zero.

### Related:

- #1483
