### PR TITLE
Feat: basic expectations

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -414,6 +414,18 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value is finite.
+     *
+     * @return self<TValue>
+     */
+    public function toBeFinite(string $message = ''): self
+    {
+        Assert::assertFinite($this->value, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value is an instance of $class.
      *
      * @param  class-string  $class
@@ -518,6 +530,54 @@ final class Expectation
     public function toBeNumeric(string $message = ''): self
     {
         Assert::assertIsNumeric($this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is positive.
+     *
+     * @return self<TValue>
+     */
+    public function toBePositive(string $message = ''): self
+    {
+        Assert::assertGreaterThan(0, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is negative.
+     *
+     * @return self<TValue>
+     */
+    public function toBeNegative(string $message = ''): self
+    {
+        Assert::assertLessThan(0, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is even.
+     *
+     * @return self<TValue>
+     */
+    public function toBeEven(string $message = ''): self
+    {
+        Assert::assertTrue(is_int($this->value) && $this->value % 2 === 0, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is odd.
+     *
+     * @return self<TValue>
+     */
+    public function toBeOdd(string $message = ''): self
+    {
+        Assert::assertTrue(is_int($this->value) && $this->value % 2 !== 0, $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -364,6 +364,38 @@ final class Expectation
     }
 
     /**
+     * Asserts that every element in the value is unique.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveUniqueItems(string $message = ''): self
+    {
+        if (! is_array($this->value)) {
+            InvalidExpectationValue::expected('array');
+        }
+
+        Assert::assertTrue(count(array_unique($this->value, SORT_REGULAR)) === count($this->value), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value contains at least one duplicate.
+     *
+     * @return self<TValue>
+     */
+    public function toHaveDuplicates(string $message = ''): self
+    {
+        if (! is_array($this->value)) {
+            InvalidExpectationValue::expected('array');
+        }
+
+        Assert::assertTrue(count(array_unique($this->value, SORT_REGULAR)) < count($this->value), $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value contains the property $name.
      *
      * @return self<TValue>
@@ -511,6 +543,20 @@ final class Expectation
     public function toBeList(string $message = ''): self
     {
         Assert::assertIsList($this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is an associative array.
+     *
+     * @return self<TValue>
+     */
+    public function toBeAssociative(string $message = ''): self
+    {
+        $this->toBeArray($message);
+
+        Assert::assertFalse(array_is_list($this->value), $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -558,7 +558,9 @@ final class Expectation
      */
     public function toBeAssociative(string $message = ''): self
     {
-        $this->toBeArray($message);
+        if (! is_array($this->value)) {
+            InvalidExpectationValue::expected('array');
+        }
 
         Assert::assertFalse(array_is_list($this->value), $message);
 

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -505,6 +505,10 @@ final class Expectation
      */
     public function toBeFinite(string $message = ''): self
     {
+        if (! is_int($this->value) && ! is_float($this->value)) {
+            InvalidExpectationValue::expected('int|float');
+        }
+
         Assert::assertFinite($this->value, $message);
 
         return $this;
@@ -640,6 +644,10 @@ final class Expectation
      */
     public function toBePositive(string $message = ''): self
     {
+        if (! is_int($this->value) && ! is_float($this->value)) {
+            InvalidExpectationValue::expected('int|float');
+        }
+
         Assert::assertGreaterThan(0, $this->value, $message);
 
         return $this;
@@ -652,6 +660,10 @@ final class Expectation
      */
     public function toBeNegative(string $message = ''): self
     {
+        if (! is_int($this->value) && ! is_float($this->value)) {
+            InvalidExpectationValue::expected('int|float');
+        }
+
         Assert::assertLessThan(0, $this->value, $message);
 
         return $this;
@@ -664,7 +676,11 @@ final class Expectation
      */
     public function toBeEven(string $message = ''): self
     {
-        Assert::assertTrue(is_int($this->value) && $this->value % 2 === 0, $message);
+        if (! is_int($this->value)) {
+            InvalidExpectationValue::expected('int');
+        }
+
+        Assert::assertTrue($this->value % 2 === 0, $message);
 
         return $this;
     }
@@ -676,7 +692,11 @@ final class Expectation
      */
     public function toBeOdd(string $message = ''): self
     {
-        Assert::assertTrue(is_int($this->value) && $this->value % 2 !== 0, $message);
+        if (! is_int($this->value)) {
+            InvalidExpectationValue::expected('int');
+        }
+
+        Assert::assertTrue($this->value % 2 !== 0, $message);
 
         return $this;
     }

--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -198,6 +198,22 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value contains $needle, ignoring case.
+     *
+     * @return self<TValue>
+     */
+    public function toContainIgnoringCase(string $needle, string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertStringContainsStringIgnoringCase($needle, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that $needle equal an element of the value.
      *
      * @return self<TValue>
@@ -233,6 +249,23 @@ final class Expectation
     }
 
     /**
+     * Asserts that the value starts with $expected, ignoring case.
+     *
+     * @param  non-empty-string  $expected
+     * @return self<TValue>
+     */
+    public function toStartWithIgnoringCase(string $expected, string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(stripos($this->value, $expected) === 0, $message);
+
+        return $this;
+    }
+
+    /**
      * Asserts that the value ends with $expected.
      *
      * @param  non-empty-string  $expected
@@ -245,6 +278,26 @@ final class Expectation
         }
 
         Assert::assertStringEndsWith($expected, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value ends with $expected, ignoring case.
+     *
+     * @param  non-empty-string  $expected
+     * @return self<TValue>
+     */
+    public function toEndWithIgnoringCase(string $expected, string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(
+            substr_compare($this->value, $expected, -strlen($expected), strlen($expected), true) === 0,
+            $message
+        );
 
         return $this;
     }
@@ -590,6 +643,22 @@ final class Expectation
     public function toBeDigits(string $message = ''): self
     {
         Assert::assertTrue(ctype_digit((string) $this->value), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the value is blank.
+     *
+     * @return self<TValue>
+     */
+    public function toBeBlank(string $message = ''): self
+    {
+        if (! is_string($this->value)) {
+            InvalidExpectationValue::expected('string');
+        }
+
+        Assert::assertTrue(trim($this->value) === '', $message);
 
         return $this;
     }

--- a/tests/Features/Expect/toBeAssociative.php
+++ b/tests/Features/Expect/toBeAssociative.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -18,7 +19,7 @@ test('failures', function (): void {
 
 test('failures with invalid type', function (): void {
     expect('foo')->toBeAssociative();
-})->throws(ExpectationFailedException::class);
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [array].');
 
 test('failures with custom message', function (): void {
     expect([1, 2, 3])->toBeAssociative('oh no!');

--- a/tests/Features/Expect/toBeAssociative.php
+++ b/tests/Features/Expect/toBeAssociative.php
@@ -16,6 +16,10 @@ test('failures', function (): void {
     expect([1, 2, 3])->toBeAssociative();
 })->throws(ExpectationFailedException::class);
 
+test('failures with invalid type', function (): void {
+    expect('foo')->toBeAssociative();
+})->throws(ExpectationFailedException::class);
+
 test('failures with custom message', function (): void {
     expect([1, 2, 3])->toBeAssociative('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');

--- a/tests/Features/Expect/toBeAssociative.php
+++ b/tests/Features/Expect/toBeAssociative.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(['name' => 'Nuno'])->toBeAssociative()
+        ->and(['id' => 1, 'name' => 'Taylor'])->toBeAssociative()
+        ->and(['foo' => 'bar'])->toBeAssociative()
+        ->and([1, 2, 3])->not->toBeAssociative()
+        ->and([])->not->toBeAssociative();
+});
+
+test('failures', function (): void {
+    expect([1, 2, 3])->toBeAssociative();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect([1, 2, 3])->toBeAssociative('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(['foo' => 'bar'])->not->toBeAssociative();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeBlank.php
+++ b/tests/Features/Expect/toBeBlank.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -15,6 +16,10 @@ test('pass', function (): void {
 test('failures', function (): void {
     expect('hello')->toBeBlank();
 })->throws(ExpectationFailedException::class);
+
+test('failures with invalid type', function (): void {
+    expect([])->toBeBlank();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
 
 test('failures with custom message', function (): void {
     expect('hello')->toBeBlank('oh no!');

--- a/tests/Features/Expect/toBeBlank.php
+++ b/tests/Features/Expect/toBeBlank.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect('')->toBeBlank()
+        ->and('   ')->toBeBlank()
+        ->and("\n\t")->toBeBlank()
+        ->and('hello')->not->toBeBlank()
+        ->and(' hello ')->not->toBeBlank();
+});
+
+test('failures', function (): void {
+    expect('hello')->toBeBlank();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect('hello')->toBeBlank('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect('')->not->toBeBlank();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeEven.php
+++ b/tests/Features/Expect/toBeEven.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -20,6 +21,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect(3)->toBeEven('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect([])->toBeEven();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [int].');
 
 test('not failures', function (): void {
     expect(10)->not->toBeEven();

--- a/tests/Features/Expect/toBeEven.php
+++ b/tests/Features/Expect/toBeEven.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(2)->toBeEven()
+        ->and(10)->toBeEven()
+        ->and(0)->toBeEven()
+        ->and(-4)->toBeEven()
+        ->and(3)->not->toBeEven()
+        ->and(-5)->not->toBeEven();
+});
+
+test('failures', function (): void {
+    expect(3)->toBeEven();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect(3)->toBeEven('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(10)->not->toBeEven();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeFinite.php
+++ b/tests/Features/Expect/toBeFinite.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -21,6 +22,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect(INF)->toBeFinite('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect('foo')->toBeFinite();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [int|float].');
 
 test('not failures', function (): void {
     expect(42)->not->toBeFinite();

--- a/tests/Features/Expect/toBeFinite.php
+++ b/tests/Features/Expect/toBeFinite.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(1.5)->toBeFinite()
+        ->and(-10.2)->toBeFinite()
+        ->and(0)->toBeFinite()
+        ->and(42)->toBeFinite()
+        ->and(INF)->not->toBeFinite()
+        ->and(-INF)->not->toBeFinite()
+        ->and(NAN)->not->toBeFinite();
+});
+
+test('failures', function (): void {
+    expect(INF)->toBeFinite();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect(INF)->toBeFinite('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(42)->not->toBeFinite();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeNegative.php
+++ b/tests/Features/Expect/toBeNegative.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -18,6 +19,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect(0)->toBeNegative('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect('foo')->toBeNegative();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [int|float].');
 
 test('not failures', function (): void {
     expect(-10)->not->toBeNegative();

--- a/tests/Features/Expect/toBeNegative.php
+++ b/tests/Features/Expect/toBeNegative.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(-5)->toBeNegative()
+        ->and(-0.5)->toBeNegative()
+        ->and(0)->not->toBeNegative()
+        ->and(5)->not->toBeNegative();
+});
+
+test('failures', function (): void {
+    expect(0)->toBeNegative();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect(0)->toBeNegative('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(-10)->not->toBeNegative();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeOdd.php
+++ b/tests/Features/Expect/toBeOdd.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(1)->toBeOdd()
+        ->and(-7)->toBeOdd()
+        ->and(2)->not->toBeOdd()
+        ->and(0)->not->toBeOdd();
+});
+
+test('failures', function (): void {
+    expect(2)->toBeOdd();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect(2)->toBeOdd('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(7)->not->toBeOdd();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeOdd.php
+++ b/tests/Features/Expect/toBeOdd.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -18,6 +19,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect(2)->toBeOdd('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect([])->toBeOdd();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [int].');
 
 test('not failures', function (): void {
     expect(7)->not->toBeOdd();

--- a/tests/Features/Expect/toBePositive.php
+++ b/tests/Features/Expect/toBePositive.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -18,6 +19,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect(0)->toBePositive('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect('foo')->toBePositive();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [int|float].');
 
 test('not failures', function (): void {
     expect(10)->not->toBePositive();

--- a/tests/Features/Expect/toBePositive.php
+++ b/tests/Features/Expect/toBePositive.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect(5)->toBePositive()
+        ->and(0.5)->toBePositive()
+        ->and(0)->not->toBePositive()
+        ->and(-1)->not->toBePositive();
+});
+
+test('failures', function (): void {
+    expect(0)->toBePositive();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect(0)->toBePositive('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect(10)->not->toBePositive();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toContainIgnoringCase.php
+++ b/tests/Features/Expect/toContainIgnoringCase.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -14,6 +15,10 @@ test('pass', function (): void {
 test('failures', function (): void {
     expect('Hello World')->toContainIgnoringCase('Symfony');
 })->throws(ExpectationFailedException::class);
+
+test('failures with invalid type', function (): void {
+    expect([])->toContainIgnoringCase('world');
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
 
 test('failures with custom message', function (): void {
     expect('Hello World')->toContainIgnoringCase('Symfony', 'oh no!');

--- a/tests/Features/Expect/toContainIgnoringCase.php
+++ b/tests/Features/Expect/toContainIgnoringCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect('Hello World')->toContainIgnoringCase('world')
+        ->and('PestPHP')->toContainIgnoringCase('php')
+        ->and('PestPHP')->toContainIgnoringCase('PESTPHP')
+        ->and('Laravel')->not->toContainIgnoringCase('symfony');
+});
+
+test('failures', function (): void {
+    expect('Hello World')->toContainIgnoringCase('Symfony');
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect('Hello World')->toContainIgnoringCase('Symfony', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect('PestPHP')->not->toContainIgnoringCase('php');
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEndWithIgnoringCase.php
+++ b/tests/Features/Expect/toEndWithIgnoringCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect('Laravel')->toEndWithIgnoringCase('VEL')
+        ->and('PestPHP')->toEndWithIgnoringCase('php')
+        ->and('PestPHP')->toEndWithIgnoringCase('PestPHP')
+        ->and('Framework')->not->toEndWithIgnoringCase('frame');
+});
+
+test('failures', function (): void {
+    expect('Laravel')->toEndWithIgnoringCase('lar');
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect('Laravel')->toEndWithIgnoringCase('lar', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect('Laravel')->not->toEndWithIgnoringCase('VEL');
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toEndWithIgnoringCase.php
+++ b/tests/Features/Expect/toEndWithIgnoringCase.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -14,6 +15,10 @@ test('pass', function (): void {
 test('failures', function (): void {
     expect('Laravel')->toEndWithIgnoringCase('lar');
 })->throws(ExpectationFailedException::class);
+
+test('failures with invalid type', function (): void {
+    expect([])->toEndWithIgnoringCase('VEL');
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
 
 test('failures with custom message', function (): void {
     expect('Laravel')->toEndWithIgnoringCase('lar', 'oh no!');

--- a/tests/Features/Expect/toHaveDuplicates.php
+++ b/tests/Features/Expect/toHaveDuplicates.php
@@ -2,14 +2,17 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
     expect([1, 2, 2])->toHaveDuplicates()
         ->and(['a', 'b', 'a'])->toHaveDuplicates()
+        ->and([[1], [1]])->toHaveDuplicates()
         ->and([1, 2, 3])->not->toHaveDuplicates()
         ->and([])->not->toHaveDuplicates()
-        ->and([1])->not->toHaveDuplicates();
+        ->and([1])->not->toHaveDuplicates()
+        ->and([[1], [2]])->not->toHaveDuplicates();
 });
 
 test('failures', function (): void {
@@ -19,6 +22,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect([1, 2, 3])->toHaveDuplicates('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect('foo')->toHaveDuplicates();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [array].');
 
 test('not failures', function (): void {
     expect([1, 2, 2])->not->toHaveDuplicates();

--- a/tests/Features/Expect/toHaveDuplicates.php
+++ b/tests/Features/Expect/toHaveDuplicates.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect([1, 2, 2])->toHaveDuplicates()
+        ->and(['a', 'b', 'a'])->toHaveDuplicates()
+        ->and([1, 2, 3])->not->toHaveDuplicates()
+        ->and([])->not->toHaveDuplicates()
+        ->and([1])->not->toHaveDuplicates();
+});
+
+test('failures', function (): void {
+    expect([1, 2, 3])->toHaveDuplicates();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect([1, 2, 3])->toHaveDuplicates('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect([1, 2, 2])->not->toHaveDuplicates();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toHaveUniqueItems.php
+++ b/tests/Features/Expect/toHaveUniqueItems.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -9,8 +10,10 @@ test('pass', function (): void {
         ->and(['a', 'b', 'c'])->toHaveUniqueItems()
         ->and([])->toHaveUniqueItems()
         ->and([1])->toHaveUniqueItems()
+        ->and([[1], [2]])->toHaveUniqueItems()
         ->and([1, 2, 2])->not->toHaveUniqueItems()
-        ->and(['a', 'a'])->not->toHaveUniqueItems();
+        ->and(['a', 'a'])->not->toHaveUniqueItems()
+        ->and([[1], [1]])->not->toHaveUniqueItems();
 });
 
 test('failures', function (): void {
@@ -20,6 +23,10 @@ test('failures', function (): void {
 test('failures with custom message', function (): void {
     expect([1, 2, 2])->toHaveUniqueItems('oh no!');
 })->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with invalid type', function (): void {
+    expect('foo')->toHaveUniqueItems();
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [array].');
 
 test('not failures', function (): void {
     expect([1, 2, 3])->not->toHaveUniqueItems();

--- a/tests/Features/Expect/toHaveUniqueItems.php
+++ b/tests/Features/Expect/toHaveUniqueItems.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect([1, 2, 3])->toHaveUniqueItems()
+        ->and(['a', 'b', 'c'])->toHaveUniqueItems()
+        ->and([])->toHaveUniqueItems()
+        ->and([1])->toHaveUniqueItems()
+        ->and([1, 2, 2])->not->toHaveUniqueItems()
+        ->and(['a', 'a'])->not->toHaveUniqueItems();
+});
+
+test('failures', function (): void {
+    expect([1, 2, 2])->toHaveUniqueItems();
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect([1, 2, 2])->toHaveUniqueItems('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect([1, 2, 3])->not->toHaveUniqueItems();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toStartWithIgnoringCase.php
+++ b/tests/Features/Expect/toStartWithIgnoringCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function (): void {
+    expect('Laravel')->toStartWithIgnoringCase('lar')
+        ->and('PestPHP')->toStartWithIgnoringCase('PEST')
+        ->and('PestPHP')->toStartWithIgnoringCase('PestPHP')
+        ->and('Framework')->not->toStartWithIgnoringCase('work');
+});
+
+test('failures', function (): void {
+    expect('Laravel')->toStartWithIgnoringCase('vel');
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function (): void {
+    expect('Laravel')->toStartWithIgnoringCase('vel', 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function (): void {
+    expect('Laravel')->not->toStartWithIgnoringCase('lar');
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toStartWithIgnoringCase.php
+++ b/tests/Features/Expect/toStartWithIgnoringCase.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Exceptions\InvalidExpectationValue;
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function (): void {
@@ -14,6 +15,10 @@ test('pass', function (): void {
 test('failures', function (): void {
     expect('Laravel')->toStartWithIgnoringCase('vel');
 })->throws(ExpectationFailedException::class);
+
+test('failures with invalid type', function (): void {
+    expect([])->toStartWithIgnoringCase('lar');
+})->throws(InvalidExpectationValue::class, 'Invalid expectation value type. Expected [string].');
 
 test('failures with custom message', function (): void {
     expect('Laravel')->toStartWithIgnoringCase('vel', 'oh no!');


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

* [ ] Bug Fix
* [x] New Feature

### Description:

This PR introduces a set of new primitive expectations to Pest, focusing on commonly used numeric, string, and array assertions that are currently missing from the core API.

#### Numeric

* `toBePositive()`
* `toBeNegative()`
* `toBeEven()`
* `toBeOdd()`
* `toBeFinite()`

#### String

* `toBeBlank()`
* `toContainIgnoringCase()`
* `toStartWithIgnoringCase()`
* `toEndWithIgnoringCase()`

#### Array

* `toBeAssociative()`
* `toHaveUniqueItems()`
* `toHaveDuplicates()`

All expectations follow the existing Pest conventions, support negated expectations, include comprehensive test coverage, and are documented.

### Related:

N/A
