### PR TITLE
Fix repeat with named dataset arguments

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -408,15 +408,24 @@ trait Testable
     private function __resolveTestArguments(array $arguments): array
     {
         $method = TestSuite::getInstance()->tests->get(self::$__filename)->getMethod($this->name());
-
-        if ($method->repetitions > 1) {
-            $firstArgument = array_shift($arguments);
-            $arguments[] = $firstArgument;
-        }
-
         $underlyingTest = Reflection::getFunctionVariable($this->__test, 'closure');
         $testParameterTypesByName = Reflection::getFunctionArguments($underlyingTest);
         $testParameterTypes = array_values($testParameterTypesByName);
+
+        if ($method->repetitions > 1) {
+            $firstArgument = array_shift($arguments);
+
+            if (array_is_list($arguments)) {
+                $arguments[] = $firstArgument;
+            } else {
+                $testParameterNames = array_keys($testParameterTypesByName);
+                $iterationParameterName = $testParameterNames[count($arguments)] ?? null;
+
+                if ($iterationParameterName !== null) {
+                    $arguments[$iterationParameterName] = $firstArgument;
+                }
+            }
+        }
 
         if (count($arguments) !== 1) {
             foreach ($arguments as $argumentIndex => $argumentValue) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1455,6 +1455,14 @@
   ✓ multiple times with repeat iterator with multiple dataset ('c') / ('d') @ repetition 2 of 2
   ✓ multiple times with repeat iterator with multiple dataset ('c') / ('e') @ repetition 2 of 2
   ✓ multiple times with repeat iterator with multiple dataset ('c') / ('f') @ repetition 2 of 2
+  ✓ multiple times with named dataset arguments ('Taylor', 'taylor@laravel.com') @ repetition 1 of 2
+  ✓ multiple times with named dataset arguments ('Nuno', 'enunomaduro@gmail.com') @ repetition 1 of 2
+  ✓ multiple times with named dataset arguments ('Taylor', 'taylor@laravel.com') @ repetition 2 of 2
+  ✓ multiple times with named dataset arguments ('Nuno', 'enunomaduro@gmail.com') @ repetition 2 of 2
+  ✓ multiple times with named dataset arguments and repeat iterator ('Taylor', 'taylor@laravel.com') @ repetition 1 of 2
+  ✓ multiple times with named dataset arguments and repeat iterator ('Nuno', 'enunomaduro@gmail.com') @ repetition 1 of 2
+  ✓ multiple times with named dataset arguments and repeat iterator ('Taylor', 'taylor@laravel.com') @ repetition 2 of 2
+  ✓ multiple times with named dataset arguments and repeat iterator ('Nuno', 'enunomaduro@gmail.com') @ repetition 2 of 2
   ✓ describe blocks → multiple times @ repetition 1 of 3
   ✓ describe blocks → multiple times @ repetition 2 of 3
   ✓ describe blocks → multiple times @ repetition 3 of 3
@@ -2226,4 +2234,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1573 passed (3414 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1581 passed (3434 assertions)

--- a/tests/Features/Repeat.php
+++ b/tests/Features/Repeat.php
@@ -44,6 +44,28 @@ test('multiple times with repeat iterator with multiple dataset', function (stri
         ->toBeGreaterThan(0);
 })->repeat(times: 2)->with(['a', 'b', 'c'], ['d', 'e', 'f']);
 
+test('multiple times with named dataset arguments', function (string $name, string $email): void {
+    expect($name)
+        ->toBeIn(['Taylor', 'Nuno'])
+        ->and($email)
+        ->toContain('@');
+})->repeat(times: 2)->with([
+    ['name' => 'Taylor', 'email' => 'taylor@laravel.com'],
+    ['name' => 'Nuno', 'email' => 'enunomaduro@gmail.com'],
+]);
+
+test('multiple times with named dataset arguments and repeat iterator', function (string $name, string $email, int $iteration): void {
+    expect($name)
+        ->toBeIn(['Taylor', 'Nuno'])
+        ->and($email)
+        ->toContain('@')
+        ->and($iteration)
+        ->toBeIn([1, 2]);
+})->repeat(times: 2)->with([
+    ['name' => 'Taylor', 'email' => 'taylor@laravel.com'],
+    ['name' => 'Nuno', 'email' => 'enunomaduro@gmail.com'],
+]);
+
 describe('describe blocks', function (): void {
     test('multiple times', function (): void {
         expect(true)->toBeTrue();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1563 passed (3379 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1563 passed (3379 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`repeat()` prepends its iteration value to the data provider arguments and later moves it to the end before invoking the test. With named dataset arguments, appending that value as a positional argument causes PHP to throw `Cannot use positional argument after named argument`.

This keeps the existing positional behavior, maps the iteration value to the next test parameter when named arguments are used, and omits it when the test does not accept an iteration parameter. Regression coverage includes both named datasets with and without the repeat iterator.

The aggregate visual snapshots are updated for the eight additional repeated executions and twenty assertions.

### Related:

Fixes #1767

### Validation:

- `php bin/pest tests/Features/Repeat.php --compact` — 142 tests, 327 assertions
- `composer test:lint`
- `composer test:type:check`
- Type coverage — 100%

The full local matrix was also attempted. Its remaining failures are limited to the existing macOS-specific `Backtrace` expectation and platform-dependent visual aggregate counts; the focused behavior, lint, static analysis, and type coverage pass.
