### PR TITLE
fix: apply negated toUse to each target in a multi-element expect

### DIFF
--- a/src/Expectations/OppositeExpectation.php
+++ b/src/Expectations/OppositeExpectation.php
@@ -12,7 +12,6 @@ use Pest\Arch\Expectations\ToBeUsedInNothing;
 use Pest\Arch\Expectations\ToUse;
 use Pest\Arch\GroupArchExpectation;
 use Pest\Arch\PendingArchExpectation;
-use Pest\Arch\SingleArchExpectation;
 use Pest\Arch\Support\FileLineFinder;
 use Pest\Exceptions\InvalidExpectation;
 use Pest\Exceptions\MissingDependency;
@@ -79,9 +78,24 @@ final readonly class OppositeExpectation
         /** @var Expectation<array<int, string>|string> $original */
         $original = $this->original;
 
-        return GroupArchExpectation::fromExpectations($original, array_map(fn (string $target): SingleArchExpectation => ToUse::make($original, $target)->opposite(
-            fn () => $this->throwExpectationFailedException('toUse', $target),
-        ), is_string($targets) ? [$targets] : $targets));
+        $targets = is_string($targets) ? [$targets] : $targets;
+
+        $values = is_array($original->value) ? $original->value : [$original->value];
+
+        $expectations = [];
+
+        foreach ($values as $value) {
+            /** @var Expectation<array<int, string>|string> $expectation */
+            $expectation = new Expectation($value);
+
+            foreach ($targets as $target) {
+                $expectations[] = ToUse::make($expectation, $target)->opposite(
+                    fn () => $this->throwExpectationFailedException('toUse', $target),
+                );
+            }
+        }
+
+        return GroupArchExpectation::fromExpectations($original, $expectations);
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1146,6 +1146,12 @@
   ✓ it can handle a non-defined exception
   ✓ it can handle a class not found Error
 
+   PASS  Tests\Features\Expect\toUse
+  ✓ single target fails when it uses the dependency
+  ✓ multi target fails when any target uses the dependency
+  ✓ multi target fails regardless of the violating target position
+  ✓ multi target passes when no target uses the dependency
+
    PASS  Tests\Features\Expect\toUseStrictEquality
   ✓ missing strict equality
   ✓ has strict equality
@@ -2186,4 +2192,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1542 passed (3375 assertions)
+  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1546 passed (3387 assertions)

--- a/tests/Features/Expect/toUse.php
+++ b/tests/Features/Expect/toUse.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Fixtures\Arch\ToUse\CleanClass;
+use Tests\Fixtures\Arch\ToUse\Dependencies\Dependency;
+use Tests\Fixtures\Arch\ToUse\UsesDependency;
+
+test('single target fails when it uses the dependency', function (): void {
+    expect(UsesDependency::class)->not->toUse(Dependency::class);
+})->throws(ExpectationFailedException::class);
+
+test('multi target fails when any target uses the dependency', function (): void {
+    expect([UsesDependency::class, CleanClass::class])->not->toUse(Dependency::class);
+})->throws(ExpectationFailedException::class);
+
+test('multi target fails regardless of the violating target position', function (): void {
+    expect([CleanClass::class, UsesDependency::class])->not->toUse(Dependency::class);
+})->throws(ExpectationFailedException::class);
+
+test('multi target passes when no target uses the dependency', function (): void {
+    expect([CleanClass::class])->not->toUse(Dependency::class);
+});

--- a/tests/Fixtures/Arch/ToUse/CleanClass.php
+++ b/tests/Fixtures/Arch/ToUse/CleanClass.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUse;
+
+final class CleanClass {}

--- a/tests/Fixtures/Arch/ToUse/Dependencies/Dependency.php
+++ b/tests/Fixtures/Arch/ToUse/Dependencies/Dependency.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUse\Dependencies;
+
+final class Dependency {}

--- a/tests/Fixtures/Arch/ToUse/UsesDependency.php
+++ b/tests/Fixtures/Arch/ToUse/UsesDependency.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUse;
+
+use Tests\Fixtures\Arch\ToUse\Dependencies\Dependency;
+
+final class UsesDependency
+{
+    public function make(): Dependency
+    {
+        return new Dependency;
+    }
+}

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1525 passed (3322 assertions)';",
+            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1529 passed (3334 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1525 passed (3322 assertions)';
+    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1529 passed (3334 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A negated `toUse` on a multi-element `expect([...])` never failed. The positive check fails as soon as one target doesn't use the dependency, and the negation reads that failure as a pass, so a real violation by another target slips through. This decomposes the expect targets the way the dependencies already are, so each one is checked on its own.

### Related:

Fixes #1751
