### PR TITLE
[Rector] Skip RemoveDefaultValueFromAssignedPropertyRector for now

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
+use Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector;
@@ -56,6 +57,7 @@ return RectorConfig::configure()
         AddArrowFunctionReturnTypeRector::class => [
             __DIR__.'/tests',
         ],
+        RemoveDefaultValueFromAssignedPropertyRector::class,       
     ])
     ->withPreparedSets(
         deadCode: true,


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] QA

### Description:

`RemoveDefaultValueFromAssignedPropertyRector` is new rule and seems still buggy, the fix is on the way:

- https://github.com/rectorphp/rector-src/pull/8214

Here skip for now.

<!-- describe what your PR is solving -->

### Related:

To fix CI failure https://github.com/pestphp/pest/actions/runs/30383066819/job/90355447958#step:10:23

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
