### PR TITLE
Document the Tia options in pest --help

### DIFF
--- a/src/Plugins/Help.php
+++ b/src/Plugins/Help.php
@@ -114,6 +114,41 @@ final readonly class Help implements HandlesArguments
             ],
         ];
 
+        $content['Tia'] = [
+            [
+                'arg' => '--tia',
+                'desc' => 'Re-run only the tests affected by your changes, replaying the rest from cache',
+            ],
+            [
+                'arg' => '--no-tia',
+                'desc' => 'Disable test impact analysis for this run',
+            ],
+            [
+                'arg' => '--tia --fresh',
+                'desc' => 'Discard the recorded dependency graph and record it again',
+            ],
+            [
+                'arg' => '--tia --filtered',
+                'desc' => 'Narrow the run to the affected test files only',
+            ],
+            [
+                'arg' => '--tia --locally',
+                'desc' => 'Enable test impact analysis on local machines only',
+            ],
+            [
+                'arg' => '--tia --baselined',
+                'desc' => 'Fetch the shared dependency graph recorded by the CI baseline',
+            ],
+            [
+                'arg' => '--tia --refetch',
+                'desc' => 'Force a fresh fetch of the shared dependency graph',
+            ],
+            [
+                'arg' => '--baseline',
+                'desc' => 'Output to standard output the test impact analysis storage directory',
+            ],
+        ];
+
         $content['Execution'] = [...[
             [
                 'arg' => '--parallel',

--- a/tests/.pest/snapshots/Visual/Help/visual_snapshot_of_help_command_output.snap
+++ b/tests/.pest/snapshots/Visual/Help/visual_snapshot_of_help_command_output.snap
@@ -168,6 +168,16 @@
   AI OPTIONS:
   --ai ..... Run a code snippet as a fully scaffolded test for AI verification  
 
+  TIA OPTIONS:
+  --tia  Re-run only the tests affected by your changes, replaying the rest from cache  
+  --no-tia ......................... Disable test impact analysis for this run  
+  --tia --fresh .... Discard the recorded dependency graph and record it again  
+  --tia --filtered ............ Narrow the run to the affected test files only  
+  --tia --locally ......... Enable test impact analysis on local machines only  
+  --tia --baselined  Fetch the shared dependency graph recorded by the CI baseline  
+  --tia --refetch ......... Force a fresh fetch of the shared dependency graph  
+  --baseline  Output to standard output the test impact analysis storage directory  
+
   MUTATION TESTING OPTIONS:
   --mutate .... Runs mutation testing, to understand the quality of your tests  
   --mutate --parallel ...................... Runs mutation testing in parallel  


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`pest --help` documents `--update-shards`, `--ai` and the whole `--mutate` family, but says nothing about Tia. Someone who has not read the release post has no way to discover the flagship feature of Pest 5 from the CLI, and the modifier flags (`--fresh`, `--filtered`, `--baselined`, `--refetch`, `--locally`, `--baseline`) are effectively invisible.

This adds a `TIA OPTIONS` section to `Plugins/Help.php`, following the `--mutate` convention of listing the modifiers as `--tia --fresh` and friends. The descriptions come from the flag handling in `Plugins/Tia.php`, so they match what each option actually does. The section renders right after `AI OPTIONS`, keeping the two Pest 5 headline features together.

```
  TIA OPTIONS:
  --tia  Re-run only the tests affected by your changes, replaying the rest from cache
  --no-tia ......................... Disable test impact analysis for this run
  --tia --fresh .... Discard the recorded dependency graph and record it again
  --tia --filtered ............ Narrow the run to the affected test files only
  --tia --locally ......... Enable test impact analysis on local machines only
  --tia --baselined  Fetch the shared dependency graph recorded by the CI baseline
  --tia --refetch ......... Force a fresh fetch of the shared dependency graph
  --baseline  Output to standard output the test impact analysis storage directory
```

The visual help snapshot is updated accordingly, and `composer lint` is clean.