### PR TITLE
fix(overrides): updates test suite sorter for phpunit 13 orders

### DIFF
--- a/overrides/Runner/TestSuiteSorter.php
+++ b/overrides/Runner/TestSuiteSorter.php
@@ -78,9 +78,13 @@ final class TestSuiteSorter
 
     public const int ORDER_DEFECTS_FIRST = 3;
 
-    public const int ORDER_DURATION = 4;
+    public const int ORDER_DURATION_ASCENDING = 4;
 
-    public const int ORDER_SIZE = 5;
+    public const int ORDER_SIZE_ASCENDING = 5;
+
+    public const int ORDER_DURATION_DESCENDING = 6;
+
+    public const int ORDER_SIZE_DESCENDING = 7;
 
     /**
      * @var non-empty-array<non-empty-string, positive-int>
@@ -113,8 +117,10 @@ final class TestSuiteSorter
             self::ORDER_DEFAULT,
             self::ORDER_REVERSED,
             self::ORDER_RANDOMIZED,
-            self::ORDER_DURATION,
-            self::ORDER_SIZE,
+            self::ORDER_DURATION_ASCENDING,
+            self::ORDER_SIZE_ASCENDING,
+            self::ORDER_DURATION_DESCENDING,
+            self::ORDER_SIZE_DESCENDING,
         ];
 
         if (! in_array($order, $allowedOrders, true)) {
@@ -157,10 +163,14 @@ final class TestSuiteSorter
             $suite->setTests($this->reverse($suite->tests()));
         } elseif ($order === self::ORDER_RANDOMIZED) {
             $suite->setTests($this->randomize($suite->tests()));
-        } elseif ($order === self::ORDER_DURATION) {
+        } elseif ($order === self::ORDER_DURATION_ASCENDING) {
             $suite->setTests($this->sortByDuration($suite->tests()));
-        } elseif ($order === self::ORDER_SIZE) {
+        } elseif ($order === self::ORDER_DURATION_DESCENDING) {
+            $suite->setTests($this->sortByDurationDescending($suite->tests()));
+        } elseif ($order === self::ORDER_SIZE_ASCENDING) {
             $suite->setTests($this->sortBySize($suite->tests()));
+        } elseif ($order === self::ORDER_SIZE_DESCENDING) {
+            $suite->setTests($this->sortBySizeDescending($suite->tests()));
         }
 
         if ($orderDefects === self::ORDER_DEFECTS_FIRST) {
@@ -246,11 +256,39 @@ final class TestSuiteSorter
      * @param  list<Test>  $tests
      * @return list<Test>
      */
+    private function sortByDurationDescending(array $tests): array
+    {
+        usort(
+            $tests,
+            fn (Test $left, Test $right) => $this->cmpDuration($right, $left),
+        );
+
+        return $tests;
+    }
+
+    /**
+     * @param  list<Test>  $tests
+     * @return list<Test>
+     */
     private function sortBySize(array $tests): array
     {
         usort(
             $tests,
             fn (Test $left, Test $right) => $this->cmpSize($left, $right),
+        );
+
+        return $tests;
+    }
+
+    /**
+     * @param  list<Test>  $tests
+     * @return list<Test>
+     */
+    private function sortBySizeDescending(array $tests): array
+    {
+        usort(
+            $tests,
+            fn (Test $left, Test $right) => $this->cmpSize($right, $left),
         );
 
         return $tests;

--- a/tests/Features/OrderBy.php
+++ b/tests/Features/OrderBy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+it('runs with every supported order', function (string $order): void {
+    $process = new Process(
+        ['php', 'bin/pest', 'tests/Fixtures/DirectoryWithTests/ExampleTest.php', '--order-by='.$order],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true', 'PAO_DISABLE' => '1'],
+    );
+
+    $process->run();
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(removeAnsiEscapeSequences($process->getOutput()))->toContain('1 passed');
+})->with([
+    'default',
+    'defects',
+    'duration',
+    'duration-ascending',
+    'duration-descending',
+    'random',
+    'reverse',
+    'size',
+    'size-ascending',
+    'size-descending',
+]);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

On Pest 5, four `--order-by` values crash at CLI-parse time, before a single test runs:

```
$ vendor/bin/pest --order-by=duration
Undefined constant PHPUnit\Runner\TestSuiteSorter::ORDER_DURATION_ASCENDING
at vendor/phpunit/phpunit/src/TextUI/Configuration/Cli/Builder.php:768
```

Same failure for `duration-ascending`, `duration-descending`, and `size-descending`.
Reproduced on Pest 5.0.1, PHPUnit 13.2.4, PHP 8.4.23.

The cause is `overrides/Runner/TestSuiteSorter.php`, which `BootOverrides` loads in place
of PHPUnit's class. It still declares the PHPUnit 12 constants:

```php
public const int ORDER_DURATION = 4;
public const int ORDER_SIZE     = 5;
```

PHPUnit 13 renamed both and added descending variants (`src/Runner/TestSuiteSorter.php:38-45`):

```php
public const int ORDER_DURATION_ASCENDING  = 4;
public const int ORDER_SIZE_ASCENDING      = 5;
public const int ORDER_DURATION_DESCENDING = 6;
public const int ORDER_SIZE_DESCENDING     = 7;
```

`Builder.php` resolves the new names, the override does not define them, and PHP fails
on the constant lookup. Worth noting that the `duration` arm is also where PHPUnit emits
its "use `duration-ascending` instead" deprecation, so users never see that notice either.

`--order-by=size` happens to still work because `ORDER_SIZE` and `ORDER_SIZE_ASCENDING`
are both `5`, but it resolves through a constant the override defines under the old name,
which is luck rather than correctness.

This PR updates the override to declare PHPUnit 13's four constants and extends the
`$order` comparisons in `reorderTestsInSuite()` so ascending and descending are handled
separately for both duration and size, matching PHPUnit 13's implementation. The old
`ORDER_DURATION` and `ORDER_SIZE` names are dropped rather than aliased, since keeping
them would let the override drift from PHPUnit again.

Anyone upgrading from Pest 4 with `--order-by=duration` in their config, which is common
for parallel suites, currently gets a hard crash that points into PHPUnit instead of Pest.