### PR TITLE
fix: stale cached coverage of changed files survives the Tia coverage merge as phantom uncovered lines

### DIFF
--- a/src/Plugins/Tia.php
+++ b/src/Plugins/Tia.php
@@ -78,6 +78,8 @@ final class Tia implements AddsOutput, HandlesArguments, Terminable
 
     public const string KEY_COVERAGE_MARKER = 'coverage.marker';
 
+    public const string KEY_COVERAGE_CHANGED = 'coverage.changed.json';
+
     public const string KEY_FETCH_COOLDOWN = 'fetch-cooldown.json';
 
     private const string RECORDING_GLOBAL = 'TIA_RECORDING';
@@ -675,6 +677,7 @@ final class Tia implements AddsOutput, HandlesArguments, Terminable
 
         if ($this->piggybackCoverage) {
             $this->state->write(self::KEY_COVERAGE_MARKER, '');
+            $this->state->delete(self::KEY_COVERAGE_CHANGED);
         }
 
         if ($this->piggybackCoverage && ! $this->state->exists(self::KEY_COVERAGE_CACHE)) {
@@ -821,6 +824,13 @@ final class Tia implements AddsOutput, HandlesArguments, Terminable
             $changed,
             $graph->lastRunTree($this->branch),
         );
+
+        if ($this->piggybackCoverage && $changed !== []) {
+            $this->state->write(self::KEY_COVERAGE_CHANGED, (string) json_encode(array_map(
+                fn (string $file): string => $projectRoot.DIRECTORY_SEPARATOR.$file,
+                $changed,
+            )));
+        }
 
         $hasProjectPhpSourceChanges = $this->hasProjectPhpSourceChanges($changed);
         $coverageAvailable = $this->piggybackCoverage || $this->recorder->driverAvailable();

--- a/src/Plugins/Tia/CoverageMerger.php
+++ b/src/Plugins/Tia/CoverageMerger.php
@@ -28,6 +28,8 @@ final class CoverageMerger
 
         $state->delete(Tia::KEY_COVERAGE_MARKER);
 
+        $changedFiles = self::consumeChangedFiles($state);
+
         $cachedBytes = $state->read(Tia::KEY_COVERAGE_CACHE);
 
         if ($cachedBytes === null) {
@@ -59,6 +61,7 @@ final class CoverageMerger
         self::primeUncoveredFiles($cached);
         self::primeUncoveredFiles($current);
 
+        self::dropChangedFilesFromCached($cached, $changedFiles);
         self::stripCurrentTestsFromCached($cached, $current);
 
         $cached->merge($current);
@@ -89,6 +92,56 @@ final class CoverageMerger
         $decoded = @gzdecode($bytes);
 
         return $decoded === false ? null : $decoded;
+    }
+
+    /**
+     * Cached coverage of a changed file was measured against old file contents,
+     * so its line numbers no longer match the source on disk. Every test that
+     * covered the file is part of the affected set and has just been re-run,
+     * meaning the current report already carries the file's entire coverage —
+     * anything cached for it is stale and must not survive the merge.
+     *
+     * @param  array<int, string>  $changedFiles
+     */
+    private static function dropChangedFilesFromCached(CodeCoverage $cached, array $changedFiles): void
+    {
+        if ($changedFiles === []) {
+            return;
+        }
+
+        $data = $cached->getData();
+
+        $lineCoverage = $data->lineCoverage();
+        $functionCoverage = $data->functionCoverage();
+
+        foreach ($changedFiles as $file) {
+            unset($lineCoverage[$file], $functionCoverage[$file]);
+        }
+
+        $data->setLineCoverage($lineCoverage);
+        $data->setFunctionCoverage($functionCoverage);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function consumeChangedFiles(State $state): array
+    {
+        $encoded = $state->read(Tia::KEY_COVERAGE_CHANGED);
+
+        if ($encoded === null) {
+            return [];
+        }
+
+        $state->delete(Tia::KEY_COVERAGE_CHANGED);
+
+        $decoded = json_decode($encoded, true);
+
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter($decoded, is_string(...)));
     }
 
     private static function stripCurrentTestsFromCached(CodeCoverage $cached, CodeCoverage $current): void

--- a/tests/Unit/Plugins/Tia/CoverageMerger.php
+++ b/tests/Unit/Plugins/Tia/CoverageMerger.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia;
+use Pest\Plugins\Tia\Contracts\State;
+use Pest\Plugins\Tia\CoverageMerger;
+use Pest\Plugins\Tia\FileState;
+use Pest\Support\Container;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
+use SebastianBergmann\CodeCoverage\Data\ProcessedFunctionCoverageData;
+use SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData;
+use SebastianBergmann\CodeCoverage\Driver\Driver;
+use SebastianBergmann\CodeCoverage\Filter;
+
+beforeEach(function (): void {
+    $this->root = sys_get_temp_dir().'/pest-tia-coverage-merger-'.bin2hex(random_bytes(4));
+    mkdir($this->root, 0755, true);
+
+    $this->state = new FileState($this->root);
+
+    Container::getInstance()->add(State::class, $this->state);
+});
+
+afterEach(function (): void {
+    foreach (glob($this->root.'/*') ?: [] as $file) {
+        @unlink($file);
+    }
+
+    @rmdir($this->root);
+});
+
+/**
+ * @param  array<string, array<int, null|list<string>>>  $lineCoverage
+ * @param  array<string, array<string, ProcessedFunctionCoverageData>>  $functionCoverage
+ * @param  array<string, array{size: string, status: string}>  $tests
+ */
+function tiaMergerCoverage(array $lineCoverage, array $functionCoverage, array $tests): CodeCoverage
+{
+    $coverage = new CodeCoverage(new TiaMergerStubDriver, new Filter);
+
+    $data = new ProcessedCodeCoverageData;
+    $data->setLineCoverage($lineCoverage);
+    $data->setFunctionCoverage($functionCoverage);
+
+    $coverage->setData($data);
+    $coverage->setTests($tests);
+
+    return $coverage;
+}
+
+function tiaMergerWriteReport(string $reportPath, CodeCoverage $coverage): void
+{
+    file_put_contents(
+        $reportPath,
+        '<?php return unserialize('.var_export(serialize($coverage), true).");\n",
+    );
+}
+
+describe('applyIfMarked()', function (): void {
+    it('drops cached coverage of changed files so stale line numbers do not survive the merge', function (): void {
+        $changedFile = '/project/src/Changed.php';
+        $stableFile = '/project/src/Stable.php';
+
+        $rerunTest = 'tests/Unit/ChangedTest.php::it covers changed code';
+        $untouchedTest = 'tests/Unit/StableTest.php::it covers stable code';
+
+        $tests = [
+            $rerunTest => ['size' => 'unknown', 'status' => 'success'],
+            $untouchedTest => ['size' => 'unknown', 'status' => 'success'],
+        ];
+
+        // The baseline measured Changed.php before its lines shifted.
+        $cached = tiaMergerCoverage([
+            $changedFile => [10 => [$rerunTest], 12 => [$rerunTest], 14 => null],
+            $stableFile => [20 => [$rerunTest, $untouchedTest], 22 => [$untouchedTest]],
+        ], [
+            $changedFile => ['oldFunction' => new ProcessedFunctionCoverageData([], [])],
+            $stableFile => ['stableFunction' => new ProcessedFunctionCoverageData([], [])],
+        ], $tests);
+
+        // Changed.php shifted by one line, so the rerun test now covers 11/13.
+        $current = tiaMergerCoverage([
+            $changedFile => [11 => [$rerunTest], 13 => [$rerunTest], 15 => null],
+            $stableFile => [20 => [$rerunTest]],
+        ], [
+            $changedFile => ['newFunction' => new ProcessedFunctionCoverageData([], [])],
+        ], [$rerunTest => $tests[$rerunTest]]);
+
+        $this->state->write(Tia::KEY_COVERAGE_CACHE, gzencode(serialize($cached)));
+        $this->state->write(Tia::KEY_COVERAGE_MARKER, '');
+        $this->state->write(Tia::KEY_COVERAGE_CHANGED, json_encode([$changedFile]));
+
+        $reportPath = $this->root.'/report.php';
+        tiaMergerWriteReport($reportPath, $current);
+
+        CoverageMerger::applyIfMarked($reportPath);
+
+        $merged = require $reportPath;
+        assert($merged instanceof CodeCoverage);
+
+        $lineCoverage = $merged->getData()->lineCoverage();
+
+        expect($lineCoverage[$changedFile])->toBe([11 => [$rerunTest], 13 => [$rerunTest], 15 => null])
+            ->and($lineCoverage[$stableFile][20])->toBe([$untouchedTest, $rerunTest])
+            ->and($lineCoverage[$stableFile][22])->toBe([$untouchedTest]);
+
+        $functionCoverage = $merged->getData()->functionCoverage();
+
+        expect(array_keys($functionCoverage[$changedFile]))->toBe(['newFunction'])
+            ->and(array_keys($functionCoverage[$stableFile]))->toBe(['stableFunction'])
+            ->and($this->state->exists(Tia::KEY_COVERAGE_CHANGED))->toBeFalse();
+
+        $updatedCache = unserialize(gzdecode($this->state->read(Tia::KEY_COVERAGE_CACHE)));
+        assert($updatedCache instanceof CodeCoverage);
+
+        expect($updatedCache->getData()->lineCoverage()[$changedFile])
+            ->toBe([11 => [$rerunTest], 13 => [$rerunTest], 15 => null]);
+    });
+
+    it('re-attributes rerun tests on unchanged files during the merge', function (): void {
+        $file = '/project/src/Example.php';
+
+        $rerunTest = 'tests/Unit/ExampleTest.php::it runs again';
+        $untouchedTest = 'tests/Unit/OtherTest.php::it stays cached';
+
+        $cached = tiaMergerCoverage([
+            $file => [10 => [$rerunTest, $untouchedTest], 12 => [$rerunTest]],
+        ], [], [
+            $rerunTest => ['size' => 'unknown', 'status' => 'success'],
+            $untouchedTest => ['size' => 'unknown', 'status' => 'success'],
+        ]);
+
+        $current = tiaMergerCoverage([
+            $file => [10 => [$rerunTest], 12 => []],
+        ], [], [
+            $rerunTest => ['size' => 'unknown', 'status' => 'success'],
+        ]);
+
+        $this->state->write(Tia::KEY_COVERAGE_CACHE, gzencode(serialize($cached)));
+        $this->state->write(Tia::KEY_COVERAGE_MARKER, '');
+
+        $reportPath = $this->root.'/report.php';
+        tiaMergerWriteReport($reportPath, $current);
+
+        CoverageMerger::applyIfMarked($reportPath);
+
+        $merged = require $reportPath;
+        assert($merged instanceof CodeCoverage);
+
+        $lineCoverage = $merged->getData()->lineCoverage();
+
+        expect($lineCoverage[$file][10])->toBe([$untouchedTest, $rerunTest])
+            ->and($lineCoverage[$file][12])->toBe([]);
+    });
+
+    it('stores the current run as the baseline and clears the changed list when no cache exists', function (): void {
+        $file = '/project/src/Example.php';
+        $test = 'tests/Unit/ExampleTest.php::it runs';
+
+        $current = tiaMergerCoverage([
+            $file => [10 => [$test]],
+        ], [], [
+            $test => ['size' => 'unknown', 'status' => 'success'],
+        ]);
+
+        $this->state->write(Tia::KEY_COVERAGE_MARKER, '');
+        $this->state->write(Tia::KEY_COVERAGE_CHANGED, json_encode([$file]));
+
+        $reportPath = $this->root.'/report.php';
+        tiaMergerWriteReport($reportPath, $current);
+
+        CoverageMerger::applyIfMarked($reportPath);
+
+        expect($this->state->exists(Tia::KEY_COVERAGE_CHANGED))->toBeFalse();
+
+        $cache = unserialize(gzdecode($this->state->read(Tia::KEY_COVERAGE_CACHE)));
+        assert($cache instanceof CodeCoverage);
+
+        expect($cache->getData()->lineCoverage()[$file])->toBe([10 => [$test]]);
+    });
+});
+
+final class TiaMergerStubDriver extends Driver
+{
+    public function name(): string
+    {
+        return 'stub';
+    }
+
+    public function version(): string
+    {
+        return '0.0.0';
+    }
+
+    public function start(): void
+    {
+        // no-op
+    }
+
+    public function stop(): RawCodeCoverageData
+    {
+        return RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
+    }
+}


### PR DESCRIPTION
## The bug

When Tia piggybacks coverage (`--tia --coverage`), the merged report contains phantom "executable but uncovered" lines for every changed file, at the file's **old** line numbers, alongside the live data at the new line numbers. Coverage for changed files is deflated on every filtered run, and lines that are now comments/blank can show up as uncovered executable lines.

## Root cause

Two behaviours compose into the bug:

1. `CoverageMerger::stripCurrentTestsFromCached()` removes the re-run test IDs from the cached baseline's line entries, but keeps the line keys — an entry like `[42 => ['testA']]` becomes `[42 => []]`, which in `ProcessedCodeCoverageData` semantics means *executable but uncovered*.
2. `ProcessedCodeCoverageData::merge()` (phpunit/php-code-coverage) never removes lines that exist only in the destination side — any line missing from `$newData` is skipped via `continue`.

For a changed file, every test that covered it is in the affected set and has just been re-run, so the live report already carries the file's **entire** coverage at the new line numbers. The cached entries at the old line numbers are pure staleness — but nothing invalidates them, so the stripped-to-empty entries survive the merge as phantom uncovered lines. Cached `functionCoverage` of changed files (e.g. renamed functions) survives the same way, and so does the data of deleted files.

## The fix

Invalidate the cached data of changed files before merging:

- `Tia::enterReplayMode()` persists the changed-files list (the same one fed to `Graph::affected()`, as absolute paths) under a new state key, `coverage.changed.json`. The key is cleared alongside the marker write in `handleParent()` so a list from an aborted run can never leak into a later one.
- `CoverageMerger::applyIfMarked()` consumes that key and drops those files from the cached baseline's line and function coverage before the strip + merge. Since the affected set re-runs every test that covered a changed file, the live report fully re-measures it — the merge then simply copies the live data over.

Unchanged files keep the existing behaviour: rerun test IDs are stripped from their cached entries and re-attributed from the live data, while tests outside the affected set keep their cached attribution.

## Tests

`tests/Unit/Plugins/Tia/CoverageMerger.php` (new):

- a changed file with shifted line numbers ends up with only the live data — no phantom entries at the old line numbers, in the report, the updated cache, or `functionCoverage` (fails on 5.x with `10 => [], 12 => []` surviving the merge);
- rerun tests are still re-attributed on unchanged files, and non-rerun tests keep their cached attribution;
- with no cache yet, the current run becomes the baseline and the changed list is consumed.
