### PR TITLE
fix: key Tia results per dataset row

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -280,7 +280,7 @@ trait Testable
 
         /** @var Tia $tia */
         $tia = Container::getInstance()->get(Tia::class);
-        $status = $tia->getStatus(self::$__filename, $this::class.'::'.$this->name());
+        $status = $tia->getStatus(self::$__filename, $this->valueObjectForEvents()->id());
         $replay = ReplayType::fromStatus($status);
 
         if ($replay !== ReplayType::None) {
@@ -319,7 +319,7 @@ trait Testable
     private function __beginReplay(ReplayType $replay, Tia $tia): void
     {
         $this->__replay = $replay;
-        $this->__replayAssertions = $tia->getAssertionCount($this::class.'::'.$this->name());
+        $this->__replayAssertions = $tia->getAssertionCount($this->valueObjectForEvents()->id());
         $this->__ran = true;
     }
 

--- a/src/Subscribers/EnsureTiaAssertionsAreRecordedOnFinished.php
+++ b/src/Subscribers/EnsureTiaAssertionsAreRecordedOnFinished.php
@@ -22,7 +22,7 @@ final readonly class EnsureTiaAssertionsAreRecordedOnFinished implements Finishe
 
         if ($test instanceof TestMethod) {
             $this->collector->recordAssertions(
-                $test->className().'::'.$test->methodName(),
+                $test->id(),
                 $event->numberOfAssertionsPerformed(),
             );
         }

--- a/src/Subscribers/EnsureTiaResultsAreCollected.php
+++ b/src/Subscribers/EnsureTiaResultsAreCollected.php
@@ -21,7 +21,7 @@ final readonly class EnsureTiaResultsAreCollected implements PreparationStartedS
         $test = $event->test();
 
         if ($test instanceof TestMethod) {
-            $this->collector->testPrepared($test->className().'::'.$test->methodName(), $test->file());
+            $this->collector->testPrepared($test->id(), $test->file());
         }
     }
 }

--- a/tests/Unit/Plugins/Tia/ResultKey.php
+++ b/tests/Unit/Plugins/Tia/ResultKey.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\ResultCollector;
+use Pest\Subscribers\EnsureTiaAssertionsAreRecordedOnFinished;
+use Pest\Subscribers\EnsureTiaResultsAreCollected;
+use PHPUnit\Event\Code\TestDox;
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Telemetry\Duration;
+use PHPUnit\Event\Telemetry\Info;
+use PHPUnit\Event\Telemetry\MemoryUsage;
+use PHPUnit\Event\Telemetry\System;
+use PHPUnit\Event\Telemetry\SystemCpuTimeMeter;
+use PHPUnit\Event\Telemetry\SystemGarbageCollectorStatusProvider;
+use PHPUnit\Event\Telemetry\SystemMemoryMeter;
+use PHPUnit\Event\Telemetry\SystemStopWatch;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\TestData\DataFromDataProvider;
+use PHPUnit\Event\TestData\TestDataCollection;
+use PHPUnit\Metadata\MetadataCollection;
+
+function tiaResultKeyTestMethod(?string $dataSetName): TestMethod
+{
+    $testData = $dataSetName === null
+        ? TestDataCollection::fromArray([])
+        : TestDataCollection::fromArray([DataFromDataProvider::from($dataSetName, '', '')]);
+
+    return new TestMethod(
+        'Tests\Feature\OrderTest',
+        'it prices an order',
+        '/project/tests/Feature/OrderTest.php',
+        1,
+        new TestDox('Order', 'it prices an order', 'it prices an order'),
+        MetadataCollection::fromArray([]),
+        $testData,
+    );
+}
+
+function tiaResultKeyTelemetryInfo(): Info
+{
+    $system = new System(
+        new SystemStopWatch,
+        new SystemMemoryMeter,
+        new SystemGarbageCollectorStatusProvider,
+        new SystemCpuTimeMeter,
+    );
+
+    $zeroDuration = Duration::fromSecondsAndNanoseconds(0, 0);
+    $zeroMemory = MemoryUsage::fromBytes(0);
+    $zeroCpuTime = $system->snapshot()->userCpuTime();
+
+    return new Info(
+        $system->snapshot(),
+        $zeroDuration,
+        $zeroMemory,
+        $zeroDuration,
+        $zeroMemory,
+        $zeroCpuTime,
+        $zeroCpuTime,
+        $zeroCpuTime,
+        $zeroCpuTime,
+        $zeroCpuTime,
+        $zeroCpuTime,
+    );
+}
+
+it('keys a result per dataset row rather than per method', function (): void {
+    $collector = new ResultCollector;
+    $subscriber = new EnsureTiaResultsAreCollected($collector);
+
+    $subscriber->notify(new PreparationStarted(tiaResultKeyTelemetryInfo(), tiaResultKeyTestMethod('opp')));
+    $collector->testPassed();
+    $collector->finishTest();
+
+    $subscriber->notify(new PreparationStarted(tiaResultKeyTelemetryInfo(), tiaResultKeyTestMethod('fake')));
+    $collector->testSkipped('the fake driver does not report balances');
+    $collector->finishTest();
+
+    // Without the dataset in the key both rows write to `Class::method`, so the
+    // second one overwrites the first and a replay hands every row the same
+    // status — a passing row reported as skipped, or a failing one as passed.
+    expect(array_keys($collector->all()))->toBe([
+        'Tests\Feature\OrderTest::it prices an order#opp',
+        'Tests\Feature\OrderTest::it prices an order#fake',
+    ]);
+});
+
+it('records assertions against the same per-dataset key', function (): void {
+    $collector = new ResultCollector;
+
+    (new EnsureTiaResultsAreCollected($collector))->notify(
+        new PreparationStarted(tiaResultKeyTelemetryInfo(), tiaResultKeyTestMethod('opp')),
+    );
+    $collector->testPassed();
+
+    (new EnsureTiaAssertionsAreRecordedOnFinished($collector))->notify(
+        new Finished(tiaResultKeyTelemetryInfo(), tiaResultKeyTestMethod('opp'), 7),
+    );
+
+    expect($collector->all()['Tests\Feature\OrderTest::it prices an order#opp']['assertions'])->toBe(7);
+});
+
+it('leaves a test without a dataset keyed by class and method', function (): void {
+    $collector = new ResultCollector;
+
+    (new EnsureTiaResultsAreCollected($collector))->notify(
+        new PreparationStarted(tiaResultKeyTelemetryInfo(), tiaResultKeyTestMethod(null)),
+    );
+    $collector->testPassed();
+
+    expect(array_keys($collector->all()))->toBe(['Tests\Feature\OrderTest::it prices an order']);
+});


### PR DESCRIPTION
Hi @nunomaduro!

I watched Laracon US and I've been putting TIA to work immediately on a fairly large Laravel suite, but I noticed the replay didn't really agree with the run that recorded it:

```
# recording
Tests: 4 skipped, 2371 passed

# replay, nothing changed in between
Tests: 6 skipped, 2369 passed
```

Two tests that had passed came back as skipped. A plain `--no-tia` run agrees with the recording, so the replay was the odd one out.

The cause is that the result cache is keyed on `Class::method` and never sees the dataset. It happens in three spots:

* `EnsureTiaResultsAreCollected` writes `$test->className().'::'.$test->methodName()`
* `EnsureTiaAssertionsAreRecordedOnFinished` builds the same string
* `Testable` reads it back as `$this::class.'::'.$this->name()`, and `TestCase::name()` gives you the bare method name

So every row of a `->with()` test writes into the same entry and the last one to finish wins. On replay that one status gets handed to all the rows without running any of them. In my case three tests call `markTestSkipped()` for one harness only, so the skip got reported for the sibling row too, which is where the extra two came from.

The counts are the harmless half of it. `Graph::shouldRerunStatus()` re-runs a cached failure, so red in the cache is fine, but a cached pass gets replayed onto its siblings, and a row that would have failed never runs. I haven't hit that in practice, since a change that breaks a row usually marks the file affected anyway, but it seemed worth mentioning.

The fix is small: `TestMethod::id()` already appends `#dataSetName` when the test comes from a data provider, and `TestCase::valueObjectForEvents()` hands you the same value object, so both sides can just use that. Tests without a dataset keep the key they have today.

Afterwards the replay lines up:

```
# recording
Tests: 4 skipped, 2371 passed

# replay
Tests: 4 skipped, 2371 passed
```

A few notes:

* Baselines recorded before this use the old keys, so they won't match and get re-recorded. The graph already handles that.
* The new test covers all three call sites. The first two fail on `5.x` (the first one prints the two rows collapsing into a single key), the third pins that a test without a dataset is untouched.
* `composer test:unit` has one failure on `Tests\Unit\Support\Backtrace`, but it fails on a clean `5.x` here too, so it isn't from this change.

Happy to adjust anything, and thanks for the TIA-feature, the speedup is awesome!
