### PR TITLE
Handle reserved keywords in test file names

### DIFF
--- a/src/Factories/TestCaseFactory.php
+++ b/src/Factories/TestCaseFactory.php
@@ -136,7 +136,9 @@ final class TestCaseFactory
         $namespace = $this->namespace ?? implode('\\', $partsFQN);
         $baseClass = sprintf('\%s', $this->class);
 
-        if (trim($className) === '') {
+        $classNameToken = token_get_all('<?php '.$className)[1] ?? null;
+
+        if (trim($className) === '' || ! is_array($classNameToken) || $classNameToken[0] !== T_STRING) {
             $className = 'InvalidTestName'.Str::random();
         }
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A test file whose name resolves to a PHP reserved keyword, such as `list.test.php`, made Pest generate `final class list` and abort the run with a `ParseError`. The class name now falls back to the existing `InvalidTestName` placeholder when it is not a valid identifier, so these files run like any other. The printable name still comes from the file path, so the reported output is unchanged.

### Related:

Closes #1803
