### PR TITLE
fix: skip user hooks when replaying cached skipped, incomplete, and failed tests

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -286,8 +286,10 @@ trait Testable
         if ($replay !== ReplayType::None) {
             assert($status !== null);
 
+            $this->__beginReplay($replay, $tia);
+
             match ($replay) {
-                ReplayType::Pass, ReplayType::Risky => $this->__beginReplay($replay, $tia),
+                ReplayType::Pass, ReplayType::Risky => null,
                 ReplayType::Skipped => $this->markTestSkipped($status->message()),
                 ReplayType::Incomplete => $this->markTestIncomplete($status->message()),
                 ReplayType::Failure => throw new AssertionFailedError($status->message() ?: 'Cached failure'),

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1565,6 +1565,9 @@
   ✓ it allows performing no expectations without being risky
   ✓ a "describe" group of tests → it allows performing no expectations without being risky
 
+   PASS  Tests\Features\TiaReplay
+  ✓ replaying cached skipped and incomplete results does not run user hooks
+
    PASS  Tests\Features\Ticket
   ✓ it may be associated with an ticket #1, #2
   ✓ nested → it may be associated with an ticket #1, #4, #5, #6, #3
@@ -2186,4 +2189,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1542 passed (3375 assertions)
+  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1543 passed (3385 assertions)

--- a/tests/.tests/TiaReplayHooks.php
+++ b/tests/.tests/TiaReplayHooks.php
@@ -1,0 +1,32 @@
+<?php
+
+function tiaReplayHooksLog(string $hook): void
+{
+    $log = getenv('TIA_REPLAY_HOOKS_LOG');
+
+    if (is_string($log) && $log !== '') {
+        file_put_contents($log, $hook.PHP_EOL, FILE_APPEND);
+    }
+}
+
+beforeEach(function (): void {
+    tiaReplayHooksLog('beforeEach');
+});
+
+afterEach(function (): void {
+    tiaReplayHooksLog('afterEach');
+
+    throw new RuntimeException('The afterEach hook must not run for replayed tests.');
+});
+
+test('replayed pass', function (): void {
+    expect(true)->toBeTrue();
+});
+
+test('replayed skip', function (): void {
+    expect(true)->toBeTrue();
+});
+
+test('replayed incomplete', function (): void {
+    expect(true)->toBeTrue();
+});

--- a/tests/Features/TiaReplay.php
+++ b/tests/Features/TiaReplay.php
@@ -1,0 +1,92 @@
+<?php
+
+use Pest\Plugins\Tia;
+use Pest\Plugins\Tia\ChangedFiles;
+use Pest\Plugins\Tia\FileState;
+use Pest\Plugins\Tia\Fingerprint;
+use Pest\Plugins\Tia\Graph;
+use Pest\Plugins\Tia\Storage;
+use Pest\Support\Str;
+use Symfony\Component\Process\Process;
+
+test('replaying cached skipped and incomplete results does not run user hooks', function (): void {
+    $projectRoot = dirname(__DIR__, 2);
+    $home = sys_get_temp_dir().'/pest-tia-replay-'.bin2hex(random_bytes(8));
+    $log = $home.'/hooks.log';
+
+    mkdir($home, 0755, true);
+
+    try {
+        $changedFiles = new ChangedFiles($projectRoot);
+        $branch = $changedFiles->currentBranch() ?? 'main';
+        $sha = $changedFiles->currentSha();
+
+        expect($sha)->not->toBeNull();
+
+        $fixture = 'tests/.tests/TiaReplayHooks.php';
+        $classFQN = 'P\Tests\tests\TiaReplayHooks';
+
+        $graph = new Graph($projectRoot);
+        $graph->setFingerprint(Fingerprint::compute($projectRoot));
+        $graph->setRecordedAtSha($branch, $sha);
+        $graph->setLastRunTree($branch, $changedFiles->snapshotTree($changedFiles->since($sha) ?? []));
+        $graph->markKnownTestFiles([$fixture]);
+        $graph->setResult($branch, $classFQN.'::'.Str::evaluable('replayed pass'), 0, '', 0.001, 1, $fixture);
+        $graph->setResult($branch, $classFQN.'::'.Str::evaluable('replayed skip'), 1, 'cached skip', 0.001, 0, $fixture);
+        $graph->setResult($branch, $classFQN.'::'.Str::evaluable('replayed incomplete'), 2, 'cached incomplete', 0.001, 0, $fixture);
+
+        $originalHome = getenv('HOME');
+        putenv('HOME='.$home);
+
+        try {
+            $storageDir = Storage::tempDir($projectRoot);
+        } finally {
+            putenv($originalHome === false ? 'HOME' : 'HOME='.$originalHome);
+        }
+
+        $json = $graph->encode();
+
+        expect($json)->not->toBeNull()
+            ->and(new FileState($storageDir)->write(Tia::KEY_GRAPH, (string) $json))->toBeTrue();
+
+        $process = new Process(
+            ['php', 'bin/pest', $fixture, '--tia'],
+            $projectRoot,
+            [
+                'COLLISION_PRINTER' => 'DefaultPrinter',
+                'COLLISION_IGNORE_DURATION' => 'true',
+                'PARATEST' => 0,
+                'PAO_DISABLE' => '1',
+                'HOME' => $home,
+                'TIA_REPLAY_HOOKS_LOG' => $log,
+            ],
+        );
+
+        $process->run();
+
+        $output = removeAnsiEscapeSequences($process->getOutput().$process->getErrorOutput());
+
+        expect($output)
+            ->toContain('3 replayed')
+            ->toContain('1 incomplete')
+            ->toContain('1 skipped')
+            ->toContain('1 passed')
+            ->not->toContain('must not run for replayed tests')
+            ->and($process->getExitCode())->toBe(0)
+            ->and(file_exists($log))->toBeFalse();
+    } finally {
+        $delete = function (string $path) use (&$delete): void {
+            foreach (glob($path.'/{,.}*', GLOB_BRACE | GLOB_NOSORT) ?: [] as $entry) {
+                if (in_array(basename($entry), ['.', '..'], true)) {
+                    continue;
+                }
+
+                is_dir($entry) && ! is_link($entry) ? $delete($entry) : @unlink($entry);
+            }
+
+            @rmdir($path);
+        };
+
+        $delete($home);
+    }
+})->skipOnWindows();

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1525 passed (3322 assertions)';",
+            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1526 passed (3332 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1525 passed (3322 assertions)';
+    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1526 passed (3332 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When TIA replays a cached **Pass/Risky** result, `Testable::setUp()` sets `$__replay` and returns early, and `tearDown()` checks `$__replay` and short-circuits too — neither `parent::setUp()` (which, in Laravel suites, boots the application) nor the user's `beforeEach`/`afterEach` chains run. That symmetry is the established semantic of replay: a replayed test executes no user hooks.

The cached **Skipped**, **Incomplete**, and **Failure** branches broke that symmetry: they throw (`markTestSkipped()` / `markTestIncomplete()` / `AssertionFailedError`) from inside `setUp()` **before** `parent::setUp()` has run, while leaving `$__replay` at `ReplayType::None`. PHPUnit's `runBare()` still invokes the after-test hooks when `setUp()` throws, and because `$__replay` was `None`, Pest's `tearDown()` did not short-circuit — the full `afterEach` chain and `parent::tearDown()` ran against a test case that was never set up (no booted app, no `Facade::$app`, empty container).

In a Laravel suite, any `afterEach` that touches the framework (e.g. `DB::flushQueryLog()`) then throws `A facade root has not been set`, and PHPUnit converts the cached skip into an **error** (`TestCase::runBare()` explicitly promotes a `SkippedWithMessageException` to an error when tearDown throws). This also made TIA results oscillate between runs: the errored result evicted the cached skip, the next run executed the test green and re-cached the skip, and the run after that errored again.

The fix marks the replay state before the throwing branches dispatch, so `tearDown()` short-circuits for every replayed result exactly as it does on the Pass/Risky path. `__runTest()` is unreachable after a `setUp()` throw, so the hoisted `__beginReplay()` has no effect on the Pass/Risky behaviour, and the replayed skip/incomplete statuses are re-recorded unchanged, keeping the cache stable.

The regression test seeds a TIA graph with cached pass/skipped/incomplete results for a fixture whose `afterEach` throws (and logs to a spy file), then replays it in a subprocess: all three results replay with their cached statuses, exit code 0, and no hook executes. Without the fix, the cached skip becomes a `RuntimeException` error from the `afterEach` hook.

### Related:

- Fixes #1785
