### PR TITLE
Fix TIA for Livewire component views

### DIFF
--- a/src/Plugins/Tia/Graph.php
+++ b/src/Plugins/Tia/Graph.php
@@ -100,14 +100,15 @@ final class Graph
 
         $this->applyTestFileChanges($nonMigrationPaths, $affectedSet);
 
-        $staticallyHandledBlade = $this->applyBladeStaticChanges($nonMigrationPaths, $affectedSet);
+        $handledBlade = $this->applyBladeStaticChanges($nonMigrationPaths, $affectedSet)
+            + $this->applyLivewireViewChanges($nonMigrationPaths, $affectedSet);
 
         $this->applyWatchPatternFallback(
             $nonMigrationPaths,
             $unparseableMigrations,
             $preciselyHandledPages,
             $sharedFilesResolved,
-            $staticallyHandledBlade,
+            $handledBlade,
             $affectedSet,
         );
 
@@ -470,10 +471,64 @@ final class Graph
 
     /**
      * @param  list<string>  $nonMigrationPaths
+     * @param  array<string, true>  $affectedSet
+     * @return array<string, true>
+     */
+    private function applyLivewireViewChanges(array $nonMigrationPaths, array &$affectedSet): array
+    {
+        $handled = [];
+
+        foreach ($nonMigrationPaths as $rel) {
+            $sourcePaths = $this->livewireSourcePaths($rel);
+
+            if ($sourcePaths === []) {
+                continue;
+            }
+            if (! is_file($this->projectRoot.'/'.$rel)) {
+                continue;
+            }
+
+            $generatedViewIds = [];
+
+            foreach ($sourcePaths as $sourcePath) {
+                $nativeSourcePath = DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $sourcePath);
+                $hash = substr(md5($nativeSourcePath), 0, 8);
+                $generatedViewSuffix = '/livewire/views/'.$hash.'.blade.php';
+
+                foreach ($this->fileIds as $path => $id) {
+                    if (str_ends_with('/'.ltrim($path, '/'), $generatedViewSuffix)) {
+                        $generatedViewIds[$id] = true;
+                    }
+                }
+            }
+
+            if ($generatedViewIds === []) {
+                continue;
+            }
+
+            foreach ($this->edges as $testFile => $ids) {
+                foreach ($ids as $id) {
+                    if (! isset($generatedViewIds[$id])) {
+                        continue;
+                    }
+
+                    $affectedSet[$testFile] = true;
+                    $handled[$rel] = true;
+
+                    break;
+                }
+            }
+        }
+
+        return $handled;
+    }
+
+    /**
+     * @param  list<string>  $nonMigrationPaths
      * @param  list<string>  $unparseableMigrations
      * @param  array<string, true>  $preciselyHandledPages
      * @param  array<string, true>  $sharedFilesResolved
-     * @param  array<string, true>  $staticallyHandledBlade
+     * @param  array<string, true>  $handledBlade
      * @param  array<string, true>  $affectedSet
      */
     private function applyWatchPatternFallback(
@@ -481,7 +536,7 @@ final class Graph
         array $unparseableMigrations,
         array $preciselyHandledPages,
         array $sharedFilesResolved,
-        array $staticallyHandledBlade,
+        array $handledBlade,
         array &$affectedSet,
     ): void {
         $unknownToGraph = $unparseableMigrations;
@@ -493,7 +548,7 @@ final class Graph
             if (isset($sharedFilesResolved[$rel])) {
                 continue;
             }
-            if (isset($staticallyHandledBlade[$rel])) {
+            if (isset($handledBlade[$rel])) {
                 continue;
             }
             if (! isset($this->fileIds[$rel])) {
@@ -1089,6 +1144,30 @@ final class Graph
     private function isBladePath(string $rel): bool
     {
         return str_starts_with($rel, 'resources/views/') && str_ends_with($rel, '.blade.php');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function livewireSourcePaths(string $rel): array
+    {
+        if (! str_ends_with($rel, '.blade.php')) {
+            return [];
+        }
+
+        $sourcePaths = [$rel];
+        $componentDirectory = dirname($rel);
+        $componentName = preg_replace('/^⚡[\x{FE0E}\x{FE0F}]?/u', '', basename($componentDirectory));
+
+        if ($componentName === null || basename($rel) !== $componentName.'.blade.php') {
+            return $sourcePaths;
+        }
+
+        if (is_file($this->projectRoot.'/'.$componentDirectory.'/'.$componentName.'.php')) {
+            $sourcePaths[] = $componentDirectory;
+        }
+
+        return $sourcePaths;
     }
 
     private function isBladeComponentPath(string $rel): bool

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1886,6 +1886,18 @@
   ✓ rerun tracking → it flags cached failures whose file is unknown
   ✓ applyBladeStaticChanges() → it maps an anonymous index component to the views that render it
   ✓ applyBladeStaticChanges() → it falls back to watch patterns for components with no matched usage
+  ✓ Livewire component views → it maps a changed component to generated views from different workers
+  ✓ Livewire component views → it maps documented SFC locations with dataset "default pages namespace"
+  ✓ Livewire component views → it maps documented SFC locations with dataset "default layouts namespace without emoji"
+  ✓ Livewire component views → it maps documented SFC locations with dataset "additional component location"
+  ✓ Livewire component views → it maps documented SFC locations with dataset "custom component namespace"
+  ✓ Livewire component views → it maps documented SFC locations with dataset "individually registered component"
+  ✓ Livewire component views → it maps documented MFC locations using the component directory hash with dataset "default component location"
+  ✓ Livewire component views → it maps documented MFC locations using the component directory hash with dataset "default component location without emoji"
+  ✓ Livewire component views → it maps documented MFC locations using the component directory hash with dataset "default pages namespace"
+  ✓ Livewire component views → it maps documented MFC locations using the component directory hash with dataset "additional component location"
+  ✓ Livewire component views → it preserves direct view edges for class-based components
+  ✓ Livewire component views → it falls back to watch patterns when no generated view matches
   ✓ markKnownTestFiles() → it makes a test file with no edges known
   ✓ markKnownTestFiles() → it does not clobber edges of an already-known test file
   ✓ markKnownTestFiles() → it ignores paths outside the project root
@@ -2197,4 +2209,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1549 passed (3389 assertions)
+  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1561 passed (3401 assertions)

--- a/tests/Unit/Plugins/Tia/Graph.php
+++ b/tests/Unit/Plugins/Tia/Graph.php
@@ -131,6 +131,124 @@ describe('applyBladeStaticChanges()', function (): void {
     });
 });
 
+describe('Livewire component views', function (): void {
+    beforeEach(function (): void {
+        $this->projectRoot = sys_get_temp_dir().'/pest-tia-livewire-sfc-'.bin2hex(random_bytes(4));
+        mkdir($this->projectRoot, 0755, true);
+
+        $this->watchPatterns = new WatchPatterns;
+        $this->watchPatterns->add(['resources/views/**' => 'tests/Feature']);
+        Container::getInstance()->add(WatchPatterns::class, $this->watchPatterns);
+    });
+
+    afterEach(function (): void {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->projectRoot, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            assert($file instanceof SplFileInfo);
+
+            if ($file->isDir()) {
+                @rmdir($file->getPathname());
+            } else {
+                @unlink($file->getPathname());
+            }
+        }
+
+        @rmdir($this->projectRoot);
+
+        Container::getInstance()->add(WatchPatterns::class, new WatchPatterns);
+    });
+
+    it('maps a changed component to generated views from different workers', function (): void {
+        $ordersPath = 'resources/views/components/orders.blade.php';
+        $usersPath = 'resources/views/components/admin/⚡users.blade.php';
+        $ordersHash = substr(md5(DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $ordersPath)), 0, 8);
+        $usersHash = substr(md5(DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $usersPath)), 0, 8);
+
+        mkdir(dirname($this->projectRoot.'/'.$ordersPath), 0755, true);
+        mkdir(dirname($this->projectRoot.'/'.$usersPath), 0755, true);
+        file_put_contents($this->projectRoot.'/'.$ordersPath, '<div>Orders</div>');
+        file_put_contents($this->projectRoot.'/'.$usersPath, '<div>Users</div>');
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/OrdersTest.php', 'storage/framework/views/test_1/livewire/views/'.$ordersHash.'.blade.php');
+        $graph->link('tests/Feature/UsersTest.php', 'storage/framework/views/test_2/livewire/views/'.$usersHash.'.blade.php');
+
+        expect($graph->affected([$ordersPath]))->toBe(['tests/Feature/OrdersTest.php']);
+    });
+
+    it('maps documented SFC locations', function (string $sourcePath): void {
+        $hash = substr(md5(DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $sourcePath)), 0, 8);
+
+        mkdir(dirname($this->projectRoot.'/'.$sourcePath), 0755, true);
+        file_put_contents($this->projectRoot.'/'.$sourcePath, '<div>Component</div>');
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/ComponentTest.php', 'storage/framework/views/test_3/livewire/views/'.$hash.'.blade.php');
+        $graph->link('tests/Feature/UnrelatedTest.php', 'storage/framework/views/test_4/livewire/views/deadbeef.blade.php');
+
+        expect($graph->affected([$sourcePath]))->toBe(['tests/Feature/ComponentTest.php']);
+    })->with([
+        'default pages namespace' => ['resources/views/pages/post/⚡create.blade.php'],
+        'default layouts namespace without emoji' => ['resources/views/layouts/app.blade.php'],
+        'additional component location' => ['resources/views/widgets/orders.blade.php'],
+        'custom component namespace' => ['resources/views/admin/users-table.blade.php'],
+        'individually registered component' => ['resources/views/ui/button.blade.php'],
+    ]);
+
+    it('maps documented MFC locations using the component directory hash', function (string $componentDirectory, string $viewPath): void {
+        $hash = substr(md5(DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $componentDirectory)), 0, 8);
+        $classPath = $componentDirectory.'/'.basename($viewPath, '.blade.php').'.php';
+
+        mkdir($this->projectRoot.'/'.$componentDirectory, 0755, true);
+        file_put_contents($this->projectRoot.'/'.$viewPath, '<div>Component</div>');
+        file_put_contents($this->projectRoot.'/'.$classPath, '<?php');
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/ComponentTest.php', 'storage/framework/views/test_5/livewire/views/'.$hash.'.blade.php');
+        $graph->link('tests/Feature/UnrelatedTest.php', 'storage/framework/views/test_6/livewire/views/deadbeef.blade.php');
+
+        expect($graph->affected([$viewPath]))->toBe(['tests/Feature/ComponentTest.php']);
+    })->with([
+        'default component location' => ['resources/views/components/post/⚡create', 'resources/views/components/post/⚡create/create.blade.php'],
+        'default component location without emoji' => ['resources/views/components/post/create', 'resources/views/components/post/create/create.blade.php'],
+        'default pages namespace' => ['resources/views/pages/post/⚡create', 'resources/views/pages/post/⚡create/create.blade.php'],
+        'additional component location' => ['resources/views/widgets/create', 'resources/views/widgets/create/create.blade.php'],
+    ]);
+
+    it('preserves direct view edges for class-based components', function (): void {
+        $viewPath = 'resources/views/livewire/create-post.blade.php';
+
+        mkdir(dirname($this->projectRoot.'/'.$viewPath), 0755, true);
+        file_put_contents($this->projectRoot.'/'.$viewPath, '<div>Create post</div>');
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/CreatePostTest.php', $viewPath);
+
+        expect($graph->affected([$viewPath]))->toBe(['tests/Feature/CreatePostTest.php']);
+    });
+
+    it('falls back to watch patterns when no generated view matches', function (): void {
+        $ordersPath = 'resources/views/components/orders.blade.php';
+        $ordersHash = substr(md5(DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $ordersPath)), 0, 8);
+        $unmatchedPath = 'resources/views/components/unmatched.blade.php';
+
+        mkdir(dirname($this->projectRoot.'/'.$ordersPath), 0755, true);
+        file_put_contents($this->projectRoot.'/'.$ordersPath, '<div>Orders</div>');
+        file_put_contents($this->projectRoot.'/'.$unmatchedPath, '<div>Unmatched</div>');
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/OrdersTest.php', 'storage/framework/views/test_1/livewire/views/'.$ordersHash.'.blade.php');
+        $graph->link('tests/Feature/UsersTest.php', 'storage/framework/views/test_2/livewire/views/deadbeef.blade.php');
+
+        expect($graph->affected([$unmatchedPath]))
+            ->toBe(['tests/Feature/OrdersTest.php', 'tests/Feature/UsersTest.php']);
+    });
+});
+
 describe('markKnownTestFiles()', function (): void {
     it('makes a test file with no edges known', function (): void {
         $graph = new Graph(sys_get_temp_dir());

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1531 passed (3334 assertions)';",
+            "\$expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1543 passed (3346 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1531 passed (3334 assertions)';
+    $expected = '1 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1543 passed (3346 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
## Summary

- map changed Livewire single-file and multi-file component sources to the generated view hashes already recorded by TIA
- preserve direct Blade edges and the existing broad watch-pattern fallback when no safe generated-view match exists
- cover the documented Livewire 4 component locations and formats, including optional emoji filenames, and update the visual test snapshots

## Root cause

Livewire renders single-file and multi-file components through generated views under `storage/framework/views/*/livewire/views/<hash>.blade.php`. TIA recorded those generated paths, but a Git change is reported using the original component path, so the graph could not connect the changed component to its tests.

The graph now derives the same platform-specific source-path hash without requiring Livewire as a dependency and reuses matching generated-view edges. If no matching edge exists, the existing watch-pattern fallback remains unchanged.

## Validation

- `composer test`
- fresh TIA baseline in an integration Laravel application: 1,259 tests passed with 2,820 assertions
- four real Livewire SFC changes across `resources/views/components/**` and `resources/views/pages/**`: exactly 7 related test files selected, with 167 tests and 340 assertions passing
- final integration application gate with `--parallel --tia`: 1,259 tests passed with 2,820 assertions

Fixes #1808
