### PR TITLE
Fix TIA fingerprinting inside linked git worktrees

### DIFF
--- a/src/Plugins/Tia/Fingerprint.php
+++ b/src/Plugins/Tia/Fingerprint.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Pest\Plugins\Tia;
 
 use Pest\Plugins\Tia\Contracts\Lockfile;
-use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
+use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -279,13 +280,16 @@ final readonly class Fingerprint
             return $cache[$key] = true;
         }
 
-        $finder = (new Finder)
-            ->in($projectRoot)
-            ->depth('== 0')
-            ->name($relativePath)
-            ->ignoreVCSIgnored(true);
+        $process = new Process(['git', 'check-ignore', '-q', '--', $relativePath], $projectRoot);
+        $process->setTimeout(5.0);
 
-        return $cache[$key] = $finder->hasResults();
+        try {
+            $process->run();
+        } catch (ProcessException) {
+            return $cache[$key] = true;
+        }
+
+        return $cache[$key] = $process->getExitCode() !== 0;
     }
 
     private static function contentHashOrNull(string $path): ?string

--- a/tests/Unit/Plugins/Tia/Fingerprint.php
+++ b/tests/Unit/Plugins/Tia/Fingerprint.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\Fingerprint;
+use Symfony\Component\Process\Process;
+
+function fingerprintGit(string $cwd, string ...$args): void
+{
+    $process = new Process(['git', ...$args], $cwd);
+    $process->setTimeout(10.0);
+    $process->mustRun();
+}
+
+function fingerprintRepository(): string
+{
+    $root = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pest_fingerprint_'.uniqid();
+    mkdir($root, 0777, true);
+
+    fingerprintGit($root, 'init', '-q');
+    fingerprintGit($root, 'config', 'user.email', 'pest@example.com');
+    fingerprintGit($root, 'config', 'user.name', 'Pest');
+
+    return $root;
+}
+
+function fingerprintRemoveDirectory(string $path): void
+{
+    if (! is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $file) {
+        @chmod($file->getPathname(), 0777);
+        $file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+    }
+
+    @rmdir($path);
+}
+
+describe('compute()', function (): void {
+    it('fingerprints tracked structural files in a regular clone', function (): void {
+        $clone = fingerprintRepository();
+
+        try {
+            file_put_contents($clone.'/composer.lock', '{"packages": []}');
+            file_put_contents($clone.'/phpunit.xml', '<phpunit/>');
+            fingerprintGit($clone, 'add', '-A');
+            fingerprintGit($clone, 'commit', '-q', '-m', 'init');
+
+            $fingerprint = Fingerprint::compute($clone);
+
+            expect($fingerprint['structural']['composer_lock'])->not->toBeNull()
+                ->and($fingerprint['structural']['phpunit_xml'])->not->toBeNull();
+        } finally {
+            fingerprintRemoveDirectory($clone);
+        }
+    });
+
+    it('fingerprints tracked structural files inside a linked git worktree', function (): void {
+        $clone = fingerprintRepository();
+
+        try {
+            file_put_contents($clone.'/composer.lock', '{"packages": []}');
+            file_put_contents($clone.'/phpunit.xml', '<phpunit/>');
+            file_put_contents($clone.'/.gitignore', ".worktrees/\n");
+            fingerprintGit($clone, 'add', '-A');
+            fingerprintGit($clone, 'commit', '-q', '-m', 'init');
+            fingerprintGit($clone, 'worktree', 'add', '-q', '.worktrees/feature');
+
+            $worktree = $clone.'/.worktrees/feature';
+
+            $cloneFingerprint = Fingerprint::compute($clone);
+            $worktreeFingerprint = Fingerprint::compute($worktree);
+
+            expect($worktreeFingerprint['structural']['composer_lock'])->not->toBeNull()
+                ->and($worktreeFingerprint['structural']['phpunit_xml'])->not->toBeNull()
+                ->and($worktreeFingerprint['structural']['composer_lock'])->toBe($cloneFingerprint['structural']['composer_lock'])
+                ->and($worktreeFingerprint['structural']['phpunit_xml'])->toBe($cloneFingerprint['structural']['phpunit_xml']);
+        } finally {
+            fingerprintRemoveDirectory($clone);
+        }
+    });
+
+    it('excludes gitignored untracked files from the fingerprint', function (): void {
+        $clone = fingerprintRepository();
+
+        try {
+            file_put_contents($clone.'/composer.lock', '{"packages": []}');
+            file_put_contents($clone.'/.gitignore', "phpunit.xml\n");
+            fingerprintGit($clone, 'add', '-A');
+            fingerprintGit($clone, 'commit', '-q', '-m', 'init');
+
+            file_put_contents($clone.'/phpunit.xml', '<phpunit/>');
+
+            $fingerprint = Fingerprint::compute($clone);
+
+            expect($fingerprint['structural']['phpunit_xml'])->toBeNull()
+                ->and($fingerprint['structural']['composer_lock'])->not->toBeNull();
+        } finally {
+            fingerprintRemoveDirectory($clone);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #1810.

**The problem**

`Fingerprint::isTrackedByGit()` answers "is this file gitignored?" with Symfony Finder's `ignoreVCSIgnored(true)`. Finder locates the repository root by walking upward until it finds a `.git` directory. In a linked worktree `.git` is a pointer file, so the walk misses the worktree root, and what happens next depends on the directory layout:

- If an ancestor directory contains a `.git` directory (worktrees kept inside the main repository under an ignored `.worktrees/` directory, or a dotfiles repository in `$HOME` that ignores `*`), Finder adopts that ancestor as the repository root and applies its ignore rules to the worktree's files. Every structural file then reports as ignored, `trackedHash()` returns null for all of them, and `--tia` rebuilds the graph on every run with no error, just a permanent "fresh graph" message.
- If no ancestor has one, the check happens to behave correctly, which is why the failure looks machine-dependent.

**The fix**

Ask git itself with `git check-ignore -q`, run from the project root, as the issue suggests. Git resolves the `gitdir:` pointer natively, so worktrees behave like regular clones. This also matches how TIA already answers the same question in `ChangedFiles::filterIgnored()`.

Exit code 0 keeps a file out of the fingerprint (ignored), 1 keeps it in, and anything else (git missing, not a repository) keeps the file, matching the existing no-`.git` early return.

**Verification**

- New test: a repository with a linked worktree under an ignored `.worktrees/` directory. On current 5.x it fails (worktree fingerprints are null); with this change the worktree produces the same structural fingerprint as the clone, which is the property replay depends on.
- The gitignored-untracked-lockfile exclusion documented on the method keeps working, also covered by a new test.
- Full unit suite (1,608 tests), PHPStan, 100% type coverage, rector, and pint all pass.
