### PR TITLE
[5.x] feat: add support for customising baseline workflow name

### DIFF
--- a/src/Plugins/Tia/BaselineSync.php
+++ b/src/Plugins/Tia/BaselineSync.php
@@ -17,7 +17,7 @@ use Symfony\Component\Process\Process;
  */
 final readonly class BaselineSync
 {
-    private const string WORKFLOW_FILE = 'tia-baseline.yml';
+    private const string DEFAULT_WORKFLOW_FILE = 'tia-baseline.yml';
 
     private const string ARTIFACT_NAME = 'pest-tia-baseline';
 
@@ -57,7 +57,13 @@ final readonly class BaselineSync
     public function __construct(
         private State $state,
         private OutputInterface $output,
+        private WatchPatterns $watchPatterns,
     ) {}
+
+    private function workflowFile(): string
+    {
+        return $this->watchPatterns->baselineWorkflow() ?? self::DEFAULT_WORKFLOW_FILE;
+    }
 
     private function renderBadge(string $type, string $content): void
     {
@@ -276,7 +282,7 @@ final readonly class BaselineSync
 
         Panic::with(new BaselineFetchFailed(
             sprintf('%s — %s', $contextPrefix, $diagnosis['message']),
-            'Verify workflow tia-baseline.yml, artifact pest-tia-baseline, and gh token scope.',
+            sprintf('Verify workflow %s, artifact %s, and gh token scope.', $this->workflowFile(), self::ARTIFACT_NAME),
             $hasAnchor,
         ));
     }
@@ -528,7 +534,7 @@ final readonly class BaselineSync
         $process = new Process([
             'gh', 'run', 'list',
             '-R', $repo,
-            '--workflow', self::WORKFLOW_FILE,
+            '--workflow', $this->workflowFile(),
             '--status', 'success',
             '--limit', '1',
             '--json', 'databaseId',

--- a/src/Plugins/Tia/Configuration.php
+++ b/src/Plugins/Tia/Configuration.php
@@ -49,13 +49,14 @@ final class Configuration
     }
 
     /**
+     * @param  string|null  $workflow  Baseline workflow filename, defaults to `tia-baseline.yml`.
      * @return $this
      */
-    public function baselined(): self
+    public function baselined(?string $workflow = null): self
     {
         /** @var WatchPatterns $watchPatterns */
         $watchPatterns = Container::getInstance()->get(WatchPatterns::class);
-        $watchPatterns->markBaselined();
+        $watchPatterns->markBaselined($workflow);
 
         return $this;
     }

--- a/src/Plugins/Tia/WatchPatterns.php
+++ b/src/Plugins/Tia/WatchPatterns.php
@@ -44,6 +44,8 @@ final class WatchPatterns
 
     private bool $baselined = false;
 
+    private ?string $baselineWorkflow = null;
+
     public function useDefaults(string $projectRoot): void
     {
         $testPath = TestSuite::getInstance()->testPath;
@@ -167,14 +169,25 @@ final class WatchPatterns
         return $this->filtered;
     }
 
-    public function markBaselined(): void
+    public function markBaselined(?string $workflow = null): void
     {
         $this->baselined = true;
+
+        $workflow = $workflow === null ? null : trim($workflow);
+
+        if ($workflow !== null && $workflow !== '') {
+            $this->baselineWorkflow = $workflow;
+        }
     }
 
     public function isBaselined(): bool
     {
         return $this->baselined;
+    }
+
+    public function baselineWorkflow(): ?string
+    {
+        return $this->baselineWorkflow;
     }
 
     public function reset(): void
@@ -185,6 +198,7 @@ final class WatchPatterns
         $this->locally = false;
         $this->filtered = false;
         $this->baselined = false;
+        $this->baselineWorkflow = null;
     }
 
     private function keyMatches(string $key, string $file): bool

--- a/tests/Unit/Plugins/Tia/WatchPatterns.php
+++ b/tests/Unit/Plugins/Tia/WatchPatterns.php
@@ -1,0 +1,45 @@
+<?php
+
+use Pest\Plugins\Tia\Configuration;
+use Pest\Plugins\Tia\WatchPatterns;
+use Pest\Support\Container;
+
+beforeEach(function (): void {
+    $this->watchPatterns = new WatchPatterns;
+
+    Container::getInstance()->add(WatchPatterns::class, $this->watchPatterns);
+});
+
+afterEach(function (): void {
+    Container::getInstance()->add(WatchPatterns::class, new WatchPatterns);
+});
+
+test('baselined defaults to no custom workflow', function (): void {
+    (new Configuration)->baselined();
+
+    expect($this->watchPatterns->isBaselined())->toBeTrue()
+        ->and($this->watchPatterns->baselineWorkflow())->toBeNull();
+});
+
+test('baselined accepts a custom workflow filename', function (): void {
+    (new Configuration)->baselined('ci-baseline.yml');
+
+    expect($this->watchPatterns->isBaselined())->toBeTrue()
+        ->and($this->watchPatterns->baselineWorkflow())->toBe('ci-baseline.yml');
+});
+
+test('baselined ignores a blank workflow filename', function (): void {
+    (new Configuration)->baselined('   ');
+
+    expect($this->watchPatterns->isBaselined())->toBeTrue()
+        ->and($this->watchPatterns->baselineWorkflow())->toBeNull();
+});
+
+test('reset clears the custom workflow filename', function (): void {
+    (new Configuration)->baselined('ci-baseline.yml');
+
+    $this->watchPatterns->reset();
+
+    expect($this->watchPatterns->isBaselined())->toBeFalse()
+        ->and($this->watchPatterns->baselineWorkflow())->toBeNull();
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->

This adds support for using another name other than `tia-baseline.yml`, for example we use `code-coverage.yml` to contain all our code coverage flows, and it would be nice to just add TIA to this, rather than needing to rename our existing workflow, or add a separate one just for this.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
