### PR TITLE
[4.x] fix: resolve issue for named arguments

### DIFF
--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -235,7 +235,7 @@ final class TestCaseMethodFactory
             $attributesCode
                 public function $methodName(...\$arguments)
                 {
-                    if (count(\$arguments) === 1 && \$arguments[0] instanceof __PestDatasetProviderError) {
+                    if (count(\$arguments) === 1 && isset(\$arguments[0]) && \$arguments[0] instanceof __PestDatasetProviderError) {
                         throw \$arguments[0]->getPrevious() ?? \$arguments[0];
                     }
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

When running tests that have named arguments in a dataset, but only a single argument, the `$arguments[0]` throws an undefined array key exception before the test is run.

<img width="457" height="153" alt="Screenshot 2026-08-03 at 11 35 05" src="https://github.com/user-attachments/assets/619ac223-3bd5-4d3a-a620-e41a82df362f" />

This bug was introduced in [the 4.7.7 release](https://github.com/pestphp/pest/releases/tag/v4.7.7).

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->