### PR TITLE
fix: resolve git origin in linked worktrees (Tia storage key + baseline fetch)

### DIFF
--- a/src/Plugins/Tia/BaselineSync.php
+++ b/src/Plugins/Tia/BaselineSync.php
@@ -177,23 +177,11 @@ final readonly class BaselineSync
 
     private function detectGitHubRepo(string $projectRoot): ?string
     {
-        $gitConfig = $projectRoot.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'config';
+        $url = $this->originUrl($projectRoot);
 
-        if (! is_file($gitConfig)) {
+        if ($url === null) {
             return null;
         }
-
-        $content = @file_get_contents($gitConfig);
-
-        if ($content === false) {
-            return null;
-        }
-
-        if (preg_match('/\[remote "origin"\][^\[]*?url\s*=\s*(\S+)/s', $content, $match) !== 1) {
-            return null;
-        }
-
-        $url = $match[1];
 
         if (preg_match('#^git@github\.com:([\w.-]+/[\w.-]+?)(?:\.git)?$#', $url, $m) === 1) {
             return $m[1];
@@ -208,6 +196,48 @@ final readonly class BaselineSync
         }
 
         return null;
+    }
+
+    private function originUrl(string $projectRoot): ?string
+    {
+        $gitConfig = $projectRoot.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'config';
+
+        if (is_file($gitConfig)) {
+            $content = @file_get_contents($gitConfig);
+
+            if ($content === false) {
+                return null;
+            }
+
+            if (preg_match('/\[remote "origin"\][^\[]*?url\s*=\s*(\S+)/s', $content, $match) !== 1) {
+                return null;
+            }
+
+            return $match[1];
+        }
+
+        // Linked worktree: `.git` is a file pointing at the real git dir, so
+        // the config cannot be read directly — ask git itself instead.
+        if (! file_exists($projectRoot.DIRECTORY_SEPARATOR.'.git')) {
+            return null;
+        }
+
+        $process = new Process(['git', 'config', '--get', 'remote.origin.url'], $projectRoot);
+        $process->setTimeout(5.0);
+
+        try {
+            $process->run();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $url = trim($process->getOutput());
+
+        return $url === '' ? null : $url;
     }
 
     /**

--- a/src/Plugins/Tia/Storage.php
+++ b/src/Plugins/Tia/Storage.php
@@ -119,21 +119,52 @@ final class Storage
     {
         $config = $projectRoot.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'config';
 
-        if (! is_file($config)) {
+        if (is_file($config)) {
+            $raw = @file_get_contents($config);
+
+            if ($raw === false) {
+                return null;
+            }
+
+            if (preg_match('/\[remote "origin"\][^\[]*?url\s*=\s*(\S+)/s', $raw, $match) === 1) {
+                return trim($match[1]);
+            }
+
             return null;
         }
 
-        $raw = @file_get_contents($config);
+        return self::originUrlFromGit($projectRoot);
+    }
 
-        if ($raw === false) {
+    /**
+     * In a linked worktree, `.git` is a file pointing at the real git dir, so
+     * the config cannot be read directly — ask git itself instead.
+     */
+    private static function originUrlFromGit(string $projectRoot): ?string
+    {
+        if (! file_exists($projectRoot.DIRECTORY_SEPARATOR.'.git')) {
             return null;
         }
 
-        if (preg_match('/\[remote "origin"\][^\[]*?url\s*=\s*(\S+)/s', $raw, $match) === 1) {
-            return trim($match[1]);
+        $process = new \Symfony\Component\Process\Process(
+            ['git', 'config', '--get', 'remote.origin.url'],
+            $projectRoot,
+        );
+        $process->setTimeout(5.0);
+
+        try {
+            $process->run();
+        } catch (\Throwable) {
+            return null;
         }
 
-        return null;
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $url = trim($process->getOutput());
+
+        return $url === '' ? null : $url;
     }
 
     private static function slug(string $name): string

--- a/tests/Unit/Plugins/Tia/BaselineSync.php
+++ b/tests/Unit/Plugins/Tia/BaselineSync.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\BaselineSync;
+use Pest\Plugins\Tia\FileState;
+use Pest\Support\Reflection;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Process;
+
+function baselineSyncGit(string $cwd, string ...$args): void
+{
+    $process = new Process(['git', ...$args], $cwd);
+    $process->setTimeout(10.0);
+    $process->mustRun();
+}
+
+function baselineSyncRepository(?string $origin): string
+{
+    $root = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pest_baseline_sync_'.uniqid();
+    mkdir($root, 0777, true);
+
+    baselineSyncGit($root, 'init', '-q');
+    baselineSyncGit($root, 'config', 'user.email', 'pest@example.com');
+    baselineSyncGit($root, 'config', 'user.name', 'Pest');
+
+    if ($origin !== null) {
+        baselineSyncGit($root, 'remote', 'add', 'origin', $origin);
+    }
+
+    return $root;
+}
+
+function baselineSyncRemoveDirectory(string $path): void
+{
+    if (! is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $file) {
+        @chmod($file->getPathname(), 0777);
+        $file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+    }
+
+    @rmdir($path);
+}
+
+function baselineSyncDetect(string $projectRoot): ?string
+{
+    $sync = new BaselineSync(new FileState($projectRoot.DIRECTORY_SEPARATOR.'.pest-state'), new NullOutput);
+
+    /** @var ?string $repo */
+    $repo = Reflection::call($sync, 'detectGitHubRepo', [$projectRoot]);
+
+    return $repo;
+}
+
+describe('detectGitHubRepo()', function (): void {
+    it('detects the repository from an ssh origin in a regular clone', function (): void {
+        $clone = baselineSyncRepository('git@github.com:foo/bar.git');
+
+        try {
+            expect(baselineSyncDetect($clone))->toBe('foo/bar');
+        } finally {
+            baselineSyncRemoveDirectory($clone);
+        }
+    });
+
+    it('detects the repository from an https origin in a regular clone', function (): void {
+        $clone = baselineSyncRepository('https://github.com/foo/bar.git');
+
+        try {
+            expect(baselineSyncDetect($clone))->toBe('foo/bar');
+        } finally {
+            baselineSyncRemoveDirectory($clone);
+        }
+    });
+
+    it('detects the repository inside a linked git worktree', function (): void {
+        $clone = baselineSyncRepository('git@github.com:foo/bar.git');
+        $worktree = $clone.'-wt';
+
+        try {
+            file_put_contents($clone.'/README.md', 'pest');
+            baselineSyncGit($clone, 'add', '-A');
+            baselineSyncGit($clone, 'commit', '-q', '-m', 'init');
+            baselineSyncGit($clone, 'worktree', 'add', '-q', $worktree);
+
+            expect(baselineSyncDetect($worktree))->toBe('foo/bar');
+        } finally {
+            baselineSyncRemoveDirectory($worktree);
+            baselineSyncRemoveDirectory($clone);
+        }
+    });
+
+    it('returns null for a non-github origin', function (): void {
+        $clone = baselineSyncRepository('git@gitlab.com:foo/bar.git');
+
+        try {
+            expect(baselineSyncDetect($clone))->toBeNull();
+        } finally {
+            baselineSyncRemoveDirectory($clone);
+        }
+    });
+
+    it('returns null when there is no origin remote', function (): void {
+        $clone = baselineSyncRepository(null);
+
+        try {
+            expect(baselineSyncDetect($clone))->toBeNull();
+        } finally {
+            baselineSyncRemoveDirectory($clone);
+        }
+    });
+});

--- a/tests/Unit/Plugins/Tia/Storage.php
+++ b/tests/Unit/Plugins/Tia/Storage.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\Storage;
+use Symfony\Component\Process\Process;
+
+function storageGit(string $cwd, string ...$args): void
+{
+    $process = new Process(['git', ...$args], $cwd);
+    $process->setTimeout(10.0);
+    $process->mustRun();
+}
+
+function storageRepository(?string $origin): string
+{
+    $root = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pest_storage_'.uniqid();
+    mkdir($root, 0777, true);
+
+    storageGit($root, 'init', '-q');
+    storageGit($root, 'config', 'user.email', 'pest@example.com');
+    storageGit($root, 'config', 'user.name', 'Pest');
+
+    if ($origin !== null) {
+        storageGit($root, 'remote', 'add', 'origin', $origin);
+    }
+
+    return $root;
+}
+
+function storageRemoveDirectory(string $path): void
+{
+    if (! is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $file) {
+        @chmod($file->getPathname(), 0777);
+        $file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+    }
+
+    @rmdir($path);
+}
+
+function storageKeyHash(string $projectRoot): string
+{
+    preg_match('/([a-f0-9]{16})$/', basename(Storage::tempDir($projectRoot)), $match);
+
+    return $match[1] ?? '';
+}
+
+describe('tempDir()', function (): void {
+    it('derives the storage key from the origin remote in a regular clone', function (): void {
+        $clone = storageRepository('git@github.com:foo/bar.git');
+
+        try {
+            expect(storageKeyHash($clone))->toBe(substr(hash('sha256', 'github.com/foo/bar'), 0, 16));
+        } finally {
+            storageRemoveDirectory($clone);
+        }
+    });
+
+    it('derives the same origin key inside a linked git worktree', function (): void {
+        $clone = storageRepository('git@github.com:foo/bar.git');
+        $worktree = $clone.'-wt';
+
+        try {
+            file_put_contents($clone.'/README.md', 'pest');
+            storageGit($clone, 'add', '-A');
+            storageGit($clone, 'commit', '-q', '-m', 'init');
+            storageGit($clone, 'worktree', 'add', '-q', $worktree);
+
+            expect(storageKeyHash($worktree))->toBe(storageKeyHash($clone))
+                ->and(storageKeyHash($worktree))->toBe(substr(hash('sha256', 'github.com/foo/bar'), 0, 16));
+        } finally {
+            storageRemoveDirectory($worktree);
+            storageRemoveDirectory($clone);
+        }
+    });
+
+    it('falls back to a path-derived key when there is no origin remote', function (): void {
+        $clone = storageRepository(null);
+
+        try {
+            $realpath = realpath($clone);
+
+            expect($realpath)->not->toBeFalse()
+                ->and(storageKeyHash($clone))->toBe(substr(hash('sha256', (string) $realpath), 0, 16));
+        } finally {
+            storageRemoveDirectory($clone);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

In a **linked git worktree** (`git worktree add`), `.git` is a *file* containing a `gitdir:` pointer, not a directory. Two TIA code paths read `<projectRoot>/.git/config` directly with `file_get_contents`, so both silently fail in every linked worktree:

1. **`Storage::rawOriginUrl()`** — the project key falls back to a hash of the absolute path instead of the normalized origin URL. The [TIA docs](https://github.com/pestphp/docs/blob/master/tia.md) promise:

   > Sharing state per remote URL means multiple worktrees of the same repository share one cache, while unrelated projects on the same machine stay isolated.

   In a linked worktree that promise doesn't hold today — every worktree gets an unrelated path-derived key.

2. **`BaselineSync::detectGitHubRepo()`** — returns `null`, so `--tia --baselined` silently skips the CI baseline fetch and falls back to a full local re-record. This bites hardest exactly where the baseline fetch matters most: fresh, short-lived worktree checkouts (CI shards, coding-agent worktrees) that have no local graph to reuse.

## Reproduction (measured on v5.0.2)

`pest --baseline` prints the resolved storage directory:

```bash
# main checkout
$ vendor/bin/pest --baseline
/Users/x/.pest/tia/repo-840a07cab1e2d72d        # hash derived from origin URL

# linked worktree of the same repository — before this fix
$ cd ../repo-wt && vendor/bin/pest --baseline
/Users/x/.pest/tia/wt-feee7be378801f90          # hash of realpath — origin ignored

# linked worktree — after this fix
$ vendor/bin/pest --baseline
/Users/x/.pest/tia/wt-840a07cab1e2d72d          # origin-derived hash again
```

To reproduce from scratch: `git worktree add ../repo-wt` on any repo with an `origin` remote, `composer install` in the worktree, run `vendor/bin/pest --baseline` in both checkouts and compare the hashes.

## Fix

- Keep the existing fast `.git/config` file read for regular checkouts — behaviour there is unchanged, no process is spawned.
- When `.git` exists but is not a directory (linked worktree), fall back to `git config --get remote.origin.url` executed in the project root. Git resolves the `gitdir:` pointer natively, so worktrees behave like regular clones.
- The subprocess has a 5s timeout, and every failure mode (git binary missing, no origin remote, non-zero exit) degrades to the existing `null` behaviour — a worktree without a resolvable origin keeps today's path-hash fallback.
- `BaselineSync::detectGitHubRepo()` now derives the URL through the same resolution, so both call sites agree on what the origin is.

## Related work — checked, not duplicates

- #1810 / #1813 fix `Fingerprint::isTrackedByGit()`, which breaks in linked worktrees for the same root cause (Symfony Finder doesn't resolve the `gitdir:` pointer). Different defect, different file — this PR is complementary and touches neither `Fingerprint.php` nor the paths changed there.
- #1805 / #1809 address TIA for projects in repository subdirectories; #1752 addresses project-root resolution with a symlinked `vendor`. Neither touches origin resolution.

## Tests

`tests/Unit/Plugins/Tia/Storage.php` and `tests/Unit/Plugins/Tia/BaselineSync.php` create real temp repositories (plus a linked worktree via `git worktree add`) and cover:

- the storage key is derived from the origin remote in a regular clone, and resolves to the **same** origin hash inside a linked worktree;
- the path-derived fallback still applies when there is no origin remote;
- `detectGitHubRepo()` resolves `owner/repo` from ssh and https origins, resolves it **inside a linked worktree**, and returns `null` for non-GitHub or missing origins.

Verified both ways: all 8 pass on this branch, and with `src/Plugins/Tia/{Storage,BaselineSync}.php` reverted to `5.x` exactly the two worktree tests fail (path hash instead of origin hash; `null` instead of `foo/bar`) while the six regular-checkout tests keep passing — i.e. behaviour outside worktrees is unchanged.

## Notes for review

- `Storage::projectKey()` still prefixes `slug(basename($projectRoot))`, so two worktrees end up with *sibling* storage dirs (`repo-<hash>`, `wt-<hash>`) that share the origin-derived hash, rather than literally one shared directory. If literal sharing (the docs' wording) is preferred, the slug would also need to derive from the origin identity — happy to extend the PR that way. Keeping per-worktree keys does avoid concurrent runs in different worktrees racing on the same `graph.json`.
