### PR TITLE
[4.x] correct error handling for PestDatasetProviderError

### DIFF
--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -235,8 +235,8 @@ final class TestCaseMethodFactory
             $attributesCode
                 public function $methodName(...\$arguments)
                 {
-                    if (count(\$arguments) === 1 && \$arguments[0] instanceof __PestDatasetProviderError) {
-                        throw \$arguments[0]->getPrevious() ?? \$arguments[0];
+                    if (count(\$arguments) === 1 && \$arguments[array_key_first(\$arguments)] instanceof __PestDatasetProviderError) {
+                        throw \$arguments[array_key_first(\$arguments)->getPrevious() ?? \$arguments[array_key_first(\$arguments)];
                     }
 
                     return \$this->__runTest(


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When using named parameter, the argument array does not start by zero. Therefore, `array_key_first` must be used to check the first argument. Otherwise "Undefined array key 0" is seen as error message at test cases with datasets using named arguments.

### Related:

https://github.com/pestphp/pest/pull/1749