### PR TITLE
Fix array_flip corrupting duplicate CLI flags in parallel worker argument handling

### DIFF
--- a/src/Plugins/Concerns/HandleArguments.php
+++ b/src/Plugins/Concerns/HandleArguments.php
@@ -50,11 +50,14 @@ trait HandleArguments
      */
     public function popArgument(string $argument, array $arguments): array
     {
-        $arguments = array_flip($arguments);
+        $key = array_search($argument, $arguments, true);
 
-        unset($arguments[$argument]);
+        while ($key !== false) {
+            unset($arguments[$key]);
+            $key = array_search($argument, $arguments, true);
+        }
 
-        return array_values(array_flip($arguments));
+        return array_values($arguments);
     }
 
     /**

--- a/src/Plugins/Coverage.php
+++ b/src/Plugins/Coverage.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class Coverage implements AddsOutput, HandlesArguments
 {
+    use Concerns\HandleArguments;
+
     private const string COVERAGE_OPTION = 'coverage';
 
     private const string MIN_OPTION = 'min';
@@ -77,11 +79,9 @@ final class Coverage implements AddsOutput, HandlesArguments
             return false;
         }))];
 
-        $originals = array_flip($originals);
         foreach ($arguments as $argument) {
-            unset($originals[$argument]);
+            $originals = $this->popArgument($argument, $originals);
         }
-        $originals = array_flip($originals);
 
         $inputs = [];
         $inputs[] = new InputOption(self::COVERAGE_OPTION, null, InputOption::VALUE_NONE);

--- a/tests/Fixtures/MultipleGroups/OneTest.php
+++ b/tests/Fixtures/MultipleGroups/OneTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('belongs to group one', function () {
+    expect(true)->toBeTrue();
+})->group('one');

--- a/tests/Fixtures/MultipleGroups/ThreeTest.php
+++ b/tests/Fixtures/MultipleGroups/ThreeTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('belongs to group three', function () {
+    expect(true)->toBeTrue();
+})->group('three');

--- a/tests/Fixtures/MultipleGroups/TwoTest.php
+++ b/tests/Fixtures/MultipleGroups/TwoTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('belongs to group two', function () {
+    expect(true)->toBeTrue();
+})->group('two');

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -47,3 +47,19 @@ test('parallel reports invalid datasets as failures', function () use ($run) {
         ->toContain('Tests:    1 failed, 1 passed (1 assertions)')
         ->toContain('Parallel: 3 processes');
 })->skipOnWindows();
+
+test('parallel honors multiple --group flags', function () use ($run) {
+    $output = $run('tests/Fixtures/MultipleGroups', '--group=one', '--group=two');
+
+    expect($output)
+        ->toContain('Tests:    2 passed (2 assertions)')
+        ->toContain('Parallel: 3 processes');
+})->skipOnWindows();
+
+test('parallel honors multiple --exclude-group flags', function () use ($run) {
+    $output = $run('tests/Fixtures/MultipleGroups', '--exclude-group=one', '--exclude-group=two');
+
+    expect($output)
+        ->toContain('Tests:    1 passed (1 assertions)')
+        ->toContain('Parallel: 3 processes');
+})->skipOnWindows();


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix

### Description:

`--parallel` silently drops every repeated flag after the first for any option PHPUnit allows multiple times (`--group`, `--exclude-group`, etc.) — `--group=a --group=b --parallel` only honors `a`.

**Root cause:** in a parallel worker, `ParaTest\WrapperRunner\WrapperWorker` expands array-valued options into space-separated pairs (`['--group', 'a', '--group', 'b']`), so the literal string `'--group'` appears twice in the argument list. Two places in Pest then removed arguments via an `array_flip()` round-trip:

- `Concerns\HandleArguments::popArgument()` — used unconditionally by `Memory::handleArguments()` (and conditionally by `Bail`, `Retry`, `Verbose`, `Snapshot`, `Parallel`)
- `Coverage::handleArguments()`'s inline flip/unflip removal

`array_flip()` can't represent duplicate values as distinct keys, so flipping and unflipping silently collapses the two `'--group'` entries into one — corrupting the array regardless of what the plugin was actually trying to remove, and regardless of whether that argument was even present.

**`5.x` already fixed this same class of bug independently**, so this PR ports that exact fix to `4.x` rather than introducing a different one: `popArgument()` now removes by key via `array_search()` in a loop instead of `array_flip()`, and `Coverage::handleArguments()` delegates to it instead of keeping its own duplicate flip/unflip logic. No `5.x` changes are needed — this is a `4.x`-only backport.

Added two integration tests in `tests/Visual/Parallel.php` (with a `MultipleGroups` fixture) that run `bin/pest --parallel` with two `--group` flags and two `--exclude-group` flags and assert the correct union/exclusion — both fail on `4.x` before this change and pass after.

### Related:

Fixes #1437