### PR TITLE
feat: let a shard unit bundle several test classes

### DIFF
--- a/src/Plugins/Help.php
+++ b/src/Plugins/Help.php
@@ -154,7 +154,7 @@ final readonly class Help implements HandlesArguments
             ],
             [
                 'arg' => '--update-shards',
-                'desc' => 'Update shards.json with test timing data for time-balanced sharding',
+                'desc' => 'Update the shards file with timing data for time-balanced sharding',
             ],
         ], ...$content['Execution']];
 

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -41,6 +41,23 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
 
     private static bool $updateShards = false;
 
+    private static ?string $timingsFilename = null;
+
+    /**
+     * @var array<string, float|array{time: float, tests: list<string>}>|null
+     */
+    private static ?array $externalTimings = null;
+
+    /**
+     * @var list<string>
+     */
+    private static array $selectedUnits = [];
+
+    /**
+     * @var array<string, scalar>
+     */
+    private static array $metadata = [];
+
     private static bool $timeBalanced = false;
 
     private static bool $shardsOutdated = false;
@@ -48,7 +65,7 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
     private static bool $passed = false;
 
     /**
-     * @var array<string, float>|null
+     * @var array<string, float|array{time: float, tests: list<string>}>|null
      */
     private static ?array $collectedTimings = null;
 
@@ -61,6 +78,41 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         private readonly OutputInterface $output,
     ) {
         //
+    }
+
+    public static function useTimingsFile(string $filename): void
+    {
+        self::$timingsFilename = $filename;
+    }
+
+    /**
+     * @param  array<string, float|array{time: float, tests: list<string>}>  $units
+     * @param  array<string, scalar>  $metadata  Stored alongside the units, and read back
+     *                                           by {@see self::metadata()} on sharded runs.
+     */
+    public static function useTimings(array $units, array $metadata = []): void
+    {
+        self::$externalTimings = $units;
+
+        if ($metadata !== []) {
+            self::$metadata = $metadata;
+        }
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public static function metadata(): array
+    {
+        return self::$metadata;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function selectedUnits(): array
+    {
+        return self::$selectedUnits;
     }
 
     /**
@@ -98,20 +150,25 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         /** @phpstan-ignore-next-line */
         $tests = $this->allTests($arguments);
 
-        $timings = $this->loadShardsFile();
-        if ($timings !== null) {
-            $knownTests = array_values(array_filter($tests, fn (string $test): bool => isset($timings[$test])));
-            $newTests = array_values(array_diff($tests, $knownTests));
+        $units = $this->loadShardsFile();
+        if ($units !== null) {
+            $newTests = array_values(array_diff($tests, $this->testsOf($units)));
 
-            $partitions = $this->partitionByTime($knownTests, $timings, $total);
+            $partitions = $this->partitionByTime($units, $total);
+
+            $median = $this->medianTime($units);
 
             foreach ($newTests as $i => $test) {
-                $partitions[$i % $total][] = $test;
+                $partitions[$i % $total][$test] = ['time' => $median, 'tests' => [$test]];
             }
 
-            $testsToRun = $partitions[$index - 1] ?? [];
+            $selected = $partitions[$index - 1] ?? [];
+
+            self::$selectedUnits = array_keys($selected);
             self::$timeBalanced = true;
             self::$shardsOutdated = $newTests !== [];
+
+            $testsToRun = array_values(array_intersect($tests, $this->testsOf($selected)));
         } else {
             $isInCurrentShard = fn (int $key): bool => $key % $total === ($index - 1);
             $testsToRun = array_values(array_filter($tests, $isInCurrentShard, ARRAY_FILTER_USE_KEY));
@@ -198,9 +255,12 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
      */
     private function buildListTestsCommand(array $arguments, string $testPath): array
     {
-        $filtered = $this->removeParallelArguments($arguments);
+        $filtered = array_filter(
+            $this->removeParallelArguments($arguments),
+            fn (string $argument): bool => ! str_starts_with($argument, '--coverage'),
+        );
 
-        return ['php', ...$filtered, '--test-directory='.$testPath, '--list-tests'];
+        return ['php', ...array_values($filtered), '--test-directory='.$testPath, '--list-tests'];
     }
 
     /**
@@ -274,15 +334,14 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
     {
         self::$passed = $exitCode === 0;
 
-        if (self::$updateShards && self::$passed && ! Parallel::isWorker()) {
+        if (self::$updateShards && (self::$passed || self::$externalTimings !== null) && ! Parallel::isWorker()) {
             self::$collectedTimings = $this->collectTimings();
 
-            $count = self::$knownTests !== null
-                ? count(array_intersect_key(self::$collectedTimings, array_flip(self::$knownTests)))
-                : count(self::$collectedTimings);
+            $count = count($this->unitsToWrite(self::$collectedTimings));
 
             $this->output->writeln(sprintf(
-                '  <fg=gray>Shards:</>   <fg=default>shards.json updated with timings for %d test class%s.</>',
+                '  <fg=gray>Shards:</>   <fg=default>%s updated with timings for %d test class%s.</>',
+                $this->timingsFilename(),
                 $count,
                 $count === 1 ? '' : 'es',
             ));
@@ -310,7 +369,10 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         ));
 
         if (self::$shardsOutdated) {
-            $this->output->writeln('  <fg=yellow;options=bold>WARN</>  <fg=default>The [tests/.pest/shards.json] file is out of date. Run [--update-shards] to update it.</>');
+            $this->output->writeln(sprintf(
+                '  <fg=yellow;options=bold>WARN</>  <fg=default>The [%s] file is out of date. Run [--update-shards] to update it.</>',
+                $this->relativeTimingsPath(),
+            ));
         }
 
         return $exitCode;
@@ -328,7 +390,7 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             return;
         }
 
-        if (! self::$passed) {
+        if (! self::$passed && self::$externalTimings === null) {
             return;
         }
 
@@ -342,10 +404,14 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
     }
 
     /**
-     * @return array<string, float>
+     * @return array<string, float|array{time: float, tests: list<string>}>
      */
     private function collectTimings(): array
     {
+        if (self::$externalTimings !== null) {
+            return self::$externalTimings;
+        }
+
         $runId = Parallel::getGlobal('SHARD_RUN_ID');
 
         if (is_string($runId)) {
@@ -407,15 +473,46 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         return $merged;
     }
 
+    private function timingsFilename(): string
+    {
+        return self::$timingsFilename ?? 'shards.json';
+    }
+
+    private function relativeTimingsPath(): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [TestSuite::getInstance()->testPath, '.pest', $this->timingsFilename()]);
+    }
+
     private function shardsPath(): string
     {
-        $testSuite = TestSuite::getInstance();
-
-        return implode(DIRECTORY_SEPARATOR, [$testSuite->rootPath, $testSuite->testPath, '.pest', 'shards.json']);
+        return TestSuite::getInstance()->rootPath.DIRECTORY_SEPARATOR.$this->relativeTimingsPath();
     }
 
     /**
-     * @return array<string, float>|null
+     * @param  array<string, mixed>  $units
+     * @return array<string, array{time: float, tests: list<string>}>
+     */
+    private function normaliseUnits(array $units): array
+    {
+        $normalised = [];
+
+        foreach ($units as $key => $unit) {
+            if (is_array($unit) && isset($unit['time']) && isset($unit['tests']) && is_array($unit['tests'])) {
+                $normalised[$key] = ['time' => (float) $unit['time'], 'tests' => array_values(array_map(strval(...), $unit['tests']))];
+
+                continue;
+            }
+
+            if (is_float($unit) || is_int($unit)) {
+                $normalised[$key] = ['time' => (float) $unit, 'tests' => [$key]];
+            }
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @return array<string, array{time: float, tests: list<string>}>|null
      */
     private function loadShardsFile(): ?array
     {
@@ -428,50 +525,74 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
         $contents = file_get_contents($path);
 
         if ($contents === false) {
-            throw new InvalidOption('The [tests/.pest/shards.json] file could not be read. Delete it or run [--update-shards] to regenerate.');
+            throw new InvalidOption(sprintf('The [%s] file could not be read. Delete it or run [--update-shards] to regenerate.', $this->relativeTimingsPath()));
         }
 
         $data = json_decode($contents, true);
 
-        if (! is_array($data) || ! isset($data['timings']) || ! is_array($data['timings'])) {
-            throw new InvalidOption('The [tests/.pest/shards.json] file is corrupted. Delete it or run [--update-shards] to regenerate.');
+        $units = null;
+
+        if (is_array($data)) {
+            $units = $data['units'] ?? $data['timings'] ?? null;
         }
 
-        return $data['timings'];
+        if (! is_array($units)) {
+            throw new InvalidOption(sprintf('The [%s] file is corrupted. Delete it or run [--update-shards] to regenerate.', $this->relativeTimingsPath()));
+        }
+
+        if (is_array($data) && isset($data['metadata']) && is_array($data['metadata'])) {
+            self::$metadata = array_filter($data['metadata'], is_scalar(...));
+        }
+
+        return $this->normaliseUnits($units);
     }
 
     /**
-     * @param  list<string>  $tests
-     * @param  array<string, float>  $timings
-     * @return list<list<string>>
+     * @param  array<string, array{time: float, tests: list<string>}>  $units
+     * @return list<string>
      */
-    private function partitionByTime(array $tests, array $timings, int $total): array
+    private function testsOf(array $units): array
     {
-        $knownTimings = array_filter(
-            array_map(fn (string $test): ?float => $timings[$test] ?? null, $tests),
-            fn (?float $t): bool => $t !== null,
-        );
+        $tests = [];
 
-        $median = $knownTimings !== [] ? $this->median(array_values($knownTimings)) : 1.0;
+        foreach ($units as $unit) {
+            foreach ($unit['tests'] as $test) {
+                $tests[$test] = true;
+            }
+        }
 
-        $testsWithTimings = array_map(
-            fn (string $test): array => ['test' => $test, 'time' => $timings[$test] ?? $median],
-            $tests,
-        );
+        return array_keys($tests);
+    }
 
-        usort($testsWithTimings, fn (array $a, array $b): int => $b['time'] <=> $a['time']);
+    /**
+     * @param  array<string, array{time: float, tests: list<string>}>  $units
+     */
+    private function medianTime(array $units): float
+    {
+        $times = array_column($units, 'time');
 
-        /** @var list<list<string>> */
+        return $times === [] ? 1.0 : $this->median($times);
+    }
+
+    /**
+     * @param  array<string, array{time: float, tests: list<string>}>  $units
+     * @return list<array<string, array{time: float, tests: list<string>}>>
+     */
+    private function partitionByTime(array $units, int $total): array
+    {
+        uasort($units, fn (array $a, array $b): int => $b['time'] <=> $a['time']);
+
+        /** @var list<array<string, array{time: float, tests: list<string>}>> */
         $bins = array_fill(0, $total, []);
         /** @var non-empty-list<float> */
         $binTimes = array_fill(0, $total, 0.0);
 
-        foreach ($testsWithTimings as $item) {
+        foreach ($units as $key => $unit) {
             $minIndex = array_search(min($binTimes), $binTimes, strict: true);
             assert(is_int($minIndex));
 
-            $bins[$minIndex][] = $item['test'];
-            $binTimes[$minIndex] += $item['time'];
+            $bins[$minIndex][$key] = $unit;
+            $binTimes[$minIndex] += $unit['time'];
         }
 
         return $bins;
@@ -495,9 +616,32 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
     }
 
     /**
-     * @param  array<string, float>  $timings
+     * @param  array<string, float|array{time: float, tests: list<string>}>  $units
+     * @return array<string, array{time: float, tests: list<string>}>
      */
-    private function writeTimings(array $timings): void
+    private function unitsToWrite(array $units): array
+    {
+        $units = $this->normaliseUnits($units);
+
+        if (self::$knownTests === null) {
+            return $units;
+        }
+
+        $known = self::$knownTests;
+
+        $units = array_filter($units, fn (array $unit): bool => array_intersect($unit['tests'], $known) !== []);
+
+        foreach (array_diff($known, $this->testsOf($units)) as $test) {
+            $units[$test] = ['time' => 0.0, 'tests' => [$test]];
+        }
+
+        return $units;
+    }
+
+    /**
+     * @param  array<string, float|array{time: float, tests: list<string>}>  $units
+     */
+    private function writeTimings(array $units): void
     {
         $path = $this->shardsPath();
 
@@ -506,18 +650,25 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
             mkdir($directory, 0755, true);
         }
 
-        if (self::$knownTests !== null) {
-            $knownSet = array_flip(self::$knownTests);
-            $timings = array_intersect_key($timings, $knownSet);
-        }
+        $bundled = self::$externalTimings !== null && array_filter($units, is_array(...)) !== [];
 
-        ksort($timings);
+        $units = $this->unitsToWrite($units);
 
-        $canonical = self::$knownTests ?? array_keys($timings);
+        ksort($units);
+
+        $canonical = self::$knownTests ?? $this->testsOf($units);
         sort($canonical);
 
+        $payload = $bundled
+            ? ['units' => $units]
+            : ['timings' => array_map(fn (array $unit): float => $unit['time'], $units)];
+
+        if (self::$metadata !== []) {
+            $payload['metadata'] = self::$metadata;
+        }
+
         file_put_contents($path, json_encode([
-            'timings' => $timings,
+            ...$payload,
             'checksum' => md5(implode("\n", $canonical)),
             'updated_at' => date('c'),
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");

--- a/tests/.pest/snapshots/Visual/Help/visual_snapshot_of_help_command_output.snap
+++ b/tests/.pest/snapshots/Visual/Help/visual_snapshot_of_help_command_output.snap
@@ -54,7 +54,7 @@
   EXECUTION OPTIONS:
   --parallel ........................................... Run tests in parallel  
   --update-snapshots  Update snapshots for tests using the "toMatchSnapshot" expectation  
-  --update-shards  Update shards.json with test timing data for time-balanced sharding  
+  --update-shards  Update the shards file with timing data for time-balanced sharding  
   --globals-backup ................. Backup and restore $GLOBALS for each test  
   --static-backup ......... Backup and restore static properties for each test  
   --strict-coverage ................... Be strict about code coverage metadata  

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1836,6 +1836,15 @@
   ✓ addOutput → it displays shard information after test execution
   ✓ addOutput → it uses singular form for single test file
   ✓ addOutput → it returns original exit code when shard is not set
+  ✓ timings file → it reads and writes shards.json until a plugin overrides the filename
+  ✓ timings file → it prefers timings supplied by a plugin over the ones collected from the test run
+  ✓ timings file → it records known tests without supplied timings as zero
+  ✓ timings file → it keeps timings supplied by a plugin even when the test suite did not pass
+  ✓ timings file → it strips coverage arguments when building the list-tests command
+  ✓ units → it treats a bare timing as a unit bundling only its own test class
+  ✓ units → it keeps the test classes a unit bundles together in one shard
+  ✓ units → it collects every test class the given units bundle
+  ✓ units → it writes bundled units, and reads back both shapes
 
    PASS  Tests\Unit\Plugins\Tia\ContentHash
   ✓ of() → it returns false when file does not exist
@@ -2221,4 +2230,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1570 passed (3410 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1579 passed (3423 assertions)

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -2,6 +2,8 @@
 
 use Pest\Exceptions\InvalidOption;
 use Pest\Plugins\Shard;
+use Pest\Subscribers\EnsureShardTimingsAreCollected;
+use Pest\Support\Arr;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -495,5 +497,189 @@ describe('addOutput', function (): void {
 
         expect($exitCode)->toBe(1)
             ->and($outputText)->not->toContain('Shard:');
+    });
+});
+
+describe('timings file', function (): void {
+    afterEach(function (): void {
+        $reflection = new ReflectionClass(Shard::class);
+        $reflection->getProperty('timingsFilename')->setValue(null, null);
+        $reflection->getProperty('externalTimings')->setValue(null, null);
+        $reflection->getProperty('collectedTimings')->setValue(null, null);
+        $reflection->getProperty('knownTests')->setValue(null, null);
+        $reflection->getProperty('updateShards')->setValue(null, false);
+        $reflection->getProperty('shard')->setValue(null, null);
+
+        new ReflectionClass(EnsureShardTimingsAreCollected::class)
+            ->getProperty('timings')
+            ->setValue(null, []);
+    });
+
+    it('reads and writes shards.json until a plugin overrides the filename', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $method = new ReflectionClass($shard)->getMethod('shardsPath');
+
+        expect($method->invoke($shard))->toEndWith('.pest'.DIRECTORY_SEPARATOR.'shards.json');
+
+        Shard::useTimingsFile('mutation-shards.json');
+
+        expect($method->invoke($shard))->toEndWith('.pest'.DIRECTORY_SEPARATOR.'mutation-shards.json');
+    });
+
+    it('prefers timings supplied by a plugin over the ones collected from the test run', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        new ReflectionClass(EnsureShardTimingsAreCollected::class)
+            ->getProperty('timings')
+            ->setValue(null, ['Tests\\Unit\\CollectedTest' => 9.0]);
+
+        Shard::useTimings(['Tests\\Unit\\SuppliedTest' => 1.5]);
+
+        $method = new ReflectionClass($shard)->getMethod('collectTimings');
+
+        expect($method->invoke($shard))->toBe(['Tests\\Unit\\SuppliedTest' => 1.5]);
+    });
+
+    it('records known tests without supplied timings as zero', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $reflection = new ReflectionClass($shard);
+        $reflection->getProperty('knownTests')->setValue(null, ['Tests\\Unit\\MutatedTest', 'Tests\\Unit\\PlainTest']);
+
+        Shard::useTimingsFile('shards-fixture.json');
+        Shard::useTimings($timings = ['Tests\\Unit\\MutatedTest' => 4.5]);
+
+        $path = $reflection->getMethod('shardsPath')->invoke($shard);
+
+        try {
+            $reflection->getMethod('writeTimings')->invoke($shard, $timings);
+
+            expect(json_decode((string) file_get_contents($path), true)['timings'])->toEqual([
+                'Tests\\Unit\\MutatedTest' => 4.5,
+                'Tests\\Unit\\PlainTest' => 0.0,
+            ]);
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    it('keeps timings supplied by a plugin even when the test suite did not pass', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        new ReflectionClass($shard)->getProperty('updateShards')->setValue(null, true);
+
+        Shard::useTimingsFile('mutation-shards.json');
+        Shard::useTimings(['Tests\\Unit\\SuppliedTest' => 1.5]);
+
+        $paratest = Arr::get($_SERVER, 'PARATEST');
+        unset($_SERVER['PARATEST']);
+
+        try {
+            expect($shard->addOutput(1))->toBe(1)
+                ->and($output->fetch())->toContain('mutation-shards.json updated with timings for 1 test class.');
+        } finally {
+            if ($paratest !== null) {
+                $_SERVER['PARATEST'] = $paratest;
+            }
+        }
+    });
+
+    it('strips coverage arguments when building the list-tests command', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $method = new ReflectionClass($shard)->getMethod('buildListTestsCommand');
+
+        $command = $method->invoke($shard, ['bin/pest', '--coverage-php=/tmp/coverage.php', '--update-shards'], 'tests');
+
+        expect($command)->toBe([
+            'php',
+            'bin/pest',
+            '--update-shards',
+            '--test-directory=tests',
+            '--list-tests',
+        ]);
+    });
+});
+
+describe('units', function (): void {
+    afterEach(function (): void {
+        $reflection = new ReflectionClass(Shard::class);
+        $reflection->getProperty('timingsFilename')->setValue(null, null);
+        $reflection->getProperty('externalTimings')->setValue(null, null);
+        $reflection->getProperty('collectedTimings')->setValue(null, null);
+        $reflection->getProperty('knownTests')->setValue(null, null);
+        $reflection->getProperty('selectedUnits')->setValue(null, []);
+    });
+
+    it('treats a bare timing as a unit bundling only its own test class', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $method = new ReflectionClass($shard)->getMethod('normaliseUnits');
+
+        expect($method->invoke($shard, ['Tests\\Unit\\FooTest' => 1.5]))->toBe([
+            'Tests\\Unit\\FooTest' => ['time' => 1.5, 'tests' => ['Tests\\Unit\\FooTest']],
+        ]);
+    });
+
+    it('keeps the test classes a unit bundles together in one shard', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $method = new ReflectionClass($shard)->getMethod('partitionByTime');
+
+        $partitions = $method->invoke($shard, [
+            'app/Heavy.php' => ['time' => 10.0, 'tests' => ['Tests\\Unit\\OneTest', 'Tests\\Unit\\TwoTest']],
+            'app/Light.php' => ['time' => 1.0, 'tests' => ['Tests\\Unit\\ThreeTest']],
+            'app/Medium.php' => ['time' => 4.0, 'tests' => ['Tests\\Unit\\FourTest']],
+        ], 2);
+
+        expect(array_keys($partitions[0]))->toBe(['app/Heavy.php'])
+            ->and(array_keys($partitions[1]))->toBe(['app/Medium.php', 'app/Light.php']);
+    });
+
+    it('collects every test class the given units bundle', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $method = new ReflectionClass($shard)->getMethod('testsOf');
+
+        expect($method->invoke($shard, [
+            'app/One.php' => ['time' => 1.0, 'tests' => ['Tests\\Unit\\FooTest', 'Tests\\Unit\\BarTest']],
+            'app/Two.php' => ['time' => 1.0, 'tests' => ['Tests\\Unit\\BarTest']],
+        ]))->toBe(['Tests\\Unit\\FooTest', 'Tests\\Unit\\BarTest']);
+    });
+
+    it('writes bundled units, and reads back both shapes', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $reflection = new ReflectionClass($shard);
+        $reflection->getProperty('knownTests')->setValue(null, ['Tests\\Unit\\FooTest', 'Tests\\Unit\\BarTest']);
+
+        Shard::useTimingsFile('units-fixture.json');
+        Shard::useTimings($units = [
+            'app/One.php' => ['time' => 4.5, 'tests' => ['Tests\\Unit\\FooTest']],
+        ]);
+
+        $path = $reflection->getMethod('shardsPath')->invoke($shard);
+
+        try {
+            $reflection->getMethod('writeTimings')->invoke($shard, $units);
+
+            expect(json_decode((string) file_get_contents($path), true))->toHaveKey('units')
+                ->and($reflection->getMethod('loadShardsFile')->invoke($shard))->toEqual([
+                    'app/One.php' => ['time' => 4.5, 'tests' => ['Tests\\Unit\\FooTest']],
+                    'Tests\\Unit\\BarTest' => ['time' => 0.0, 'tests' => ['Tests\\Unit\\BarTest']],
+                ]);
+        } finally {
+            @unlink($path);
+        }
     });
 });

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1561 passed (3368 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1561 passed (3368 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
`--shard` splits test classes and weighs each one on its own. That holds while a test class is the whole unit of work, but not when the work a shard has to do spans several of them: splitting those classes across shards duplicates the work and leaves every shard with a partial result.

Mutation testing is the case that needs this. A mutation belongs to a source file, several test classes can cover that file, so the file is the unit and its covering test classes have to travel together. Related to #1691.

## What changed

`Shard::useTimings()` accepts a richer value. Instead of a duration per test class, a unit may be `['time' => float, 'tests' => list<string>]` under any key. A bare float still means a test class bundling only itself, so an existing `shards.json` and the behaviour of a plain `--update-shards` run are unchanged.

LPT partitioning now runs over units, and the `--filter` a shard receives is the union of the test classes its units bundle. `Shard::selectedUnits()` exposes the keys allocated to the current shard, so a plugin can narrow the work it generates to match.

`Shard::useTimings()` also takes optional metadata, stored next to the units and read back through `Shard::metadata()`. That lets a plugin carry a reference value from the unsharded run that produces the file into the sharded runs that consume it.

Three smaller fixes ride along. The timings file is written when a plugin supplied the units and the run exits non-zero, so a job whose only purpose is to record timings is not lost to an unrelated failure. The count reported by `--update-shards` now matches the number of entries actually written. The `--list-tests` subprocess no longer inherits `--coverage` arguments.

## Testing

`tests/Unit/Plugins/Shard.php` covers unit normalisation, partitioning that keeps a bundle intact, both file shapes on read and write, precedence of plugin-supplied units, and the zero entries written for test classes that produced no work of their own.

## Follow-ups

The plugin side that consumes this API lands in pestphp/pest-plugin-mutate#40. Together with #40 this closes the request in #1691.

