### PR TITLE
fix: skip TIA when mutation testing consumes the coverage report

### DIFF
--- a/src/Plugins/Tia.php
+++ b/src/Plugins/Tia.php
@@ -129,6 +129,8 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
         '--coverage-text', '--coverage-xml',
     ];
 
+    private const string MUTATE_OPTION = '--mutate';
+
     /** @var list<string> */
     private const array PARTIAL_SELECTION_FLAGS = [
         '--filter', '--exclude-filter', '--group', '--exclude-group',
@@ -504,6 +506,13 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
 
             $this->forceRefetch = false;
             $this->filteredMode = false;
+
+            return $arguments;
+        }
+
+        if (! $isWorker && $enabled && $this->hasArgument(self::MUTATE_OPTION, $this->originalArguments)) {
+            $this->requestWorkerResults();
+            $this->emitMutationRecordSkipped();
 
             return $arguments;
         }
@@ -1284,6 +1293,14 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
 
         $this->renderChild('Running in TIA mode, however TIA is skipped as an active coverage report narrows the edges it could record.');
         $this->renderChild('Record the baseline with a plain --tia run first; coverage runs then reuse it.');
+    }
+
+    private function emitMutationRecordSkipped(): void
+    {
+        $this->output->writeln('');
+
+        $this->renderChild('TIA is skipped — mutation testing needs the coverage report of a real run.');
+        $this->renderChild('Drop --mutate to use TIA.');
     }
 
     /**

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1607,6 +1607,10 @@
   ✓ a test edit narrows to the affected file and replays the rest
   ✓ a parallel run merges worker results into the parent baseline
 
+   PASS  Tests\Features\Tia\CoverageConsumer
+  ✓ a mutation run under --tia runs the tests instead of replaying them
+  ✓ a mutation run under --tia does not purge the graph it cannot rebuild
+
    PASS  Tests\Features\Tia\CoveragePiggyback
   ✓ a coverage report does not found a dependency graph with dataset "pest coverage"
   ✓ a coverage report does not found a dependency graph with dataset "phpunit coverage report"
@@ -2435,4 +2439,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 34 skipped, 1760 passed (3983 assertions)
+  Tests:    1 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 34 skipped, 1762 passed (3988 assertions)

--- a/tests/Features/Tia/CoverageConsumer.php
+++ b/tests/Features/Tia/CoverageConsumer.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Fixtures\Tia\Project;
+
+afterEach(function (): void {
+    Project::destroyAll();
+});
+
+test('a mutation run under --tia runs the tests instead of replaying them', function (): void {
+    $project = Project::make('master');
+    $project->seed('master');
+
+    $result = $project->pest('--tia', '--mutate', '--everything', '--min=100');
+
+    expect($result->output)->toContain('TIA is skipped')
+        ->and($result->tally())->toContain(Project::TOTAL_TESTS.' passed')
+        ->and($result->tally())->not->toContain('replayed');
+})->skipOnWindows();
+
+test('a mutation run under --tia does not purge the graph it cannot rebuild', function (): void {
+    $project = Project::make('master');
+    $project->seed('master');
+
+    $project->pest('--tia', '--mutate', '--fresh', '--everything', '--min=100');
+    $delta = $project->delta();
+
+    expect($project->graphExists())->toBeTrue()
+        ->and($delta->isHardSuppressed())->toBeTrue($delta->summary());
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

`Mutate` runs before `Tia` in the plugin chain. It pops `--mutate` and appends `--coverage-php=<path>`. `Tia` reads raw argv, so it sees neither flag, never sets `piggybackCoverage`, and replays instead of running. The report is written but empty, so every mutant escapes.

```
argv: --tia --mutate     Mutate       --tia --coverage-php=...     Tia
                     ------------->                            ---------> raw argv has no --mutate
                     pops --mutate                                        piggyback OFF -> replay
                     adds --coverage-php                                  report written, EMPTY
```

`--tia --mutate` now skips TIA and runs the suite, so the report is real. Also fixes `--tia --mutate --fresh` purging the graph it then never rebuilt.

### Related:

Closes #1797
