### PR TITLE
fix: static analysis of methods chained on `describe()`

### DIFF
--- a/src/PendingCalls/DescribeCall.php
+++ b/src/PendingCalls/DescribeCall.php
@@ -10,6 +10,8 @@ use Pest\TestSuite;
 
 /**
  * @internal
+ *
+ * @mixin TestCall
  */
 final class DescribeCall
 {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

On PHPStan level 2, `describe('...', fn () => ...)->skip(...)` and `->with(...)` are reported as calls to undefined methods on `Pest\PendingCalls\DescribeCall`, even though both work at runtime.

`DescribeCall::__call()` forwards to `BeforeEachCall`, which is already annotated with `@mixin TestCall`, so the methods exist for real, there is just nothing telling static analysis about them one level up. This adds the same annotation to `DescribeCall`.

### Related:

Fixes #1837