### PR TITLE
fix: reject a wrong-cased Tia page directory on case-insensitive filesystems

### DIFF
--- a/bin/pest-tia-vite-deps.mjs
+++ b/bin/pest-tia-vite-deps.mjs
@@ -190,6 +190,24 @@ async function listPageFiles(pagesDir) {
   return out
 }
 
+// `existsSync()` ignores casing on APFS and NTFS, and on a macOS bind mount seen from
+// inside a Linux container, so the `resources/js/Pages` candidate resolves in a project
+// whose directory is really `resources/js/pages`. Every page path is derived from the
+// directory we accept here, so the wrong casing would silently detach the pages tree from
+// the paths the PHP side reports.
+export async function matchesDiskCasing(projectRoot, rel) {
+  let current = projectRoot
+
+  for (const segment of rel.split('/')) {
+    let entries
+    try { entries = await readdir(current) } catch { return false }
+    if (!entries.includes(segment)) return false
+    current = join(current, segment)
+  }
+
+  return true
+}
+
 async function discoverPagesDir() {
   const override = process.env.TIA_VITE_PAGES_DIR
   if (override && override.length > 0) {
@@ -199,6 +217,7 @@ async function discoverPagesDir() {
   for (const rel of PAGE_DIR_CANDIDATES) {
     const abs = resolve(PROJECT_ROOT, rel)
     if (!existsSync(abs)) continue
+    if (!(await matchesDiskCasing(PROJECT_ROOT, rel))) continue
     const files = await listPageFiles(abs)
     if (files.length > 0) return abs
   }

--- a/src/Plugins/Tia/JsModuleGraph.php
+++ b/src/Plugins/Tia/JsModuleGraph.php
@@ -85,12 +85,37 @@ final class JsModuleGraph
                 continue;
             }
 
+            if (! self::matchesDiskCasing($projectRoot, $rel)) {
+                continue;
+            }
+
             if (self::dirHasPageFile($abs)) {
                 return $abs;
             }
         }
 
         return null;
+    }
+
+    private static function matchesDiskCasing(string $projectRoot, string $relative): bool
+    {
+        $current = rtrim($projectRoot, DIRECTORY_SEPARATOR);
+
+        foreach (explode('/', $relative) as $segment) {
+            $entries = @scandir($current);
+
+            if ($entries === false) {
+                return false;
+            }
+
+            if (! in_array($segment, $entries, true)) {
+                return false;
+            }
+
+            $current .= DIRECTORY_SEPARATOR.$segment;
+        }
+
+        return true;
     }
 
     private static function dirHasPageFile(string $dir): bool

--- a/tests/Unit/Plugins/Tia/JsModuleGraph.php
+++ b/tests/Unit/Plugins/Tia/JsModuleGraph.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\JsModuleGraph;
+
+function tiaJsModuleGraphCall(string $method, mixed ...$arguments): mixed
+{
+    return new ReflectionMethod(JsModuleGraph::class, $method)->invoke(null, ...$arguments);
+}
+
+describe('page directory discovery', function (): void {
+    beforeEach(function (): void {
+        $this->projectRoot = sys_get_temp_dir().'/pest-tia-js-module-graph-'.bin2hex(random_bytes(4));
+        mkdir($this->projectRoot.'/resources/js/pages', 0755, true);
+        file_put_contents($this->projectRoot.'/resources/js/pages/Dashboard.vue', "<template>ok</template>\n");
+    });
+
+    afterEach(function (): void {
+        @unlink($this->projectRoot.'/resources/js/pages/Dashboard.vue');
+        @rmdir($this->projectRoot.'/resources/js/pages');
+        @rmdir($this->projectRoot.'/resources/js');
+        @rmdir($this->projectRoot.'/resources');
+        @rmdir($this->projectRoot);
+    });
+
+    it('resolves the pages directory with the casing it has on disk', function (): void {
+        $expected = $this->projectRoot
+            .DIRECTORY_SEPARATOR.'resources'
+            .DIRECTORY_SEPARATOR.'js'
+            .DIRECTORY_SEPARATOR.'pages';
+
+        expect(tiaJsModuleGraphCall('firstExistingPagesDir', $this->projectRoot))->toBe($expected);
+    });
+
+    it('rejects a candidate whose own casing differs from disk', function (): void {
+        expect(tiaJsModuleGraphCall('matchesDiskCasing', $this->projectRoot, 'resources/js/pages'))->toBeTrue()
+            ->and(tiaJsModuleGraphCall('matchesDiskCasing', $this->projectRoot, 'resources/js/Pages'))->toBeFalse();
+    });
+
+    it('rejects a candidate whose parent segments differ from disk', function (): void {
+        expect(tiaJsModuleGraphCall('matchesDiskCasing', $this->projectRoot, 'Resources/js/pages'))->toBeFalse();
+    });
+
+    it('rejects a candidate that is absent from disk', function (): void {
+        expect(tiaJsModuleGraphCall('matchesDiskCasing', $this->projectRoot, 'assets/js/pages'))->toBeFalse();
+    });
+});

--- a/tests/Unit/Plugins/Tia/ViteDepsHelper.php
+++ b/tests/Unit/Plugins/Tia/ViteDepsHelper.php
@@ -357,6 +357,49 @@ function tiaViteAliasResults(): array
     return $cache = ['roots' => $roots, 'aliases' => $aliases];
 }
 
+/**
+ * @return array<string, bool>
+ */
+function tiaDiskCasingResults(): array
+{
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+
+    $root = sys_get_temp_dir().'/pest-tia-casing-'.bin2hex(random_bytes(6));
+    mkdir($root.'/resources/js/pages', 0755, true);
+    file_put_contents($root.'/resources/js/pages/Dashboard.vue', "<template>ok</template>\n");
+
+    $helper = str_replace('\\', '/', tiaViteHelperPath());
+    $normalized = str_replace('\\', '/', $root);
+
+    $script = <<<JS
+    import { matchesDiskCasing } from '{$helper}'
+    const out = {
+      exact: await matchesDiskCasing('{$normalized}', 'resources/js/pages'),
+      'wrong-leaf': await matchesDiskCasing('{$normalized}', 'resources/js/Pages'),
+      'wrong-parent': await matchesDiskCasing('{$normalized}', 'Resources/js/pages'),
+      absent: await matchesDiskCasing('{$normalized}', 'assets/js/pages'),
+    }
+    process.stdout.write(JSON.stringify(out))
+    JS;
+
+    $process = new Process(['node', '--input-type=module', '-e', $script]);
+    $process->mustRun();
+
+    /** @var array<string, bool> $results */
+    $results = json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR);
+
+    @unlink($root.'/resources/js/pages/Dashboard.vue');
+    @rmdir($root.'/resources/js/pages');
+    @rmdir($root.'/resources/js');
+    @rmdir($root.'/resources');
+    @rmdir($root);
+
+    return $cache = $results;
+}
+
 beforeEach(function (): void {
     if ((new ExecutableFinder)->find('node') === null) {
         $this->markTestSkipped('node is not available.');
@@ -409,3 +452,12 @@ it('builds the expected alias map from a vite config', function (string $name): 
 
     expect($results['aliases'][$name])->toEqual($expected);
 })->with(array_keys(tiaViteAliasFixtures()));
+
+it('accepts a page directory candidate only when it matches the casing on disk', function (): void {
+    $results = tiaDiskCasingResults();
+
+    expect($results['exact'])->toBeTrue()
+        ->and($results['wrong-leaf'])->toBeFalse()
+        ->and($results['wrong-parent'])->toBeFalse()
+        ->and($results['absent'])->toBeFalse();
+});


### PR DESCRIPTION
## The bug

`JsModuleGraph::PAGE_DIR_CANDIDATES` probes `resources/js/Pages` before `resources/js/pages`, and the probe is a bare `is_dir()`. `is_dir()` ignores casing on APFS and NTFS — and, less obviously, on a macOS bind mount seen from inside a Linux container, which is what Docker Desktop and ddev give you by default. So in a project whose real directory is the lowercase `resources/js/pages` (the Laravel 12 starter-kit layout), the capital-P candidate resolves and is accepted.

That breaks a `--tia` run in two ways.

**1. The run dies after the summary and the graph is never persisted.**

`dirHasPageFile()` iterates the wrong-cased path, which populates the container's dentry cache under `Pages`. `fingerprint()` then walks `dirname($pagesDir)` = `resources/js`, gets the real lowercase `pages` back from `readdir()`, and `opendir()` on it hits the case-aliased entry and fails:

```
Tests:    914 passed (3632 assertions)

   UnexpectedValueException
  RecursiveDirectoryIterator::__construct(/var/www/html/resources/js/pages): Failed to open directory: No such file or directory
  at vendor/pestphp/pest/src/Plugins/Tia/JsModuleGraph.php:277
```

Exit code 1, and — the part that actually costs the user — the graph never lands, so every subsequent run reports `fresh graph` and Tia never replays anything. The directory obviously exists, which sends you looking in the wrong place.

**2. `bin/pest-tia-vite-deps.mjs` silently under-selects.**

`discoverPagesDir()` runs the same capital-first probe with `existsSync`, so `pagesDir` comes back wrong-cased and every page path derives from it via `resolve(dir, entry.name)`. Deps reached through the `@` alias resolve lowercase and still match, but anything imported *relatively* from inside a page keeps the wrong casing and never joins with the paths reported for changed files. Those edges quietly disappear and Tia selects too few tests. Fixing only the crash would leave this in place, so both probes are fixed here.

`TIA_VITE_PAGES_DIR` is not a workaround for this: `firstExistingPagesDir()` never reads it.

## The fix

After `is_dir()` / `existsSync()` passes, require each segment of the candidate to appear in its parent directory with exactly the casing the candidate asks for (`scandir()` / `readdir()` are case-exact on every filesystem). The wrong-cased candidate is then skipped and the loop falls through to the real directory.

The `TIA_VITE_PAGES_DIR` override stays exempt — that casing was stated explicitly.

Behaviour on case-sensitive filesystems is unchanged: `is_dir()` was already exact there, and the new check agrees with it.

## Tests

`tests/Unit/Plugins/Tia/JsModuleGraph.php` (new) and one case added to `tests/Unit/Plugins/Tia/ViteDepsHelper.php` for the Node side. The `matchesDiskCasing` assertions are filesystem-independent, so they hold the contract on Linux CI too.

One caveat worth stating plainly: `it('resolves the pages directory with the casing it has on disk')` is the test that actually reproduces the bug, and it can only *fail* on a case-insensitive filesystem — on Linux CI it passes both before and after. On macOS, against `5.x` without this patch, it fails with:

```
-'/…/resources/js/pages'
+'/…/resources/js/Pages'
```

## Verification

- `vendor/bin/pint --test --parallel`, `rector --dry-run`, `phpstan` — clean; type coverage 100%.
- `pest --exclude-group=integration` — 1548 passed.
- `pest --group=tia` — 198 passed.
- Reproduced and fixed on a real project: a Laravel 13 + Inertia app with lowercase `resources/js/pages`, on macOS under ddev with `performance_mode: none`. Inside the container, `is_dir('…/resources/js/Pages')` is `true` while `scandir` reports `pages`, and the same check against a container-native path (`/tmp`) is `false` — so it is the mount, not PHP. Before the patch `firstExistingPagesDir()` returned `…/resources/js/Pages` and the suite exited 1 with the exception above; after it, it returns `…/resources/js/pages`.
