### PR TITLE
fix: fail missing snapshots in CI

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -734,6 +734,12 @@ final class Expectation
         };
 
         if (! $snapshots->has()) {
+            if (! Snapshot::shouldCreateMissingSnapshots()) {
+                $filename = $snapshots->filename();
+
+                Assert::fail($message === '' ? "Snapshot is missing at [$filename]. Run Pest with --update-snapshots to create it." : $message);
+            }
+
             $filename = $snapshots->save($string);
 
             TestSuite::getInstance()->registerSnapshotChange("Snapshot created at [$filename]");

--- a/src/Plugins/Snapshot.php
+++ b/src/Plugins/Snapshot.php
@@ -17,6 +17,36 @@ final class Snapshot implements HandlesArguments
     public static bool $updateSnapshots = false;
 
     /**
+     * @var list<string>
+     */
+    private const array CI_ENVIRONMENT_VARIABLES = [
+        'CI',
+        'GITHUB_ACTIONS',
+        'GITLAB_CI',
+        'CIRCLECI',
+        'TRAVIS',
+        'APPVEYOR',
+        'BITBUCKET_BUILD_NUMBER',
+        'BUILDKITE',
+        'TEAMCITY_VERSION',
+        'JENKINS_URL',
+        'SYSTEM_COLLECTIONURI',
+        'CI_NAME',
+        'TASKCLUSTER_ROOT_URL',
+        'DRONE',
+        'WERCKER',
+        'NEVERCODE',
+        'SEMAPHORE',
+        'NETLIFY',
+        'NOW_BUILDER',
+    ];
+
+    public static function shouldCreateMissingSnapshots(): bool
+    {
+        return self::$updateSnapshots || ! self::runningOnCI();
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function handleArguments(array $arguments): array
@@ -118,5 +148,20 @@ final class Snapshot implements HandlesArguments
         }
 
         return true;
+    }
+
+    private static function runningOnCI(): bool
+    {
+        if (Environment::name() === Environment::CI) {
+            return true;
+        }
+
+        foreach (self::CI_ENVIRONMENT_VARIABLES as $environmentVariable) {
+            if (getenv($environmentVariable) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Repositories/SnapshotRepository.php
+++ b/src/Repositories/SnapshotRepository.php
@@ -56,7 +56,12 @@ final class SnapshotRepository
 
         file_put_contents($snapshotFilename, $snapshot);
 
-        return str_replace(dirname($this->testsPath).'/', '', $snapshotFilename);
+        return $this->filename();
+    }
+
+    public function filename(): string
+    {
+        return str_replace(dirname($this->testsPath).'/', '', $this->getSnapshotFilename());
     }
 
     public function flush(): void


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Prevent snapshot assertions from silently creating missing snapshots during CI runs unless --update-snapshots is enabled.
