### PR TITLE
fix(tia): persist state on detached HEAD

### DIFF
--- a/src/Plugins/Snapshot.php
+++ b/src/Plugins/Snapshot.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Plugins;
 
 use Pest\Contracts\Plugins\HandlesArguments;
+use Pest\Support\Ci;
 use Pest\TestSuite;
 
 /**
@@ -16,34 +17,9 @@ final class Snapshot implements HandlesArguments
 
     public static bool $updateSnapshots = false;
 
-    /**
-     * @var list<string>
-     */
-    private const array CI_ENVIRONMENT_VARIABLES = [
-        'CI',
-        'GITHUB_ACTIONS',
-        'GITLAB_CI',
-        'CIRCLECI',
-        'TRAVIS',
-        'APPVEYOR',
-        'BITBUCKET_BUILD_NUMBER',
-        'BUILDKITE',
-        'TEAMCITY_VERSION',
-        'JENKINS_URL',
-        'SYSTEM_COLLECTIONURI',
-        'CI_NAME',
-        'TASKCLUSTER_ROOT_URL',
-        'DRONE',
-        'WERCKER',
-        'NEVERCODE',
-        'SEMAPHORE',
-        'NETLIFY',
-        'NOW_BUILDER',
-    ];
-
     public static function shouldCreateMissingSnapshots(): bool
     {
-        return self::$updateSnapshots || ! self::runningOnCI();
+        return self::$updateSnapshots || ! Ci::isRunning();
     }
 
     /**
@@ -148,14 +124,5 @@ final class Snapshot implements HandlesArguments
         }
 
         return true;
-    }
-
-    private static function runningOnCI(): bool
-    {
-        if (Environment::name() === Environment::CI) {
-            return true;
-        }
-
-        return array_any(self::CI_ENVIRONMENT_VARIABLES, fn (string $environmentVariable): bool => getenv($environmentVariable) !== false);
     }
 }

--- a/src/Plugins/Tia.php
+++ b/src/Plugins/Tia.php
@@ -20,7 +20,7 @@ use Pest\Panic;
 use Pest\Plugins\Concerns\HandleArguments;
 use Pest\Plugins\Tia\BaselineSync;
 use Pest\Plugins\Tia\ChangedFiles;
-use Pest\Plugins\Tia\CiDefaultBranch;
+use Pest\Plugins\Tia\CiBranch;
 use Pest\Plugins\Tia\Contracts\State;
 use Pest\Plugins\Tia\CoverageCollector;
 use Pest\Plugins\Tia\Fingerprint;
@@ -196,8 +196,6 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
 
     private bool $unreadableGraphReported = false;
 
-    private bool $detachedHead = false;
-
     private bool $graphUnreachable = false;
 
     private bool $fullSuiteFallbackRan = false;
@@ -283,19 +281,11 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
 
     private function deleteState(string $key): bool
     {
-        if ($this->detachedHead) {
-            return false;
-        }
-
         return $this->state->delete($key);
     }
 
     private function saveGraph(Graph $graph): bool
     {
-        if ($this->detachedHead) {
-            return true;
-        }
-
         $json = $graph->encode();
 
         if ($json === null) {
@@ -851,7 +841,7 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
         $fingerprint = Fingerprint::compute($projectRoot);
         $this->startFingerprint = $fingerprint;
 
-        if ($forceRebuild && ! $this->detachedHead) {
+        if ($forceRebuild) {
             Storage::purge($projectRoot);
         }
 
@@ -1950,10 +1940,17 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
 
         Parallel::setGlobal(self::FALLBACK_BRANCH_GLOBAL, $this->fallbackBranch);
 
-        $currentBranch = $changedFiles->currentBranch();
+        $this->branch = $changedFiles->currentBranch()
+            ?? CiBranch::detectCurrent()
+            ?? $this->workspaceBranch($projectRoot);
+    }
 
-        $this->detachedHead = $currentBranch === null;
-        $this->branch = $currentBranch ?? $this->fallbackBranch;
+    private function workspaceBranch(string $projectRoot): string
+    {
+        $realProjectRoot = realpath($projectRoot);
+        $hash = hash('sha256', $realProjectRoot === false ? $projectRoot : $realProjectRoot);
+
+        return Graph::WORKSPACE_BRANCH_PREFIX.substr($hash, 0, 16);
     }
 
     private function resolveFallbackBranch(ChangedFiles $changedFiles): ?string
@@ -1965,7 +1962,7 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
         }
 
         return $this->watchPatterns->defaultBranch()
-            ?? CiDefaultBranch::detect()
+            ?? CiBranch::detectDefault()
             ?? $changedFiles->defaultBranch()
             ?? $this->soleRecordedBranch();
     }
@@ -1978,7 +1975,10 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
             return null;
         }
 
-        $branches = Graph::branchesIn($json);
+        $branches = array_values(array_filter(
+            Graph::branchesIn($json),
+            fn (string $branch): bool => ! str_starts_with($branch, Graph::WORKSPACE_BRANCH_PREFIX),
+        ));
 
         return count($branches) === 1 ? $branches[0] : null;
     }

--- a/src/Plugins/Tia/BaselineSync.php
+++ b/src/Plugins/Tia/BaselineSync.php
@@ -8,6 +8,7 @@ use Pest\Exceptions\BaselineFetchFailed;
 use Pest\Panic;
 use Pest\Plugins\Tia;
 use Pest\Plugins\Tia\Contracts\State;
+use Pest\Support\Ci;
 use Pest\Support\View;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
@@ -164,7 +165,7 @@ final readonly class BaselineSync
 
     private function emitPublishInstructions(): void
     {
-        if ($this->isCi()) {
+        if (Ci::isRunning()) {
             $this->renderBadge('INFO', 'No baseline yet — this run will produce one.');
 
             return;
@@ -172,13 +173,6 @@ final readonly class BaselineSync
 
         $this->renderBadge('WARN', 'No baseline published yet — recording locally.');
         $this->renderChild('See https://pestphp.com/docs/tia for how to publish one from CI.');
-    }
-
-    private function isCi(): bool
-    {
-        return getenv('GITHUB_ACTIONS') === 'true'
-            || getenv('GITLAB_CI') === 'true'
-            || getenv('CIRCLECI') === 'true';
     }
 
     private function detectGitHubRepo(string $projectRoot): ?string

--- a/src/Plugins/Tia/CiBranch.php
+++ b/src/Plugins/Tia/CiBranch.php
@@ -9,7 +9,7 @@ use Pest\Plugins\Tia\Contracts\Ci;
 /**
  * @internal
  */
-final class CiDefaultBranch
+final class CiBranch
 {
     /**
      * @var array<int, class-string<Ci>>
@@ -19,7 +19,20 @@ final class CiDefaultBranch
         Cis\GitHub::class,
     ];
 
-    public static function detect(): ?string
+    public static function detectCurrent(): ?string
+    {
+        foreach (self::CIS as $class) {
+            $branch = (new $class)->currentBranch();
+
+            if ($branch !== null) {
+                return $branch;
+            }
+        }
+
+        return null;
+    }
+
+    public static function detectDefault(): ?string
     {
         foreach (self::CIS as $class) {
             $branch = (new $class)->defaultBranch();

--- a/src/Plugins/Tia/Cis/GitHub.php
+++ b/src/Plugins/Tia/Cis/GitHub.php
@@ -14,6 +14,11 @@ final readonly class GitHub implements Ci
 {
     use ReadsEnvironment;
 
+    public function currentBranch(): ?string
+    {
+        return $this->environment('GITHUB_REF_NAME');
+    }
+
     public function defaultBranch(): ?string
     {
         $path = $this->environment('GITHUB_EVENT_PATH');

--- a/src/Plugins/Tia/Cis/GitLab.php
+++ b/src/Plugins/Tia/Cis/GitLab.php
@@ -14,6 +14,11 @@ final readonly class GitLab implements Ci
 {
     use ReadsEnvironment;
 
+    public function currentBranch(): ?string
+    {
+        return $this->environment('CI_COMMIT_BRANCH');
+    }
+
     public function defaultBranch(): ?string
     {
         return $this->environment('CI_DEFAULT_BRANCH');

--- a/src/Plugins/Tia/Contracts/Ci.php
+++ b/src/Plugins/Tia/Contracts/Ci.php
@@ -9,5 +9,7 @@ namespace Pest\Plugins\Tia\Contracts;
  */
 interface Ci
 {
+    public function currentBranch(): ?string;
+
     public function defaultBranch(): ?string;
 }

--- a/src/Plugins/Tia/Graph.php
+++ b/src/Plugins/Tia/Graph.php
@@ -18,6 +18,8 @@ use PHPUnit\TextUI\Configuration\Registry;
  */
 final class Graph
 {
+    public const string WORKSPACE_BRANCH_PREFIX = '@workspace:';
+
     /**
      * @var array<string, string>
      */
@@ -1632,6 +1634,10 @@ final class Graph
         $survivors = array_fill_keys($keep, true);
 
         foreach (array_keys($this->baselines) as $branch) {
+            if (str_starts_with($branch, self::WORKSPACE_BRANCH_PREFIX)) {
+                continue;
+            }
+
             if (! isset($survivors[$branch])) {
                 unset($this->baselines[$branch]);
             }

--- a/src/Support/Ci.php
+++ b/src/Support/Ci.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Support;
+
+use Pest\Plugins\Environment;
+
+/**
+ * @internal
+ */
+final class Ci
+{
+    /**
+     * @var list<string>
+     */
+    private const array ENVIRONMENT_VARIABLES = [
+        'CI',
+        'GITHUB_ACTIONS',
+        'GITLAB_CI',
+        'CIRCLECI',
+        'TRAVIS',
+        'APPVEYOR',
+        'BITBUCKET_BUILD_NUMBER',
+        'BUILDKITE',
+        'TEAMCITY_VERSION',
+        'JENKINS_URL',
+        'SYSTEM_COLLECTIONURI',
+        'CI_NAME',
+        'TASKCLUSTER_ROOT_URL',
+        'DRONE',
+        'WERCKER',
+        'NEVERCODE',
+        'SEMAPHORE',
+        'NETLIFY',
+        'NOW_BUILDER',
+    ];
+
+    public static function isRunning(): bool
+    {
+        if (Environment::name() === Environment::CI) {
+            return true;
+        }
+
+        return array_any(self::ENVIRONMENT_VARIABLES, fn (string $env): bool => getenv($env) !== false);
+    }
+}

--- a/tests/Features/Tia/BranchShapes.php
+++ b/tests/Features/Tia/BranchShapes.php
@@ -115,7 +115,7 @@ test('a narrowed run does not reclaim anything', function (): void {
         ->and($delta->isResultsOnly())->toBeTrue($delta->summary());
 })->skipOnWindows();
 
-test('a detached HEAD does not reclaim anything either', function (): void {
+test('a detached HEAD reclaims missing branches without changing the default baseline', function (): void {
     $project = Project::make('master');
     $project->seed('master');
 
@@ -130,8 +130,11 @@ test('a detached HEAD does not reclaim anything either', function (): void {
     $project->pest('--tia');
     $delta = $project->delta();
 
-    expect($project->branchKeys())->toBe(['master', 'feature-x'])
-        ->and($delta->isHardSuppressed())->toBeTrue($delta->summary());
+    expect($project->branchKeys())->toHaveCount(2)
+        ->and($project->branchKeys())->toContain('master')
+        ->and($project->branchKeys())->not->toContain('feature-x')
+        ->and($delta->baselineUntouched('master'))->toBeTrue($delta->summary())
+        ->and($delta->structureMoved())->toBeTrue($delta->summary());
 })->skipOnWindows();
 
 test('the default branch baseline survives every branch that comes and goes', function (): void {

--- a/tests/Features/Tia/DefaultBranchWriteTier.php
+++ b/tests/Features/Tia/DefaultBranchWriteTier.php
@@ -104,17 +104,20 @@ test('filtered mode finds nothing to do on the default branch itself', function 
         ->and($delta->isHardSuppressed())->toBeTrue($delta->summary());
 })->skipOnWindows();
 
-test('a detached HEAD replays without minting a branch key', function (): void {
+test('a detached HEAD replays through a workspace baseline', function (): void {
     $project = Project::make('master');
     $project->seed('master');
 
     $project->git()->detach();
 
     $result = $project->pest('--tia');
+    $hasWorkspaceBranch = array_any($project->branchKeys(), fn (string $branch): bool => str_starts_with($branch, '@workspace:'));
 
     expect($result->replayed())->toBe(Project::TOTAL_TESTS, $result->describe())
         ->and($result->uncached())->toBe(0, $result->describe())
-        ->and($project->branchKeys())->toBe(['master']);
+        ->and($project->branchKeys())->toHaveCount(2)
+        ->and($project->branchKeys())->toContain('master')
+        ->and($hasWorkspaceBranch)->toBeTrue();
 })->skipOnWindows();
 
 test('a detached HEAD does not write into the default branch baseline', function (array $arguments): void {
@@ -125,9 +128,13 @@ test('a detached HEAD does not write into the default branch baseline', function
     $project->pest(...$arguments);
 
     $delta = $project->delta();
+    $hasWorkspaceBranch = array_any($project->branchKeys(), fn (string $branch): bool => str_starts_with($branch, '@workspace:'));
 
     expect($delta->baselineUntouched('master'))->toBeTrue($delta->summary())
-        ->and($project->branchKeys())->toBe(['master']);
+        ->and($project->branchKeys())->toHaveCount(2)
+        ->and($project->branchKeys())->toContain('master')
+        ->and($hasWorkspaceBranch)->toBeTrue()
+        ->and($delta->writtenCount())->toBe(0, $delta->summary());
 })->with([
     'sequential' => [['--filter=adds two numbers']],
     'parallel' => [['--parallel', '--processes=2', '--filter=adds two numbers']],
@@ -146,6 +153,26 @@ test('the branch that ran gets its own key and the default branch keeps its base
         ->and($delta->baselineUntouched('master'))->toBeTrue($delta->summary())
         ->and($delta->writtenCount())->toBe(0, $delta->summary());
 })->skipOnWindows();
+
+test('a detached CI branch writes into its branch baseline', function (array $environment): void {
+    $project = Project::make('master');
+    $project->seed('master');
+
+    $project->git()->detach();
+    $project->pestWithEnvironment($project->path(), $environment, '--filter=adds two numbers');
+
+    expect($project->branchKeys())->toBe(['master', 'feature-x'])
+        ->and(array_any($project->branchKeys(), fn (string $branch): bool => str_starts_with($branch, '@workspace:')))->toBeFalse();
+})->with([
+    'GitLab' => [[
+        'GITLAB_CI' => 'true',
+        'CI_COMMIT_BRANCH' => 'feature-x',
+    ]],
+    'GitHub' => [[
+        'GITHUB_ACTIONS' => 'true',
+        'GITHUB_REF_NAME' => 'feature-x',
+    ]],
+])->skipOnWindows();
 
 test('the fallback reaches parallel workers', function (): void {
     $project = Project::make('master');

--- a/tests/Features/Tia/StateReclamation.php
+++ b/tests/Features/Tia/StateReclamation.php
@@ -8,7 +8,7 @@ afterEach(function (): void {
     Project::destroyAll();
 });
 
-test('a detached HEAD does not purge the graph on structural drift', function (array $arguments): void {
+test('a detached HEAD can rebuild the graph on structural drift', function (array $arguments): void {
     $project = Project::make('master');
     $project->seed('master');
 
@@ -25,10 +25,10 @@ test('a detached HEAD does not purge the graph on structural drift', function (a
 
     expect($result->exitCode)->toBe(0, $result->describe())
         ->and($project->graphExists())->toBeTrue('the detached run deleted graph.json')
-        ->and($delta->isHardSuppressed())->toBeTrue($delta->summary());
+        ->and($delta->structureMoved())->toBeTrue($delta->summary());
 })->with(Project::SEQUENTIAL_AND_PARALLEL)->skipOnWindows();
 
-test('a detached HEAD does not purge the graph with --fresh either', function (array $arguments): void {
+test('a detached HEAD can rebuild the graph with --fresh', function (array $arguments): void {
     $project = Project::make('master');
     $project->seed('master');
 
@@ -39,10 +39,10 @@ test('a detached HEAD does not purge the graph with --fresh either', function (a
 
     expect($result->exitCode)->toBe(0, $result->describe())
         ->and($project->graphExists())->toBeTrue('the detached --fresh run deleted graph.json')
-        ->and($delta->isHardSuppressed())->toBeTrue($delta->summary());
+        ->and($delta->structureMoved())->toBeTrue($delta->summary());
 })->with(Project::SEQUENTIAL_AND_PARALLEL)->skipOnWindows();
 
-test('a detached HEAD leaves an unreadable graph for a checkout that can rebuild it', function (): void {
+test('a detached HEAD can replace an unreadable graph for a checkout that can rebuild it', function (): void {
     $project = Project::make('master');
     $project->seed('master');
 
@@ -54,7 +54,7 @@ test('a detached HEAD leaves an unreadable graph for a checkout that can rebuild
 
     expect($result->exitCode)->toBe(0, $result->describe())
         ->and($result->tally())->toContain(Project::TOTAL_TESTS.' passed')
-        ->and(file_get_contents($project->graphDir().'/graph.json'))->toBe('{not json');
+        ->and(file_get_contents($project->graphDir().'/graph.json'))->not->toBe('{not json');
 })->skipOnWindows();
 
 test('a cached failure whose test file was deleted stops widening later runs', function (array $arguments): void {

--- a/tests/Fixtures/Tia/Project.php
+++ b/tests/Fixtures/Tia/Project.php
@@ -157,7 +157,7 @@ final class Project
     }
 
     /**
-     * @param  array<string, string>  $environment
+     * @param  array<string, string|false>  $environment
      */
     public function pestWithEnvironment(string $directory, array $environment, string ...$arguments): PestResult
     {
@@ -172,11 +172,14 @@ final class Project
                 'PAO_DISABLE' => '1',
                 'XDEBUG_MODE' => 'coverage',
                 'HOME' => $this->home(),
-                'GITHUB_EVENT_PATH' => '',
-                'CI_DEFAULT_BRANCH' => '',
-                'GITHUB_ACTIONS' => '',
-                'GITLAB_CI' => '',
-                'CIRCLECI' => '',
+                'CI' => false,
+                'GITHUB_EVENT_PATH' => false,
+                'CI_DEFAULT_BRANCH' => false,
+                'CI_COMMIT_BRANCH' => false,
+                'GITHUB_ACTIONS' => false,
+                'GITHUB_REF_NAME' => false,
+                'GITLAB_CI' => false,
+                'CIRCLECI' => false,
                 ...$environment,
             ],
         );


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This allows TIA to persist its dependency graph and related state when Git HEAD is detached.

Detached HEAD is a normal checkout state for GitLab CI and for local workflows that use jj with a colocated Git repository. TIA previously suppressed graph writes, state deletion, structural rebuilds, and `--fresh` purges in this state. A run could therefore pass without producing the graph required by a baseline artifact or a later local run.

TIA now permits the same state operations for attached and detached checkouts. It resolves the writable baseline identity in this order:

1. Use the current Git branch when Git reports one.
2. Use the current branch reported by the GitLab or GitHub CI provider.
3. Use a stable `@workspace:<hash>` key for jj and other detached workspaces.

The default branch remains the read fallback. A local detached workspace can download a baseline recorded on the default branch, calculate changes from that baseline, and store its own SHA, tree, and test results under its workspace key. This prevents an unknown detached checkout from changing the published default-branch baseline.

The TIA CI abstraction now resolves both current and default branches, so each provider owns its environment-variable handling. Workspace baselines survive Git branch reclamation and do not participate in default-branch inference.

The tests cover sequential and parallel detached runs, structural rebuilds, `--fresh`, unreadable graph replacement, branch reclamation, default-baseline isolation, and detached GitLab and GitHub branch detection. The fixture process also removes inherited CI variables so local-behavior tests remain local when the Pest suite itself runs in CI.

Thanks!
