### PR TITLE
fix: don't treat array datasets as callables

### DIFF
--- a/src/Repositories/DatasetsRepository.php
+++ b/src/Repositories/DatasetsRepository.php
@@ -141,7 +141,7 @@ final class DatasetsRepository
                 $datasets[$index] = self::getScopedDataset($data, $currentTestFile);
             }
 
-            if (is_callable($datasets[$index])) {
+            if (! is_array($datasets[$index]) && is_callable($datasets[$index])) {
                 $datasets[$index] = call_user_func($datasets[$index]);
             }
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1764,6 +1764,7 @@
   ✓ it shows the correct description for long texts with newlines
   ✓ it shows the correct description for arrays with many elements
   ✓ it shows the correct description of datasets with html
+  ✓ it does not treat a two element dataset of class names as a callable
 
    PASS  Tests\Unit\Expectations\OppositeExpectation
   ✓ it throw expectation failed exception with string argument
@@ -2221,4 +2222,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1570 passed (3410 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1571 passed (3411 assertions)

--- a/tests/Unit/DatasetsTests.php
+++ b/tests/Unit/DatasetsTests.php
@@ -109,3 +109,27 @@ it('shows the correct description of datasets with html', function (): void {
 
     expect($descriptions[0])->toBe('(\'<div class="flex items-center"></div>\')');
 });
+
+it('does not treat a two element dataset of class names as a callable', function (): void {
+    $datasets = DatasetsRepository::resolve([
+        [
+            MagicCallDataset::class,
+            AnotherMagicCallDataset::class,
+        ],
+    ], __FILE__);
+
+    expect(array_values($datasets))->toBe([
+        [MagicCallDataset::class],
+        [AnotherMagicCallDataset::class],
+    ]);
+});
+
+class MagicCallDataset
+{
+    public static function __callStatic(string $name, array $arguments): void
+    {
+        throw new RuntimeException('This dataset should not be called.');
+    }
+}
+
+class AnotherMagicCallDataset {}

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1553 passed (3356 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1553 passed (3356 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A dataset of exactly two class strings, such as `->with([Project::class, User::class])`, is also a valid PHP callable array when the first class has `__callStatic`, which every Eloquent model does. `DatasetsRepository::processDatasets()` runs its `is_callable()` check before the iterable handling, so it called `Project::User()` rather than using the two values, and the test died inside Eloquent. Arrays are now skipped by that check.

One or three values, keyed values, or nested arrays never matched the callable-array shape, which is why only this case failed.

### Related:

Fixes #1847
