### PR TITLE
fix: beforeEach/afterEach leaking into sibling describe blocks with same nested name

### DIFF
--- a/src/PendingCalls/AfterEachCall.php
+++ b/src/PendingCalls/AfterEachCall.php
@@ -6,7 +6,6 @@ namespace Pest\PendingCalls;
 
 use Closure;
 use Pest\PendingCalls\Concerns\Describable;
-use Pest\Support\Arr;
 use Pest\Support\Backtrace;
 use Pest\Support\ChainableClosure;
 use Pest\Support\HigherOrderMessageCollection;
@@ -43,7 +42,7 @@ final class AfterEachCall
         $proxies = $this->proxies;
 
         $afterEachTestCase = ChainableClosure::boundWhen(
-            fn (): bool => $describing === [] || in_array(Arr::last($describing), $this->__describing, true),
+            fn (): bool => $describing === [] || (count($describing) <= count($this->__describing) && array_slice($this->__describing, 0, count($describing)) === $describing),
             ChainableClosure::bound(fn () => $proxies->chain($this), $this->closure)->bindTo($this, self::class),
         )->bindTo($this, self::class);
 

--- a/src/PendingCalls/BeforeEachCall.php
+++ b/src/PendingCalls/BeforeEachCall.php
@@ -7,7 +7,6 @@ namespace Pest\PendingCalls;
 use Closure;
 use Pest\Exceptions\AfterBeforeTestFunction;
 use Pest\PendingCalls\Concerns\Describable;
-use Pest\Support\Arr;
 use Pest\Support\Backtrace;
 use Pest\Support\ChainableClosure;
 use Pest\Support\HigherOrderMessageCollection;
@@ -50,11 +49,9 @@ final class BeforeEachCall
         $beforeEachTestCall = function (TestCall $testCall) use ($describing): void {
 
             if ($this->describing !== []) {
-                if (Arr::last($describing) !== Arr::last($this->describing)) {
-                    return;
-                }
-
-                if (! in_array(Arr::last($describing), $testCall->describing, true)) {
+                $testCallDescribing = $testCall->describing;
+                if (count($describing) > count($testCallDescribing) ||
+                    array_slice($testCallDescribing, 0, count($describing)) !== $describing) {
                     return;
                 }
             }
@@ -63,7 +60,7 @@ final class BeforeEachCall
         };
 
         $beforeEachTestCase = ChainableClosure::boundWhen(
-            fn (): bool => $describing === [] || in_array(Arr::last($describing), $this->__describing, true),
+            fn (): bool => $describing === [] || (count($describing) <= count($this->__describing) && array_slice($this->__describing, 0, count($describing)) === $describing),
             ChainableClosure::bound(fn () => $testCaseProxies->chain($this), $this->closure)->bindTo($this, self::class),
         )->bindTo($this, self::class);
 

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -33,6 +33,8 @@
   ✓ matching describe block names → outer → middle → it should not call afterEach functions for sibling describe blocks with the same name
   ✓ matching describe block names → outer → inner → it does not get executed before the test
   ✓ matching describe block names → outer → inner → it should not call afterEach functions for descendent of sibling describe blocks with the same name
+  ✓ hierarchical test naming → block one → the same name → it does not call afterEach from sibling describe with same name
+  ✓ hierarchical test naming → block two → the same name → it correctly calls afterEach from own describe hierarchy
 
    PASS  Tests\Features\Assignee
   ✓ it may be associated with an assignee [@nunomaduro, @taylorotwell]
@@ -56,6 +58,8 @@
   ✓ matching name → it should not call the before each on the describe block with the same name
   ✓ called on all tests → beforeEach should be called
   ✓ called on all tests → beforeEach should be called for all tests
+  ✓ hierarchical test naming → block one → the same name → it does not call beforeEach from sibling describe with same name
+  ✓ hierarchical test naming → block two → the same name → it correctly calls beforeEach from own describe hierarchy
 
    PASS  Tests\Features\BeforeEachProxiesToTestCallWithExpectations
   ✓ runs 1
@@ -320,6 +324,8 @@
   ✓ depends on describe using with → foo with (3)
   ✓ depends on describe using with → bar with (3)
   ✓ with test after describe → it should run the before each
+  ✓ sibling describes may share the same it() description → block one → it can be created
+  ✓ sibling describes may share the same it() description → block two → it can be created
 
    PASS  Tests\Features\DescriptionLess
   ✓ get 'foo'
@@ -2221,4 +2227,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1570 passed (3410 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1576 passed (3417 assertions)

--- a/tests/Features/AfterEach.php
+++ b/tests/Features/AfterEach.php
@@ -100,3 +100,33 @@ describe('matching describe block names', function (): void {
         });
     });
 });
+
+describe('hierarchical test naming', function (): void {
+    describe('block one', function (): void {
+        describe('the same name', function (): void {
+            it('does not call afterEach from sibling describe with same name', function (): void {
+                expect($this)->not->toHaveProperty('example');
+            });
+        });
+    });
+
+    describe('block two', function (): void {
+        afterEach(function (): void {
+            expect($this->result)->toBeFalse();
+        });
+
+        describe('the same name', function (): void {
+            beforeEach(function (): void {
+                $this->example = false;
+            });
+
+            afterEach(function (): void {
+                $this->result = $this->example;
+            });
+
+            it('correctly calls afterEach from own describe hierarchy', function (): void {
+                expect($this->example)->toBeFalse();
+            });
+        });
+    });
+});

--- a/tests/Features/BeforeEach.php
+++ b/tests/Features/BeforeEach.php
@@ -126,3 +126,29 @@ describe('called on all tests', function (): void {
         expect($this->baz)->toBe(2);
     });
 });
+
+describe('hierarchical test naming', function (): void {
+    describe('block one', function (): void {
+        describe('the same name', function (): void {
+            it('does not call beforeEach from sibling describe with same name', function (): void {
+                expect($this)->not->toHaveProperty('example');
+            });
+        });
+    });
+
+    describe('block two', function (): void {
+        beforeEach(function (): void {
+            $this->example = false;
+        });
+
+        describe('the same name', function (): void {
+            beforeEach(function (): void {
+                $this->result = $this->example;
+            });
+
+            it('correctly calls beforeEach from own describe hierarchy', function (): void {
+                expect($this->result)->toBeFalse();
+            });
+        });
+    });
+});

--- a/tests/Features/Describe.php
+++ b/tests/Features/Describe.php
@@ -108,3 +108,17 @@ describe('with test after describe', function (): void {
         expect($this->count)->toBe(2);
     });
 });
+
+describe('sibling describes may share the same it() description', function (): void {
+    describe('block one', function (): void {
+        it('can be created', function (): void {
+            expect(true)->toBeTrue();
+        });
+    });
+
+    describe('block two', function (): void {
+        it('can be created', function (): void {
+            expect(true)->toBeTrue();
+        });
+    });
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1558 passed (3362 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1552 passed (3355 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1558 passed (3362 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

beforeEach/afterEach hooks registered inside a nested describe block leaked into tests in a sibling describe block that shared the same inner describe name, producing misleading ErrorException: Undefined property errors.

Replace the loose membership check with a strict prefix check. A hook now fires only if its entire describe path is a prefix of the test's describe path, which correctly scopes hooks to their own hierarchy while still allowing outer describe hooks to cascade into nested describes.

### Related:

https://github.com/pestphp/pest/issues/1522
