### PR TITLE
feat: add numeric expectations (toBePositive, toBeNegative, toBeZero,…

### DIFF
--- a/src/Mixins/Expectation.php
+++ b/src/Mixins/Expectation.php
@@ -152,6 +152,68 @@ final class Expectation
     /**
      * @return self<TValue>
      */
+    public function toBePositive(string $message = ''): self
+    {
+        Assert::assertGreaterThan(0, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * @return self<TValue>
+     */
+    public function toBeNegative(string $message = ''): self
+    {
+        Assert::assertLessThan(0, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * @return self<TValue>
+     */
+    public function toBeZero(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is zero.";
+        }
+
+        Assert::assertEquals(0, $this->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * @return self<TValue>
+     */
+    public function toBeOdd(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is odd.";
+        }
+
+        Assert::assertTrue(((int) $this->value) % 2 !== 0, $message);
+
+        return $this;
+    }
+
+    /**
+     * @return self<TValue>
+     */
+    public function toBeEven(string $message = ''): self
+    {
+        if ($message === '') {
+            $message = "Failed asserting that {$this->value} is even.";
+        }
+
+        Assert::assertTrue(((int) $this->value) % 2 === 0, $message);
+
+        return $this;
+    }
+
+    /**
+     * @return self<TValue>
+     */
     public function toContain(mixed ...$needles): self
     {
         foreach ($needles as $needle) {

--- a/tests/Features/Expect/toBeEven.php
+++ b/tests/Features/Expect/toBeEven.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with positive even', function (): void {
+    expect(4)->toBeEven();
+});
+
+test('passes with negative even', function (): void {
+    expect(-8)->toBeEven();
+});
+
+test('passes with zero', function (): void {
+    expect(0)->toBeEven();
+});
+
+test('failure with odd', function (): void {
+    expect(3)->toBeEven();
+})->throws(ExpectationFailedException::class);
+
+test('failure with custom message', function (): void {
+    expect(3)->toBeEven('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not', function (): void {
+    expect(3)->not->toBeEven();
+});
+
+test('not failure', function (): void {
+    expect(4)->not->toBeEven();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeNegative.php
+++ b/tests/Features/Expect/toBeNegative.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with int', function (): void {
+    expect(-1)->toBeNegative();
+});
+
+test('passes with float', function (): void {
+    expect(-0.5)->toBeNegative();
+});
+
+test('failure with zero', function (): void {
+    expect(0)->toBeNegative();
+})->throws(ExpectationFailedException::class);
+
+test('failure with positive', function (): void {
+    expect(1)->toBeNegative();
+})->throws(ExpectationFailedException::class);
+
+test('failure with custom message', function (): void {
+    expect(1)->toBeNegative('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not', function (): void {
+    expect(1)->not->toBeNegative();
+});
+
+test('not failure', function (): void {
+    expect(-1)->not->toBeNegative();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeOdd.php
+++ b/tests/Features/Expect/toBeOdd.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with positive odd', function (): void {
+    expect(3)->toBeOdd();
+});
+
+test('passes with negative odd', function (): void {
+    expect(-7)->toBeOdd();
+});
+
+test('failure with even', function (): void {
+    expect(4)->toBeOdd();
+})->throws(ExpectationFailedException::class);
+
+test('failure with zero', function (): void {
+    expect(0)->toBeOdd();
+})->throws(ExpectationFailedException::class);
+
+test('failure with custom message', function (): void {
+    expect(4)->toBeOdd('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not', function (): void {
+    expect(4)->not->toBeOdd();
+});
+
+test('not failure', function (): void {
+    expect(3)->not->toBeOdd();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBePositive.php
+++ b/tests/Features/Expect/toBePositive.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with int', function (): void {
+    expect(1)->toBePositive();
+});
+
+test('passes with float', function (): void {
+    expect(0.5)->toBePositive();
+});
+
+test('failure with zero', function (): void {
+    expect(0)->toBePositive();
+})->throws(ExpectationFailedException::class);
+
+test('failure with negative', function (): void {
+    expect(-1)->toBePositive();
+})->throws(ExpectationFailedException::class);
+
+test('failure with custom message', function (): void {
+    expect(-1)->toBePositive('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not', function (): void {
+    expect(-1)->not->toBePositive();
+});
+
+test('not failure', function (): void {
+    expect(1)->not->toBePositive();
+})->throws(ExpectationFailedException::class);

--- a/tests/Features/Expect/toBeZero.php
+++ b/tests/Features/Expect/toBeZero.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('passes with int', function (): void {
+    expect(0)->toBeZero();
+});
+
+test('passes with float', function (): void {
+    expect(0.0)->toBeZero();
+});
+
+test('passes with numeric string', function (): void {
+    expect('0')->toBeZero();
+});
+
+test('failure with positive', function (): void {
+    expect(1)->toBeZero();
+})->throws(ExpectationFailedException::class);
+
+test('failure with negative', function (): void {
+    expect(-1)->toBeZero();
+})->throws(ExpectationFailedException::class);
+
+test('failure with custom message', function (): void {
+    expect(1)->toBeZero('oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not', function (): void {
+    expect(1)->not->toBeZero();
+});
+
+test('not failure', function (): void {
+    expect(0)->not->toBeZero();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Adds five numeric expectations, filling a gap alongside the existing
`toBeGreaterThan`, `toBeLessThan`, `toBeBetween`, `toBeInfinite`, and `toBeNan`:

- `toBePositive()` — value is greater than zero
- `toBeNegative()` — value is less than zero
- `toBeZero()` — value equals zero (`0`, `0.0`, `'0'`)
- `toBeOdd()` — value is an odd number
- `toBeEven()` — value is an even number

These read as plain English, matching Pest's design goal —
`expect($balance)->toBePositive()` over `expect($balance)->toBeGreaterThan(0)`.
Common uses include asserting prices/quantities are positive, a cleared
balance is zero, or batch/pagination sizes have the expected parity.

## Usage

```
expect(10)->toBePositive();
expect(-5)->toBeNegative();
expect(0)->toBeZero();
expect(3)->toBeOdd();
expect(4)->toBeEven();

```

