### PR TITLE
fix(tia): include the PHP minor version in the fingerprint

### DIFF
--- a/src/Plugins/Tia/Fingerprint.php
+++ b/src/Plugins/Tia/Fingerprint.php
@@ -40,7 +40,7 @@ final readonly class Fingerprint
                 'js_config' => self::jsConfigHash($projectRoot),
             ],
             'environmental' => [
-                'php_minor' => PHP_MAJOR_VERSION,
+                'php_minor' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
 
             ],
         ];


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`Fingerprint::compute()` stores `PHP_MAJOR_VERSION` under the `php_minor` key, so the environmental bucket only ever holds `8`. A graph recorded on 8.4 and read back on 8.5 looks identical, `environmentalDrift()` finds nothing, and the drop-results path in `Tia.php` never fires. Cached results from one minor version get replayed on the other, and only an 8.x to 9.x jump trips it.

Recording the graph under 8.4 and reading it back under 8.5, before the change:

```
stored  (PHP 8.4.23): {"php_minor":8}
current (PHP 8.5.8):  {"php_minor":8}
environmentalDrift:   []
```

After:

```
stored  (PHP 8.4.23): {"php_minor":"8.4"}
current (PHP 8.5.8):  {"php_minor":"8.5"}
environmentalDrift:   ["php_minor"]
```

so the `Env differs from baseline (php_minor)` badge shows up and the results are dropped while the edges are reused.

Baselines recorded before this keep the old value, so the first run after upgrading drops its results once and records them again. The graph already handles that.

I left the tests alone since `Fingerprint` has no unit file today and a new one moves the snapshot tally, per CLAUDE.md. Glad to add one if you want it.

### Related:

Fixes #1857
