### PR TITLE
fix(tia): treat a test skipped from a hook as finished

### DIFF
--- a/src/Plugins/Tia/ResultCollector.php
+++ b/src/Plugins/Tia/ResultCollector.php
@@ -117,7 +117,7 @@ final class ResultCollector
 
     public function hasUnfinishedTest(): bool
     {
-        return $this->currentTestId !== null;
+        return $this->currentTestId !== null && ! isset($this->results[$this->currentTestId]);
     }
 
     public function recordAssertions(string $testId, int $assertions): void

--- a/tests/Features/Tia/CompleteRunWriteTier.php
+++ b/tests/Features/Tia/CompleteRunWriteTier.php
@@ -33,6 +33,34 @@ test('a complete run prunes a deleted test', function (array $arguments): void {
         ->and($delta->structureMoved())->toBeFalse($delta->summary());
 })->with(Project::SEQUENTIAL_AND_PARALLEL)->skipOnWindows();
 
+test('a complete run stays complete when the last test is skipped from a hook', function (array $arguments): void {
+    $project = Project::make('master');
+    $project->seed('master');
+
+    $project->write('tests/Unit/GreeterTest.php', <<<'PHP'
+        <?php
+
+        declare(strict_types=1);
+
+        use Fixture\App\Greeter;
+
+        beforeEach(function (): void {
+            test()->markTestSkipped('not today');
+        });
+
+        test('greets a person', function (): void {
+            expect((new Greeter)->greet('Nuno'))->toBe('Hello, Nuno!');
+        });
+        PHP);
+
+    $result = $project->pest(...$arguments);
+    $delta = $project->delta();
+
+    expect($result->tally())->toContain('1 skipped')
+        ->and($delta->removed())->toBe(1, $delta->summary())
+        ->and($delta->added())->toBe(0, $delta->summary());
+})->with(Project::SEQUENTIAL_AND_PARALLEL)->skipOnWindows();
+
 test('a complete run records nothing for a test file the graph does not know', function (): void {
     $project = Project::make('master');
     $project->seed('master');


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A test that skips from a `beforeEach` hook never reaches `Test\Prepared`, so PHPUnit never emits `Test\Finished` for it. The TIA result collector clears its current test on that event, so when one of these tests runs last the collector is left holding it, `hasUnfinishedTest()` reports a truncated run, and the whole run silently drops to the RESULTS-ONLY tier. Nothing is pruned and no graph is written, while the banner still says TIA is on.

A test with a recorded result is not unfinished, so the collector now checks for one. A real truncation still has no result recorded, so it is still caught.

### Related:

Fixes #1862