### PR TITLE
fix(tia): exclude vendor from xdebug coverage while recording

### DIFF
--- a/src/Plugins/Tia/Recorder.php
+++ b/src/Plugins/Tia/Recorder.php
@@ -48,6 +48,14 @@ final class Recorder
     {
         $this->active = true;
         $this->captureCoverage = true;
+
+        if ($this->driverAvailable() && $this->driver === 'xdebug') {
+            \xdebug_set_filter(
+                XDEBUG_FILTER_CODE_COVERAGE,
+                XDEBUG_PATH_EXCLUDE,
+                SourceScope::noisePaths(TestSuite::getInstance()->rootPath),
+            );
+        }
     }
 
     public function activateLinkTracking(): void

--- a/src/Plugins/Tia/SourceScope.php
+++ b/src/Plugins/Tia/SourceScope.php
@@ -100,6 +100,21 @@ final class SourceScope
         return array_values(array_unique($out));
     }
 
+    /**
+     * @return list<string> Absolute directory prefixes, each ending in a separator, that hold no project source.
+     */
+    public static function noisePaths(string $projectRoot): array
+    {
+        $out = [];
+
+        foreach ([...self::TOP_LEVEL_NOISE, ...self::NESTED_NOISE] as $relative) {
+            $abs = $projectRoot.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $relative);
+            $out[] = self::normalise(@realpath($abs) ?: $abs).DIRECTORY_SEPARATOR;
+        }
+
+        return array_values(array_unique($out));
+    }
+
     public function contains(string $absoluteFile): bool
     {
         if (isset($this->containsCache[$absoluteFile])) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1937,6 +1937,10 @@
   ✓ it records assertions against the same per-dataset key
   ✓ it leaves a test without a dataset keyed by class and method
 
+   PASS  Tests\Unit\Plugins\Tia\SourceScope
+  ✓ noisePaths() → it lists the directories that hold no project source
+  ✓ noisePaths() → it ends every path with a separator so a sibling directory cannot match it
+
    PASS  Tests\Unit\Plugins\Tia\Storage
   ✓ it uses a project-relative configured directory
   ✓ it uses an absolute configured directory
@@ -2226,4 +2230,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1573 passed (3414 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1575 passed (3429 assertions)

--- a/tests/Unit/Plugins/Tia/SourceScope.php
+++ b/tests/Unit/Plugins/Tia/SourceScope.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\SourceScope;
+
+describe('noisePaths()', function (): void {
+    it('lists the directories that hold no project source', function (): void {
+        expect(SourceScope::noisePaths('/project'))
+            ->toContain('/project/vendor/')
+            ->toContain('/project/node_modules/')
+            ->toContain('/project/storage/framework/');
+    });
+
+    it('ends every path with a separator so a sibling directory cannot match it', function (): void {
+        expect(SourceScope::noisePaths('/project'))->each->toEndWith(DIRECTORY_SEPARATOR);
+    });
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1557 passed (3374 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1557 passed (3374 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The recorder starts Xdebug coverage with no filter, so every executed line of `vendor/` is traced and then dropped by the scope check in `endTest()`. The pcov path in the same class already narrows the file list before it collects anything.

`Recorder::activate()` now calls `xdebug_set_filter()` with the directories `SourceScope` treats as noise (`vendor`, `node_modules`, the cache directories, `storage/framework`), so Xdebug never instruments them. Xdebug only honours the filter for files compiled after it is set, which is why the call sits in `activate()` and not next to `xdebug_start_code_coverage()` in `beginTest()`. Every prefix ends with a separator, otherwise `vendor` would also match a sibling such as `vendored`.

The scope check after `xdebug_get_code_coverage()` stays, since the filter is a prefilter and not a replacement for it. The recorded graph is unchanged: `tests/Features/Tia` passes in full with Xdebug 3.5.3 in coverage mode.

I added a unit file for `noisePaths()` and bumped both suite tallies by hand, since `composer update:snapshots` would have baked in the `Tests\Unit\Support\Backtrace` failure I get on a clean `5.x` here.

### Related:

Fixes #1865