### PR TITLE
fix: datasets with a single named argument

### DIFF
--- a/src/Factories/TestCaseMethodFactory.php
+++ b/src/Factories/TestCaseMethodFactory.php
@@ -187,8 +187,8 @@ final class TestCaseMethodFactory
             $attributesCode
                 public function $methodName(...\$arguments)
                 {
-                    if (count(\$arguments) === 1 && \$arguments[0] instanceof __PestDatasetProviderError) {
-                        throw \$arguments[0]->getPrevious() ?? \$arguments[0];
+                    if (count(\$arguments) === 1 && \$arguments[array_key_first(\$arguments)] instanceof __PestDatasetProviderError) {
+                        throw \$arguments[array_key_first(\$arguments)]->getPrevious() ?? \$arguments[array_key_first(\$arguments)];
                     }
 
                     return \$this->__runTest(

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -275,6 +275,7 @@
   ✓ dataset items can mix named and sequential styles with ('Taylor', 'taylor@laravel.com')
   ✓ dataset items can mix named and sequential styles with ('James', 'james@laravel.com') #1
   ✓ dataset items can mix named and sequential styles with ('James', 'james@laravel.com') #2
+  ✓ named parameters work with a single argument with ('Taylor')
 
    PASS  Tests\Features\Depends
   ✓ first
@@ -2226,4 +2227,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1573 passed (3414 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1574 passed (3415 assertions)

--- a/tests/Features/DatasetsTests.php
+++ b/tests/Features/DatasetsTests.php
@@ -494,3 +494,9 @@ test('dataset items can mix named and sequential styles', function (string $name
     ['James', 'james@laravel.com'],
     ['James', 'email' => 'james@laravel.com'],
 ]);
+
+test('named parameters work with a single argument', function (string $name): void {
+    expect($name)->toBe('Taylor');
+})->with([
+    ['name' => 'Taylor'],
+]);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1556 passed (3360 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1556 passed (3360 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A dataset row written as an associative array with one key, like `['name' => 'Taylor']`, is spread into the generated test method as a named argument, so `$arguments` holds `name` and no `0`. The guard for dataset provider errors still reads `$arguments[0]` whenever the count is 1, so every row of such a test raises `Undefined array key 0` before the body runs. Rows with two or more named keys survive because the count check short-circuits first.

This is already fixed on 4.x in 3223d50, it just never made it over to 5.x. I took that commit as is, `array_key_first()` on the guard plus the test that came with it, so a later 4.x merge stays a no-op. The snapshot and the parallel tally are updated for the extra test.

### Related:

Fixes #1868