### PR TITLE
fix: reset the snapshot counter between flaky retries

### DIFF
--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -342,7 +342,7 @@ trait Testable
                         throw $e;
                     }
 
-                    TestSuite::getInstance()->snapshots->resetExpectations();
+                    $snapshotKey = TestSuite::getInstance()->snapshots->currentKey();
 
                     $this->tearDown();
 
@@ -362,6 +362,8 @@ trait Testable
                             $this->expectedRegularExpression = null;
                         }, $outputBuffer, OutputBuffer::class)();
                     }
+
+                    TestSuite::getInstance()->snapshots->resetExpectations($snapshotKey);
 
                     $this->setUp();
                 }

--- a/src/Concerns/Testable.php
+++ b/src/Concerns/Testable.php
@@ -342,6 +342,8 @@ trait Testable
                         throw $e;
                     }
 
+                    TestSuite::getInstance()->snapshots->resetExpectations();
+
                     $this->tearDown();
 
                     Closure::bind(fn (): array => $this->mockObjects = [], $this, TestCase::class)();

--- a/src/Repositories/SnapshotRepository.php
+++ b/src/Repositories/SnapshotRepository.php
@@ -125,6 +125,11 @@ final class SnapshotRepository
         return self::$expectationsCounter[$this->getCurrentSnapshotKey()] ?? 0;
     }
 
+    public function resetExpectations(): void
+    {
+        unset(self::$expectationsCounter[$this->getCurrentSnapshotKey()]);
+    }
+
     public function startNewExpectation(): void
     {
         $key = $this->getCurrentSnapshotKey();

--- a/src/Repositories/SnapshotRepository.php
+++ b/src/Repositories/SnapshotRepository.php
@@ -125,9 +125,14 @@ final class SnapshotRepository
         return self::$expectationsCounter[$this->getCurrentSnapshotKey()] ?? 0;
     }
 
-    public function resetExpectations(): void
+    public function currentKey(): string
     {
-        unset(self::$expectationsCounter[$this->getCurrentSnapshotKey()]);
+        return $this->getCurrentSnapshotKey();
+    }
+
+    public function resetExpectations(string $key): void
+    {
+        unset(self::$expectationsCounter[$key]);
     }
 
     public function startNewExpectation(): void

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1215,6 +1215,7 @@
   ✓ it works with repeat and flaky @ repetition 2 of 2
   ✓ it works as higher order test
   ✓ it fails after exhausting all retries
+  ✓ it does not advance the snapshot counter between retries
   ✓ it throws when tries is less than 1
   ✓ it throws when tries is negative
   ↓ it does not retry todo tests
@@ -2226,4 +2227,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1573 passed (3414 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1574 passed (3418 assertions)

--- a/tests/Features/Flaky.php
+++ b/tests/Features/Flaky.php
@@ -159,6 +159,8 @@ it('does not advance the snapshot counter between retries', function (): void {
         mkdir($directory, 0755, true);
     }
 
+    array_map(unlink(...), (array) glob($directory.'/*.snap'));
+
     file_put_contents($directory.'/it_compares_a_snapshot.snap', 'before');
 
     $process = new Process(
@@ -169,7 +171,7 @@ it('does not advance the snapshot counter between retries', function (): void {
 
     $process->run();
 
-    $snapshots = glob($directory.'/*.snap');
+    $snapshots = (array) glob($directory.'/*.snap');
 
     array_map(unlink(...), $snapshots);
     rmdir($directory);

--- a/tests/Features/Flaky.php
+++ b/tests/Features/Flaky.php
@@ -152,6 +152,34 @@ it('fails after exhausting all retries', function (): void {
         ->toContain('Always fails');
 });
 
+it('does not advance the snapshot counter between retries', function (): void {
+    $directory = dirname(__DIR__).'/.pest/snapshots/Fixtures/Suites/FlakySnapshot';
+
+    if (! is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    file_put_contents($directory.'/it_compares_a_snapshot.snap', 'before');
+
+    $process = new Process(
+        ['php', 'bin/pest', 'tests/Fixtures/Suites/FlakySnapshot.php'],
+        dirname(__DIR__, 2),
+        ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true', 'PAO_DISABLE' => '1'],
+    );
+
+    $process->run();
+
+    $snapshots = glob($directory.'/*.snap');
+
+    array_map(unlink(...), $snapshots);
+    rmdir($directory);
+
+    expect($process->getExitCode())->not->toBe(0)
+        ->and($snapshots)->toHaveCount(1)
+        ->and(removeAnsiEscapeSequences($process->getOutput()))->toContain('FAILED')
+        ->toContain('it_compares_a_snapshot.snap');
+});
+
 it('throws when tries is less than 1', function (): void {
     it('invalid', function (): void {})->flaky(tries: 0);
 })->throws(InvalidArgumentException::class, 'The number of tries must be greater than 0.');

--- a/tests/Fixtures/Suites/FlakySnapshot.php
+++ b/tests/Fixtures/Suites/FlakySnapshot.php
@@ -1,0 +1,5 @@
+<?php
+
+it('compares a snapshot', function () {
+    expect('after')->toMatchSnapshot();
+})->flaky(tries: 3);

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1556 passed (3363 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1555 passed (3359 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1556 passed (3363 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`SnapshotRepository::$expectationsCounter` is static and keyed by test file plus description, so several `toMatchSnapshot()` calls in one test resolve to `.snap`, `__2.snap`, and so on. `Testable::__runTest()` replays the closure in the same process on a flaky retry and never clears that key, so attempt 2 looks for `__2.snap`. It does not exist, gets created from the current value, and the test ends as incomplete on a green suite. Every run after that passes, because attempt 1 still fails against the real baseline and attempt 2 matches the file the first run wrote. On CI the run fails, but it names a `__3.snap` nobody created instead of the value that actually drifted.

The retry already restores object properties, mock objects and the output buffer before running again. The counter belongs to that cleanup, so it is reset there too, and the retried attempt resolves the same snapshot file as the first one.

### Related:

Fixes #1871
