### PR TITLE
Prevent memory exhaustion when generating TIA graphs with PCOV

### DIFF
--- a/src/Restarters/PcovRestarter.php
+++ b/src/Restarters/PcovRestarter.php
@@ -52,13 +52,8 @@ final class PcovRestarter implements Restarter
         $env = $this->inheritEnv();
         $env[self::ENV_RESTARTED] = '1';
 
-        $command = array_merge(
-            [PHP_BINARY, '-d', 'pcov.directory='.$projectRoot],
-            array_values($arguments),
-        );
-
         $proc = @proc_open(
-            $command,
+            $this->command($projectRoot, $arguments),
             [STDIN, STDOUT, STDERR],
             $pipes,
             null,
@@ -72,6 +67,24 @@ final class PcovRestarter implements Restarter
         $exitCode = proc_close($proc);
 
         exit($exitCode === -1 ? 1 : $exitCode);
+    }
+
+    /**
+     * @param  array<int, string>  $arguments
+     * @return array<int, string>
+     */
+    private function command(string $projectRoot, array $arguments): array
+    {
+        return array_merge(
+            [
+                PHP_BINARY,
+                '-d',
+                'memory_limit='.(string) ini_get('memory_limit'),
+                '-d',
+                'pcov.directory='.$projectRoot,
+            ],
+            array_values($arguments),
+        );
     }
 
     /**

--- a/src/Restarters/PcovRestarter.php
+++ b/src/Restarters/PcovRestarter.php
@@ -71,7 +71,7 @@ final class PcovRestarter implements Restarter
 
     /**
      * @param  array<int, string>  $arguments
-     * @return array<int, string>
+     * @return list<string>
      */
     private function command(string $projectRoot, array $arguments): array
     {

--- a/src/Restarters/PcovRestarter.php
+++ b/src/Restarters/PcovRestarter.php
@@ -79,7 +79,7 @@ final class PcovRestarter implements Restarter
             [
                 PHP_BINARY,
                 '-d',
-                'memory_limit='.(string) ini_get('memory_limit'),
+                'memory_limit='.ini_get('memory_limit'),
                 '-d',
                 'pcov.directory='.$projectRoot,
             ],

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -2051,6 +2051,9 @@
   ✓ preset invalid name
   ✓ preset → myFramework
 
+   PASS  Tests\Unit\Restarters\PcovRestarter
+  ✓ it preserves the active memory limit in the restarted process
+
    PASS  Tests\Unit\Support\Arr
   ✓ last → it should return false for an empty arary
   ✓ last → it should return the last element for an array with a single element
@@ -2234,4 +2237,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1581 passed (3434 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1582 passed (3435 assertions)

--- a/tests/Features/Tia.php
+++ b/tests/Features/Tia.php
@@ -56,6 +56,7 @@ it('does not run user hooks when replaying cached skipped and incomplete results
                 'PARATEST' => 0,
                 'PAO_DISABLE' => '1',
                 'HOME' => $home,
+                'CI_DEFAULT_BRANCH' => $branch,
             ],
         );
 

--- a/tests/Unit/Restarters/PcovRestarter.php
+++ b/tests/Unit/Restarters/PcovRestarter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Restarters\PcovRestarter;
+use Symfony\Component\Process\Process;
+
+it('preserves the active memory limit in the restarted process', function (): void {
+    $originalMemoryLimit = ini_get('memory_limit');
+
+    try {
+        ini_set('memory_limit', '1234M');
+
+        $command = new ReflectionMethod(PcovRestarter::class, 'command')
+            ->invoke(new PcovRestarter, __DIR__, ['-r', 'fwrite(STDOUT, (string) ini_get("memory_limit"));']);
+
+        assert(is_array($command));
+
+        $process = new Process($command);
+        $process->mustRun();
+
+        expect($process->getOutput())->toBe('1234M');
+    } finally {
+        ini_set('memory_limit', (string) $originalMemoryLimit);
+    }
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -26,13 +26,13 @@ test('parallel', function () use ($run): void {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1563 passed (3379 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1564 passed (3380 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1563 passed (3379 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1564 passed (3380 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Preserves the active PHP `memory_limit` when PCOV restarts Pest for TIA.

Previously, CLI overrides such as `-dmemory_limit=-1` were dropped. The restarted parent could then exhaust its php.ini memory limit while merging parallel worker results and encoding the final TIA graph, after all tests had passed.

Adds focused coverage confirming the memory limit survives the restart.