### PR TITLE
fix: allow PHPUnit 13.3 patch releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "conflict": {
         "filp/whoops": "<2.18.3",
-        "phpunit/phpunit": ">13.3.0",
+        "phpunit/phpunit": ">=13.4.0",
         "sebastian/exporter": "<7.0.0",
         "webmozart/assert": "<1.11.0"
     },


### PR DESCRIPTION
## Summary

Pest 5.1.1 currently conflicts with PHPUnit versions greater than 13.3.0. That also rejects PHPUnit 13.3.1, even though it is a patch release in the supported 13.3 line.

This changes the conflict to >=13.4.0, keeping the existing boundary while allowing the 13.3.x patch releases.

## Validation

- composer validate --strict
- Composer dry-run resolution with phpunit/phpunit:13.3.1
- Pest non-integration suite: 1,564 passed, 3,379 assertions
  - php -d memory_limit=2G bin/pest --exclude-group=integration --compact

## Related work

I could not find an existing open PR for this exact conflict. Issue #1830 concerns a PHPUnit 13.3 install/lock mismatch and PR #1784 concerns PHPUnit 13 test ordering, so neither addresses this constraint.