### PR TITLE
fix(tia): select only the tests that touch a changed migration's tables

### DIFF
--- a/src/Plugins/Tia.php
+++ b/src/Plugins/Tia.php
@@ -23,6 +23,7 @@ use Pest\Plugins\Tia\ChangedFiles;
 use Pest\Plugins\Tia\CiDefaultBranch;
 use Pest\Plugins\Tia\Contracts\State;
 use Pest\Plugins\Tia\CoverageCollector;
+use Pest\Plugins\Tia\DatabaseTestTables;
 use Pest\Plugins\Tia\Fingerprint;
 use Pest\Plugins\Tia\Graph;
 use Pest\Plugins\Tia\JsModuleGraph;
@@ -30,7 +31,6 @@ use Pest\Plugins\Tia\Recorder;
 use Pest\Plugins\Tia\ResultCollector;
 use Pest\Plugins\Tia\SourceScope;
 use Pest\Plugins\Tia\Storage;
-use Pest\Plugins\Tia\TableExtractor;
 use Pest\Plugins\Tia\WatchPatterns;
 use Pest\Support\Container;
 use Pest\Support\Git;
@@ -604,11 +604,7 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
         $perTestUsesDatabase = $recorder->perTestUsesDatabase();
 
         if ($perTestUsesDatabase !== []) {
-            $perTestTables = $this->augmentDatabaseTestTables(
-                $perTestTables,
-                $perTestUsesDatabase,
-                $projectRoot,
-            );
+            $perTestTables = DatabaseTestTables::augment($perTestTables, $perTestUsesDatabase, $projectRoot);
         }
 
         if (Parallel::isWorker()) {
@@ -2207,58 +2203,6 @@ final class Tia implements AddsOutput, HandlesArguments, HandlesOriginalArgument
         }
 
         return implode(', ', $changes);
-    }
-
-    /**
-     * @param  array<string, array<int, string>>  $perTestTables
-     * @param  array<string, true>  $perTestUsesDatabase
-     * @return array<string, array<int, string>>
-     */
-    private function augmentDatabaseTestTables(array $perTestTables, array $perTestUsesDatabase, string $projectRoot): array
-    {
-        $migrationDir = rtrim($projectRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'database'.DIRECTORY_SEPARATOR.'migrations';
-
-        if (! is_dir($migrationDir)) {
-            return $perTestTables;
-        }
-
-        $allTables = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($migrationDir, \FilesystemIterator::SKIP_DOTS),
-        );
-
-        foreach ($iterator as $fileInfo) {
-            if (! $fileInfo->isFile()) {
-                continue;
-            }
-            if (! str_ends_with(strtolower((string) $fileInfo->getPathname()), '.php')) {
-                continue;
-            }
-
-            $content = @file_get_contents((string) $fileInfo->getPathname());
-
-            if ($content === false) {
-                continue;
-            }
-
-            foreach (TableExtractor::fromMigrationSource($content) as $table) {
-                $allTables[strtolower($table)] = true;
-            }
-        }
-
-        if ($allTables === []) {
-            return $perTestTables;
-        }
-
-        foreach (array_keys($perTestUsesDatabase) as $testFile) {
-            $existing = $perTestTables[$testFile] ?? [];
-            $merged = array_fill_keys($existing, true) + $allTables;
-            $names = array_keys($merged);
-            sort($names);
-            $perTestTables[$testFile] = $names;
-        }
-
-        return $perTestTables;
     }
 
     /**

--- a/src/Plugins/Tia/DatabaseTestTables.php
+++ b/src/Plugins/Tia/DatabaseTestTables.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Plugins\Tia;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * @internal
+ */
+final class DatabaseTestTables
+{
+    /**
+     * @param  array<string, array<int, string>>  $perTestTables
+     * @param  array<string, true>  $perTestUsesDatabase
+     * @return array<string, array<int, string>>
+     */
+    public static function augment(array $perTestTables, array $perTestUsesDatabase, string $projectRoot): array
+    {
+        $untracked = array_filter(
+            array_keys($perTestUsesDatabase),
+            fn (string $testFile): bool => ($perTestTables[$testFile] ?? []) === [],
+        );
+
+        if ($untracked === []) {
+            return $perTestTables;
+        }
+
+        $allTables = self::declaredTables($projectRoot);
+
+        if ($allTables === []) {
+            return $perTestTables;
+        }
+
+        foreach ($untracked as $testFile) {
+            $perTestTables[$testFile] = $allTables;
+        }
+
+        return $perTestTables;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function declaredTables(string $projectRoot): array
+    {
+        $migrationDir = rtrim($projectRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'database'.DIRECTORY_SEPARATOR.'migrations';
+
+        if (! is_dir($migrationDir)) {
+            return [];
+        }
+
+        $tables = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($migrationDir, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if (! $fileInfo->isFile()) {
+                continue;
+            }
+
+            if (! str_ends_with(strtolower((string) $fileInfo->getPathname()), '.php')) {
+                continue;
+            }
+
+            $content = @file_get_contents((string) $fileInfo->getPathname());
+
+            if ($content === false) {
+                continue;
+            }
+
+            foreach (TableExtractor::fromMigrationSource($content) as $table) {
+                $tables[strtolower($table)] = true;
+            }
+        }
+
+        $names = array_keys($tables);
+        sort($names);
+
+        return $names;
+    }
+}

--- a/src/Plugins/Tia/Graph.php
+++ b/src/Plugins/Tia/Graph.php
@@ -103,7 +103,7 @@ final class Graph
 
         $affectedSet = [];
 
-        $unparseableMigrations = $this->applyMigrationChanges($migrationPaths, $affectedSet);
+        $unmatchedMigrations = $this->applyMigrationChanges($migrationPaths, $affectedSet);
 
         [$globalFrontendRuntimeFiles, $preciselyHandledPages, $sharedFilesResolved]
             = $this->applyInertiaChanges($nonMigrationPaths, $affectedSet);
@@ -117,7 +117,7 @@ final class Graph
 
         $this->applyWatchPatternFallback(
             $nonMigrationPaths,
-            $unparseableMigrations,
+            $unmatchedMigrations,
             $preciselyHandledPages,
             $sharedFilesResolved,
             $handledBlade,
@@ -176,7 +176,7 @@ final class Graph
     /**
      * @param  list<string>  $migrationPaths
      * @param  array<string, true>  $affectedSet
-     * @return list<string> Unparseable migrations (caller treats as unknown-to-graph).
+     * @return list<string> Migrations that could not be matched by table (caller treats as unknown-to-graph).
      */
     private function applyMigrationChanges(array $migrationPaths, array &$affectedSet): array
     {
@@ -184,40 +184,40 @@ final class Graph
             return $migrationPaths;
         }
 
-        $changedTables = [];
-        $unparseable = [];
+        $unmatched = [];
 
         foreach ($migrationPaths as $rel) {
             $tables = $this->tablesForMigration($rel);
 
-            if ($tables === []) {
-                $unparseable[] = $rel;
-
-                continue;
+            if ($tables === [] || ! $this->selectTestsUsingTables($tables, $affectedSet)) {
+                $unmatched[] = $rel;
             }
+        }
 
+        return $unmatched;
+    }
+
+    /**
+     * @param  list<string>  $changedTables
+     * @param  array<string, true>  $affectedSet
+     */
+    private function selectTestsUsingTables(array $changedTables, array &$affectedSet): bool
+    {
+        $changed = array_fill_keys($changedTables, true);
+        $selected = false;
+
+        foreach ($this->testTables as $testFile => $tables) {
             foreach ($tables as $table) {
-                $changedTables[$table] = true;
-            }
-        }
+                if (isset($changed[$table])) {
+                    $affectedSet[$testFile] = true;
+                    $selected = true;
 
-        if ($changedTables !== []) {
-            foreach ($this->testTables as $testFile => $tables) {
-                if (isset($affectedSet[$testFile])) {
-                    continue;
-                }
-
-                foreach ($tables as $table) {
-                    if (isset($changedTables[$table])) {
-                        $affectedSet[$testFile] = true;
-
-                        break;
-                    }
+                    break;
                 }
             }
         }
 
-        return $unparseable;
+        return $selected;
     }
 
     /**
@@ -624,7 +624,7 @@ final class Graph
 
     /**
      * @param  list<string>  $nonMigrationPaths
-     * @param  list<string>  $unparseableMigrations
+     * @param  list<string>  $unmatchedMigrations
      * @param  array<string, true>  $preciselyHandledPages
      * @param  array<string, true>  $sharedFilesResolved
      * @param  array<string, true>  $handledBlade
@@ -632,13 +632,13 @@ final class Graph
      */
     private function applyWatchPatternFallback(
         array $nonMigrationPaths,
-        array $unparseableMigrations,
+        array $unmatchedMigrations,
         array $preciselyHandledPages,
         array $sharedFilesResolved,
         array $handledBlade,
         array &$affectedSet,
     ): void {
-        $unknownToGraph = $unparseableMigrations;
+        $unknownToGraph = $unmatchedMigrations;
 
         foreach ($nonMigrationPaths as $rel) {
             if (isset($preciselyHandledPages[$rel])) {

--- a/tests/Unit/Plugins/Tia/DatabaseTestTables.php
+++ b/tests/Unit/Plugins/Tia/DatabaseTestTables.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Plugins\Tia\DatabaseTestTables;
+
+describe('augment()', function (): void {
+    beforeEach(function (): void {
+        $this->projectRoot = sys_get_temp_dir().'/pest-tia-db-tables-'.bin2hex(random_bytes(4));
+        mkdir($this->projectRoot.'/database/migrations', 0755, true);
+        file_put_contents(
+            $this->projectRoot.'/database/migrations/2024_01_01_000000_create_orders_table.php',
+            "<?php Schema::create('orders', function () {});",
+        );
+        file_put_contents(
+            $this->projectRoot.'/database/migrations/2024_01_02_000000_create_users_table.php',
+            "<?php Schema::create('users', function () {});",
+        );
+    });
+
+    afterEach(function (): void {
+        foreach (glob($this->projectRoot.'/database/migrations/*.php') ?: [] as $migration) {
+            unlink($migration);
+        }
+
+        @rmdir($this->projectRoot.'/database/migrations');
+        @rmdir($this->projectRoot.'/database');
+        @rmdir($this->projectRoot);
+    });
+
+    it('keeps the recorded tables of a database test that tracked its queries', function (): void {
+        $augmented = DatabaseTestTables::augment(
+            ['tests/Feature/OrderTest.php' => ['orders']],
+            ['tests/Feature/OrderTest.php' => true],
+            $this->projectRoot,
+        );
+
+        expect($augmented)->toBe(['tests/Feature/OrderTest.php' => ['orders']]);
+    });
+
+    it('links a database test with no recorded tables to every declared table', function (): void {
+        $augmented = DatabaseTestTables::augment(
+            ['tests/Feature/OrderTest.php' => ['orders']],
+            ['tests/Feature/OrderTest.php' => true, 'tests/Feature/BootTest.php' => true],
+            $this->projectRoot,
+        );
+
+        expect($augmented)->toBe([
+            'tests/Feature/OrderTest.php' => ['orders'],
+            'tests/Feature/BootTest.php' => ['orders', 'users'],
+        ]);
+    });
+
+    it('leaves tests that do not use the database untouched', function (): void {
+        $augmented = DatabaseTestTables::augment(
+            ['tests/Unit/MathTest.php' => []],
+            [],
+            $this->projectRoot,
+        );
+
+        expect($augmented)->toBe(['tests/Unit/MathTest.php' => []]);
+    });
+
+    it('does nothing when the migrations declare no tables', function (): void {
+        foreach (glob($this->projectRoot.'/database/migrations/*.php') ?: [] as $migration) {
+            unlink($migration);
+        }
+
+        $augmented = DatabaseTestTables::augment(
+            [],
+            ['tests/Feature/BootTest.php' => true],
+            $this->projectRoot,
+        );
+
+        expect($augmented)->toBeEmpty();
+    });
+});

--- a/tests/Unit/Plugins/Tia/Graph.php
+++ b/tests/Unit/Plugins/Tia/Graph.php
@@ -53,6 +53,32 @@ describe('applyMigrationChanges()', function (): void {
         expect($affected)->toBe(['tests/Feature/OrderTest.php']);
     });
 
+    it('falls back to watch patterns when no recorded test touches the changed table', function (): void {
+        $this->watchPatterns->add(['database/migrations/**' => 'tests/Feature']);
+
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/UserTest.php', 'app/Models/User.php');
+        $graph->replaceTestTables([
+            'tests/Feature/UserTest.php' => ['users'],
+        ]);
+
+        $affected = $graph->affected(['database/migrations/2024_01_01_000000_create_orders_table.php']);
+
+        expect($affected)->toBe(['tests/Feature/UserTest.php']);
+    });
+
+    it('selects nothing for an unrelated migration when no watch pattern covers it', function (): void {
+        $graph = new Graph($this->projectRoot);
+        $graph->link('tests/Feature/UserTest.php', 'app/Models/User.php');
+        $graph->replaceTestTables([
+            'tests/Feature/UserTest.php' => ['users'],
+        ]);
+
+        $affected = $graph->affected(['database/migrations/2024_01_01_000000_create_orders_table.php']);
+
+        expect($affected)->toBeEmpty();
+    });
+
     it('falls back to watch patterns when no table usage was recorded at all', function (): void {
         $this->watchPatterns->add(['database/migrations/**' => 'tests/Feature']);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

On a Laravel suite whose base `TestCase` uses `RefreshDatabase`, changing any migration makes `--tia` select the entire suite, even though the graph already knows exactly which tables each test file queried.

The cause is `Tia::augmentDatabaseTestTables`: every test whose class uses `RefreshDatabase` / `DatabaseMigrations` / `DatabaseTransactions` gets **every** table declared under `database/migrations` merged into its recorded table list, whether or not it recorded tables of its own. With the trait on the base class, that is every test, so `Graph::applyMigrationChanges` intersects the changed migration against a table list that contains everything, and a one-column migration on `orders` re-runs 13k tests. On the suite I measured, that is the difference between a few seconds and a full run on every migration.

This keeps the conservative behaviour only where it is needed:

- A database test that recorded **no** table usage (nothing went through the query listener, so there is nothing to match) is still linked to every declared table.
- A database test that **did** record tables keeps exactly those. A migration touching `orders` now selects the tests that queried `orders`, which is what the table tracking exists for.
- `Graph::applyMigrationChanges` routes a parseable migration that matches **no** recorded test through the watch-pattern fallback, the same path an unparseable migration takes. Before, that case could only happen without `RefreshDatabase`; now it is reachable for every suite, and it must not silently select nothing.

The augmentation moves out of the plugin into `Tia\DatabaseTestTables` so it can be unit tested; the traversal of `database/migrations` is unchanged.

Tests: `tests/Unit/Plugins/Tia/DatabaseTestTables.php` covers the three shapes (tracked, untracked, no database), and `Graph.php` gains the no-match fallback and the no-match-no-pattern case. `tests/Features/Tia` (200) and `tests/Unit/Plugins/Tia` (174) pass, `composer lint` and `composer test:type:check` are clean.
