### PR TITLE
fix: exit code with --shard and --parallel

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -134,12 +134,11 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
 
         $arguments = [...$arguments, '--filter', $filter];
 
-        if ($this->hasArgument('--do-not-fail-on-empty-test-suite', $arguments)
-            || $this->hasArgument('--fail-on-empty-test-suite', $arguments)) {
+        if ($this->hasArgument('--do-not-fail-on-empty-test-suite', $arguments) || $this->hasArgument('--fail-on-empty-test-suite', $arguments)) {
             return $arguments;
         }
 
-        return [...$arguments, '--do-not-fail-on-empty-test-suite'];
+        return $this->pushArgument('--do-not-fail-on-empty-test-suite', $arguments);
     }
 
     /**

--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -132,7 +132,14 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
 
         $this->ensureFilterLengthIsSafe($filter);
 
-        return [...$arguments, '--filter', $filter];
+        $arguments = [...$arguments, '--filter', $filter];
+
+        if ($this->hasArgument('--do-not-fail-on-empty-test-suite', $arguments)
+            || $this->hasArgument('--fail-on-empty-test-suite', $arguments)) {
+            return $arguments;
+        }
+
+        return [...$arguments, '--do-not-fail-on-empty-test-suite'];
     }
 
     /**


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`--shard` builds its own `--filter` for the tests assigned to that shard. In parallel mode, a worker's serialized PHPUnit result reports zero tests whenever the last file it happened to process falls outside that filter, and the merged result inherits that false zero, so `--parallel` exits 1 even though every test actually passed. Since the shard already knows its filter matched real tests, it now also passes `--do-not-fail-on-empty-test-suite` alongside that filter.

### Related:

Fixes #1882
