### PR TITLE
fix(sharding): prevent shard filters from matching classes outside their partition

### DIFF
--- a/src/Plugins/Shard.php
+++ b/src/Plugins/Shard.php
@@ -29,6 +29,8 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
 
     private const int MAX_FILTER_LENGTH = 32768;
 
+    private const string CLASS_END = "\0";
+
     /**
      * @var array{
      *     index: int,
@@ -239,17 +241,35 @@ final class Shard implements AddsOutput, HandlesArguments, Terminable
                 }
                 $current = &$current[$part];
             }
+            $current[self::CLASS_END] = true;
         }
 
         $buildRegex = function (array $tree) use (&$buildRegex): string {
             $parts = [];
             foreach ($tree as $key => $sub) {
-                $subRegex = $buildRegex($sub);
-                if ($subRegex === '') {
-                    $parts[] = preg_quote($key, '/');
-                } else {
-                    $parts[] = preg_quote($key, '/').'\\\\'.(count($sub) > 1 ? '('.$subRegex.')' : $subRegex);
+                if ($key === self::CLASS_END) {
+                    continue;
                 }
+
+                assert(is_array($sub));
+
+                $endsWithClass = isset($sub[self::CLASS_END]);
+                $sub = array_diff_key($sub, [self::CLASS_END => null]);
+                $subRegex = $sub === [] ? '' : $buildRegex($sub);
+
+                $segment = preg_quote($key, '/');
+
+                if ($subRegex !== '') {
+                    $segment .= '\\\\'.(count($sub) > 1 ? '('.$subRegex.')' : $subRegex);
+                }
+
+                if ($endsWithClass && $subRegex !== '') {
+                    $parts[] = '(?:'.preg_quote($key, '/').'(?=::)|'.$segment.')';
+
+                    continue;
+                }
+
+                $parts[] = $endsWithClass ? $segment.'(?=::)' : $segment;
             }
 
             return implode('|', $parts);

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -151,7 +151,7 @@ describe('buildFilterArgument', function (): void {
         $filter = $method->invoke($shard, ['Tests\\Feature\\After']);
 
         expect(preg_match('{'.$filter.'}i', 'P\Tests\Feature\AfterAll::deletes file after all'))->toBe(0)
-            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Feature\After::it runs'))->toBe(1);
+            ->and('P\Tests\Feature\After::it runs')->toMatch('{'.$filter.'}i');
     });
 
     it('still matches dataset variants after the class boundary', function (): void {
@@ -163,7 +163,7 @@ describe('buildFilterArgument', function (): void {
 
         $filter = $method->invoke($shard, ['Tests\\Feature\\After']);
 
-        expect(preg_match('{'.$filter.'}i', 'P\Tests\Feature\After::it runs with data set "foo"'))->toBe(1);
+        expect('P\Tests\Feature\After::it runs with data set "foo"')->toMatch('{'.$filter.'}i');
     });
 
     it('keeps a class matchable when another class nests below its namespace', function (): void {
@@ -176,8 +176,8 @@ describe('buildFilterArgument', function (): void {
         $filter = $method->invoke($shard, ['Tests\\Unit\\After', 'Tests\\Unit\\After\\AfterAll']);
 
         expect($filter)->toBe('Tests\\\\Unit\\\\(?:After(?=::)|After\\\\AfterAll(?=::))')
-            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Unit\After::x'))->toBe(1)
-            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Unit\After\AfterAll::y'))->toBe(1);
+            ->and('P\Tests\Unit\After::x')->toMatch('{'.$filter.'}i')
+            ->and('P\Tests\Unit\After\AfterAll::y')->toMatch('{'.$filter.'}i');
     });
 });
 

--- a/tests/Unit/Plugins/Shard.php
+++ b/tests/Unit/Plugins/Shard.php
@@ -60,7 +60,7 @@ describe('buildFilterArgument', function (): void {
 
         $filter = $method->invoke($shard, ['Tests\\Unit\\ExampleTest']);
 
-        expect($filter)->toBe('Tests\\\\Unit\\\\ExampleTest');
+        expect($filter)->toBe('Tests\\\\Unit\\\\ExampleTest(?=::)');
     });
 
     it('generates compact filter for multiple tests with common prefix', function (): void {
@@ -75,7 +75,7 @@ describe('buildFilterArgument', function (): void {
             'Tests\\Unit\\Foo\\BazTest',
         ]);
 
-        expect($filter)->toBe('Tests\\\\Unit\\\\Foo\\\\(BarTest|BazTest)');
+        expect($filter)->toBe('Tests\\\\Unit\\\\Foo\\\\(BarTest(?=::)|BazTest(?=::))');
     });
 
     it('generates compact filter for tests with different namespaces', function (): void {
@@ -90,7 +90,7 @@ describe('buildFilterArgument', function (): void {
             'Tests\\Feature\\BarTest',
         ]);
 
-        expect($filter)->toBe('Tests\\\\(Unit\\\\FooTest|Feature\\\\BarTest)');
+        expect($filter)->toBe('Tests\\\\(Unit\\\\FooTest(?=::)|Feature\\\\BarTest(?=::))');
     });
 
     it('returns empty string for empty test list', function (): void {
@@ -118,7 +118,7 @@ describe('buildFilterArgument', function (): void {
             'Tests\\Unit\\Plugins\\Concerns\\Baz',
         ]);
 
-        expect($filter)->toBe('Tests\\\\Unit\\\\Plugins\\\\Concerns\\\\(Foo|Bar|Baz)');
+        expect($filter)->toBe('Tests\\\\Unit\\\\Plugins\\\\Concerns\\\\(Foo(?=::)|Bar(?=::)|Baz(?=::))');
     });
 
     it('handles mix of nested and flat namespaces', function (): void {
@@ -138,7 +138,46 @@ describe('buildFilterArgument', function (): void {
         $filter = $method->invoke($shard, $tests);
 
         expect($filter)
-            ->toBe(addslashes('Tests\\Unit\\(SimpleTest|Plugins\\Concerns\\(HandleArguments|Validation)|Another\\Deep\\Nested\\Test)'));
+            ->toBe(addslashes('Tests\\Unit\\(SimpleTest(?=::)|Plugins\\Concerns\\(HandleArguments(?=::)|Validation(?=::))|Another\\Deep\\Nested\\Test(?=::))'));
+    });
+
+    it('does not match a class outside of the shard when another class name is its prefix', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $reflection = new ReflectionClass($shard);
+        $method = $reflection->getMethod('buildFilterArgument');
+
+        $filter = $method->invoke($shard, ['Tests\\Feature\\After']);
+
+        expect(preg_match('{'.$filter.'}i', 'P\Tests\Feature\AfterAll::deletes file after all'))->toBe(0)
+            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Feature\After::it runs'))->toBe(1);
+    });
+
+    it('still matches dataset variants after the class boundary', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $reflection = new ReflectionClass($shard);
+        $method = $reflection->getMethod('buildFilterArgument');
+
+        $filter = $method->invoke($shard, ['Tests\\Feature\\After']);
+
+        expect(preg_match('{'.$filter.'}i', 'P\Tests\Feature\After::it runs with data set "foo"'))->toBe(1);
+    });
+
+    it('keeps a class matchable when another class nests below its namespace', function (): void {
+        $output = new BufferedOutput;
+        $shard = new Shard($output);
+
+        $reflection = new ReflectionClass($shard);
+        $method = $reflection->getMethod('buildFilterArgument');
+
+        $filter = $method->invoke($shard, ['Tests\\Unit\\After', 'Tests\\Unit\\After\\AfterAll']);
+
+        expect($filter)->toBe('Tests\\\\Unit\\\\(?:After(?=::)|After\\\\AfterAll(?=::))')
+            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Unit\After::x'))->toBe(1)
+            ->and(preg_match('{'.$filter.'}i', 'P\Tests\Unit\After\AfterAll::y'))->toBe(1);
     });
 });
 


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Shard filters are matched by PHPUnit as unanchored regular expressions against `Class::method`, so any class whose name started with another class assigned to a different shard also ran there (e.g. `Tests\Feature\After` matching `Tests\Feature\AfterAll`). Splitting Pest's own suite 1/2 executed 218 tests in both shards; with this change, zero.

The generated filter now requires `::` right after each class path. A class that is also the prefix of another class in the same shard keeps its own alternative.

Before: `Tests\\Feature\\(After|AfterAll)` → after: `Tests\\Feature\\(After(?=::)|AfterAll(?=::))`
