### PR TITLE
Command gh not found on Windows

### DIFF
--- a/src/Plugins/Tia/BaselineSync.php
+++ b/src/Plugins/Tia/BaselineSync.php
@@ -583,7 +583,12 @@ final readonly class BaselineSync
 
     private function commandExists(string $cmd): bool
     {
-        $process = new Process(['which', $cmd]);
+        if (PHP_OS_FAMILY === 'Windows') {
+            $process = new Process(['where', $cmd]);
+        } else {
+            $process = new Process(['which', $cmd]);
+        }
+
         $process->run();
 
         return $process->isSuccessful();

--- a/src/Plugins/Tia/BaselineSync.php
+++ b/src/Plugins/Tia/BaselineSync.php
@@ -10,6 +10,7 @@ use Pest\Plugins\Tia;
 use Pest\Plugins\Tia\Contracts\State;
 use Pest\Support\View;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -583,15 +584,7 @@ final readonly class BaselineSync
 
     private function commandExists(string $cmd): bool
     {
-        if (PHP_OS_FAMILY === 'Windows') {
-            $process = new Process(['where', $cmd]);
-        } else {
-            $process = new Process(['which', $cmd]);
-        }
-
-        $process->run();
-
-        return $process->isSuccessful();
+        return new ExecutableFinder()->find($cmd) !== null;
     }
 
     private function cleanup(string $dir): void


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

When running the TIA engine on Windows, the `gh` command is not detected because `which gh` only works on Unix-based OS.

For Windows, we have to use `where gh`.
