### PR TITLE
fix: filter test names with a trailing space

### DIFF
--- a/overrides/Runner/Filter/NameFilterIterator.php
+++ b/overrides/Runner/Filter/NameFilterIterator.php
@@ -22,7 +22,6 @@ use RecursiveIterator;
 
 use function end;
 use function preg_match;
-use function trim;
 
 /**
  * @extends RecursiveFilterIterator<int, Test, RecursiveIterator<int, Test>>
@@ -57,9 +56,7 @@ abstract class NameFilterIterator extends RecursiveFilterIterator
         }
 
         if ($test instanceof HasPrintableTestCaseName) {
-            $name = trim(
-                $test::getPrintableTestCaseName().'::'.$test->getPrintableTestCaseMethodName().$test->dataSetAsString()
-            );
+            $name = $test::getPrintableTestCaseName().'::'.$test->getPrintableTestCaseMethodName().$test->dataSetAsString();
         } else {
             $name = $test::class.'::'.$test->nameWithDataSet();
         }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -2210,6 +2210,11 @@
    PASS  Tests\Visual\Collision
   ✓ collision with ([''])
 
+   PASS  Tests\Visual\FilterTrailingSpace
+  ✓ filter matches a test name with a trailing space
+  ✓ filter without a trailing space does not match a test name with a trailing space
+  ✓ filter matches a dataset test name with a trailing space
+
    PASS  Tests\Visual\Help
   ✓ visual snapshot of help command output
 
@@ -2256,4 +2261,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1599 passed (3486 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1602 passed (3493 assertions)

--- a/tests/Fixtures/Suites/TrailingSpaceTest.php
+++ b/tests/Fixtures/Suites/TrailingSpaceTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+test('example test ', function () {
+    expect(true)->toBeTrue();
+});
+
+test('example test', function () {
+    expect(true)->toBeTrue();
+});
+
+test('example test with dataset ', function (int $number) {
+    expect($number)->toBe(1);
+})->with([1]);

--- a/tests/Visual/FilterTrailingSpace.php
+++ b/tests/Visual/FilterTrailingSpace.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+$runWithIdeFilter = function (string $description): Process {
+    $filter = sprintf(<<<'REGEX'
+        /^(P\\)?Tests\\Fixtures\\Suites\\TrailingSpaceTest::%s(\swith\s(data\sset\s".*"|\(.*\))(\s\/\s(data\sset\s".*"|\(.*\)))*(\s#\d+)?)?$/
+        REGEX, $description);
+
+    $process = new Process([
+        'php',
+        'bin/pest',
+        'tests/Fixtures/Suites/TrailingSpaceTest.php',
+        '--filter='.$filter,
+        '--colors=never',
+    ], dirname(__DIR__, 2), ['COLLISION_PRINTER' => 'DefaultPrinter', 'COLLISION_IGNORE_DURATION' => 'true', 'PAO_DISABLE' => '1']);
+
+    $process->run();
+
+    return $process;
+};
+
+test('filter matches a test name with a trailing space', function () use ($runWithIdeFilter): void {
+    $process = $runWithIdeFilter('example\stest\s');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('1 passed');
+})->skipOnWindows();
+
+test('filter without a trailing space does not match a test name with a trailing space', function () use ($runWithIdeFilter): void {
+    $process = $runWithIdeFilter('example\stest');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('1 passed');
+})->skipOnWindows();
+
+test('filter matches a dataset test name with a trailing space', function () use ($runWithIdeFilter): void {
+    $process = $runWithIdeFilter('example\stest\swith\sdataset\s');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('example test with dataset with (1)')
+        ->toContain('1 passed');
+})->skipOnWindows();


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

A test whose description ends with a space cannot be run alone with `--filter`. PhpStorm hits this when you run a single test.

```php
test('example test ', function () {
    expect(true)->toBeTrue();
});
```

Pest reports this test as `example test ` in its TeamCity output, so PhpStorm builds a filter that ends with \s: `--filter "/^(P\\)?Tests\\...::example\stest\s(\swith\s(data\sset\s\".*\"|\(.*\))...)?$/"`

`NameFilterIterator` calls `trim()` on the name before it matches the filter. The trailing space is removed, so no test is found and the run exits with code 0.

This PR removes the trim() call. The class name never starts with a space, and `dataSetAsString()` never ends with one. So `trim()` only changed descriptions that end with whitespace. The name now matches the TeamCity output and PHPUnit's own `NameFilterIterator`.

Only one behaviour change I noticed was that, a hand-written filter with an end anchor, such as `--filter='example test$'`, no longer matches a test named `'example test '`. An unanchored filter still matches it. Before this change, that anchored filter also selected both `'example test'` and `'example test '`.

Additionally added tests to cover; a trailing space, one without, and one dataset test with a trailing space.

Related:
Fixes #1521