### PR TITLE
[4.x] Add an observer for the exit code after output plugins

### DIFF
--- a/src/Contracts/Plugins/ObservesExitCode.php
+++ b/src/Contracts/Plugins/ObservesExitCode.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Contracts\Plugins;
+
+interface ObservesExitCode
+{
+    public function observeExitCode(int $exitCode): void;
+}

--- a/src/Plugins/Actions/CallsAddsOutput.php
+++ b/src/Plugins/Actions/CallsAddsOutput.php
@@ -26,6 +26,12 @@ final class CallsAddsOutput
             $exitCode = $plugin->addOutput($exitCode);
         }
 
+        foreach (Loader::getPlugins(Plugins\ObservesExitCode::class) as $plugin) {
+            assert($plugin instanceof Plugins\ObservesExitCode);
+
+            $plugin->observeExitCode($exitCode);
+        }
+
         return $exitCode;
     }
 }

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1706,6 +1706,15 @@
    PASS  Tests\Unit\Overrides\ThrowableBuilder
   ✓ collision editor can be added to the stack trace
 
+   PASS  Tests\Unit\Plugins\Actions\CallsAddsOutput
+  ✓ exit code observers run after every output plugin
+  ✓ exit code observers receive unchanged codes when there are no output plugins with (0)
+  ✓ exit code observers receive unchanged codes when there are no output plugins with (1)
+  ✓ exit code observers receive unchanged codes when there are no output plugins with (2)
+  ✓ exit code observers receive unchanged codes when there are no output plugins with (42)
+  ✓ output plugins work without exit code observers
+  ✓ exit code observers are not called when an output plugin throws
+
    PASS  Tests\Unit\Plugins\Concerns\HandleArguments
   ✓ method hasArgument with ('--long-argument', true)
   ✓ method hasArgument with ('-a', true)
@@ -1906,4 +1915,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1297 passed (2980 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1304 passed (2994 assertions)

--- a/tests/Unit/Plugins/Actions/CallsAddsOutput.php
+++ b/tests/Unit/Plugins/Actions/CallsAddsOutput.php
@@ -1,0 +1,114 @@
+<?php
+
+use Pest\Contracts\Plugins\AddsOutput;
+use Pest\Contracts\Plugins\ObservesExitCode;
+use Pest\Plugin\Loader;
+use Pest\Plugins\Actions\CallsAddsOutput;
+
+function withExitCodePlugins(array $plugins, Closure $test): void
+{
+    $loader = new ReflectionClass(Loader::class);
+    $instances = $loader->getProperty('instances');
+    $loaded = $loader->getProperty('loaded');
+    $previousInstances = $instances->getValue();
+    $previousLoaded = $loaded->getValue();
+
+    try {
+        $instances->setValue(null, $plugins);
+        $loaded->setValue(null, true);
+
+        $test();
+    } finally {
+        $instances->setValue(null, $previousInstances);
+        $loaded->setValue(null, $previousLoaded);
+    }
+}
+
+test('exit code observers run after every output plugin', function (): void {
+    $events = new ArrayObject;
+    $observer = new readonly class($events) implements ObservesExitCode
+    {
+        public function __construct(private ArrayObject $events) {}
+
+        public function observeExitCode(int $exitCode): void
+        {
+            $this->events[] = ['observed', $exitCode];
+        }
+    };
+    $output = new readonly class($events) implements AddsOutput
+    {
+        public function __construct(private ArrayObject $events) {}
+
+        public function addOutput(int $exitCode): int
+        {
+            $this->events[] = ['output', $exitCode];
+
+            return $exitCode + 1;
+        }
+    };
+
+    withExitCodePlugins([$observer, $output, clone $observer, clone $output], function () use ($events): void {
+        expect(CallsAddsOutput::execute(0))->toBe(2)
+            ->and($events->getArrayCopy())->toBe([
+                ['output', 0],
+                ['output', 1],
+                ['observed', 2],
+                ['observed', 2],
+            ]);
+    });
+});
+
+test('exit code observers receive unchanged codes when there are no output plugins', function (int $exitCode): void {
+    $observer = new class implements ObservesExitCode
+    {
+        public ?int $exitCode = null;
+
+        public function observeExitCode(int $exitCode): void
+        {
+            $this->exitCode = $exitCode;
+        }
+    };
+
+    withExitCodePlugins([$observer], function () use ($observer, $exitCode): void {
+        expect(CallsAddsOutput::execute($exitCode))->toBe($exitCode)
+            ->and($observer->exitCode)->toBe($exitCode);
+    });
+})->with([0, 1, 2, 42]);
+
+test('output plugins work without exit code observers', function (): void {
+    $output = new class implements AddsOutput
+    {
+        public function addOutput(int $exitCode): int
+        {
+            return 42;
+        }
+    };
+
+    withExitCodePlugins([$output], function (): void {
+        expect(CallsAddsOutput::execute(0))->toBe(42);
+    });
+});
+
+test('exit code observers are not called when an output plugin throws', function (): void {
+    $observer = new class implements ObservesExitCode
+    {
+        public bool $called = false;
+
+        public function observeExitCode(int $exitCode): void
+        {
+            $this->called = true;
+        }
+    };
+    $output = new class implements AddsOutput
+    {
+        public function addOutput(int $exitCode): int
+        {
+            throw new RuntimeException('Output failed');
+        }
+    };
+
+    withExitCodePlugins([$observer, $output], function () use ($observer): void {
+        expect(fn (): int => CallsAddsOutput::execute(0))->toThrow(RuntimeException::class, 'Output failed')
+            ->and($observer->called)->toBeFalse();
+    });
+});

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -24,13 +24,13 @@ test('parallel', function () use ($run) {
         $file = file_get_contents(__FILE__);
         $file = preg_replace(
             '/\$expected = \'.*?\';/',
-            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1281 passed (2929 assertions)';",
+            "\$expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1288 passed (2943 assertions)';",
             $file,
         );
         file_put_contents(__FILE__, $file);
     }
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1281 passed (2929 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1288 passed (2943 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Output plugins can change the exit code after another plugin has already observed it, so a reporter can announce success while a later coverage check fails the command. Add the `ObservesExitCode` plugin contract and notify its observers after every `AddsOutput` plugin has run. Observers receive the same resulting code and do not return a replacement value; the shared action covers sequential and parallel execution.

Seven tests cover output-plugin ordering, multiple observers, unchanged codes including custom codes, runs without observers, and output-plugin exceptions. The suite-output snapshots and parallel summary are updated for those additional tests.

Validation on macOS / PHP 8.5.10:

- Unit suite: exit 0, 1,289 passed; existing skipped, todo, incomplete and issue-producing tests remain.
- Parallel suite: exit 0, 1,288 passed; 2,943 assertions.
- Integration suite: 23 passed, 63 assertions.
- PHPStan, Pint, changed-file Rector checks, type coverage 100%, and whitespace checks passed. The complete 4.x Rector check still reports two pre-existing transformations in unchanged `src/Preset.php` and `src/Repositories/SnapshotRepository.php`; the modified files pass Rector.
- PAO consumer qualification passes minimum and exact coverage thresholds in sequential and parallel runs, along with its complete 292-test passing suite.

The full upstream PHP/OS matrix has not been run. This is the matching 4.x backport of https://github.com/pestphp/pest/pull/1905. It is kept in draft while the new plugin contract is reviewed on 5.x.

Prepared with AI assistance.
