### PR TITLE
fix(tia): memoize the resolved baseline instead of merging it per lookup

### DIFF
--- a/src/Plugins/Tia/Graph.php
+++ b/src/Plugins/Tia/Graph.php
@@ -58,6 +58,16 @@ final class Graph
      */
     private array $baselines = [];
 
+    /**
+     * @var array<string, array<string, array{
+     *     sha: ?string,
+     *     tree: array<string, string>,
+     *     complete?: bool,
+     *     results: array<string, array{status: int, message: string, time: float, assertions?: int, file?: string}>
+     * }>>
+     */
+    private array $resolvedBaselines = [];
+
     private string $fallbackBranch = 'main';
 
     private readonly string $projectRoot;
@@ -732,6 +742,8 @@ final class Graph
 
     public function setFallbackBranch(string $branch): void
     {
+        $this->forgetResolvedBaselines();
+
         $this->fallbackBranch = $branch;
     }
 
@@ -744,12 +756,16 @@ final class Graph
 
     public function setRecordedAtSha(string $branch, ?string $sha): void
     {
+        $this->forgetResolvedBaselines();
+
         $this->ensureBaseline($branch);
         $this->baselines[$branch]['sha'] = $sha;
     }
 
     public function setResult(string $branch, string $testId, int $status, string $message, float $time, int $assertions = 0, ?string $file = null): void
     {
+        $this->forgetResolvedBaselines();
+
         $this->ensureBaseline($branch);
 
         $entry = [
@@ -939,12 +955,16 @@ final class Graph
      */
     public function setLastRunTree(string $branch, array $tree): void
     {
+        $this->forgetResolvedBaselines();
+
         $this->ensureBaseline($branch);
         $this->baselines[$branch]['tree'] = $tree;
     }
 
     public function clearResults(string $branch): void
     {
+        $this->forgetResolvedBaselines();
+
         $this->ensureBaseline($branch);
         $this->baselines[$branch]['results'] = [];
     }
@@ -964,6 +984,14 @@ final class Graph
     {
         $fallbackBranch ??= $this->fallbackBranch;
 
+        return $this->resolvedBaselines[$branch][$fallbackBranch] ??= $this->resolveBaseline($branch, $fallbackBranch);
+    }
+
+    /**
+     * @return array{sha: ?string, tree: array<string, string>, complete?: bool, results: array<string, array{status: int, message: string, time: float, assertions?: int, file?: string}>}
+     */
+    private function resolveBaseline(string $branch, string $fallbackBranch): array
+    {
         $fallback = $branch !== $fallbackBranch ? ($this->baselines[$fallbackBranch] ?? null) : null;
         $own = $this->baselines[$branch] ?? null;
 
@@ -1016,6 +1044,11 @@ final class Graph
         }
 
         return $results;
+    }
+
+    private function forgetResolvedBaselines(): void
+    {
+        $this->resolvedBaselines = [];
     }
 
     private function ensureBaseline(string $branch): void
@@ -1586,6 +1619,8 @@ final class Graph
 
     public function markBaselineComplete(string $branch): void
     {
+        $this->forgetResolvedBaselines();
+
         if (isset($this->baselines[$branch])) {
             $this->baselines[$branch]['complete'] = true;
         }
@@ -1596,6 +1631,8 @@ final class Graph
         if (! isset($this->baselines[$branch]['results'])) {
             return;
         }
+
+        $this->forgetResolvedBaselines();
 
         $root = rtrim($this->projectRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 
@@ -1625,6 +1662,8 @@ final class Graph
      */
     public function pruneMissingBranches(array $keep): void
     {
+        $this->forgetResolvedBaselines();
+
         $survivors = array_fill_keys($keep, true);
 
         foreach (array_keys($this->baselines) as $branch) {
@@ -1643,6 +1682,8 @@ final class Graph
         if (! isset($this->baselines[$branch]['results'])) {
             return;
         }
+
+        $this->forgetResolvedBaselines();
 
         $touched = [];
         foreach ($touchedFiles as $file) {

--- a/tests/.snapshots/success.txt
+++ b/tests/.snapshots/success.txt
@@ -1925,6 +1925,21 @@
   ✓ markKnownTestFiles() → it makes a test file with no edges known
   ✓ markKnownTestFiles() → it does not clobber edges of an already-known test file
   ✓ markKnownTestFiles() → it ignores paths outside the project root
+  ✓ baselineFor() fallback merging and memoization → it overlays a partial branch baseline on top of the fallback
+  ✓ baselineFor() fallback merging and memoization → it lets a complete branch baseline shadow fallback results from the files it covers
+  ✓ baselineFor() fallback merging and memoization → it memoizes the resolved baseline until the graph changes
+  ✓ baselineFor() fallback merging and memoization → it resolves each requested fallback separately
+  ✓ baselineFor() fallback merging and memoization → it keeps the resolved baseline out of the encoded graph
+  ✓ baselineFor() fallback merging and memoization → it reflects setResult() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects a fallback branch mutation after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects setRecordedAtSha() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects setLastRunTree() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects clearResults() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects markBaselineComplete() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects pruneResultsForMissingFiles() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects pruneMissingBranches() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects pruneStaleResults() after a lookup
+  ✓ baselineFor() fallback merging and memoization → it reflects setFallbackBranch() after a lookup
 
    PASS  Tests\Unit\Plugins\Tia\IsEnabledForRun
   ✓ does not throw when an integer --random-order-seed is passed as a separate argv element
@@ -2256,4 +2271,4 @@
   ✓ pass with dataset with ('my-datas-set-value')
   ✓ within describe → pass with dataset with ('my-datas-set-value')
 
-  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1599 passed (3486 assertions)
+  Tests:    2 deprecated, 4 warnings, 5 incomplete, 2 notices, 40 todos, 35 skipped, 1614 passed (3525 assertions)

--- a/tests/Unit/Plugins/Tia/Graph.php
+++ b/tests/Unit/Plugins/Tia/Graph.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Pest\Plugins\Tia\Graph;
 use Pest\Plugins\Tia\WatchPatterns;
 use Pest\Support\Container;
+use Pest\Support\Reflection;
 use PHPUnit\Framework\TestStatus\TestStatus;
 
 describe('shouldRerunStatus()', function (): void {
@@ -310,5 +311,165 @@ describe('markKnownTestFiles()', function (): void {
         $graph->markKnownTestFiles(['/somewhere/else/tests/FooTest.php']);
 
         expect($graph->knowsTest('/somewhere/else/tests/FooTest.php'))->toBeFalse();
+    });
+});
+
+describe('baselineFor() fallback merging and memoization', function (): void {
+    beforeEach(function (): void {
+        $this->projectRoot = sys_get_temp_dir().'/pest-tia-baseline-'.bin2hex(random_bytes(4));
+        mkdir($this->projectRoot.'/tests/Feature', 0755, true);
+
+        touch($this->projectRoot.'/tests/Feature/FooTest.php');
+        touch($this->projectRoot.'/tests/Feature/BarTest.php');
+
+        $graph = new Graph($this->projectRoot);
+
+        $graph->setRecordedAtSha('main', 'main-sha');
+        $graph->setLastRunTree('main', ['app/A.php' => 'a1']);
+        $graph->setResult('main', 'Tests\FooTest::a', 0, '', 0.1, 1, 'tests/Feature/FooTest.php');
+        $graph->setResult('main', 'Tests\BarTest::b', 0, '', 0.2, 1, 'tests/Feature/BarTest.php');
+
+        $graph->setResult('develop', 'Tests\FooTest::a', 7, 'boom', 0.9, 1, 'tests/Feature/FooTest.php');
+
+        $graph->setResult('feature', 'Tests\FooTest::f', 0, '', 0.3, 1, 'tests/Feature/FooTest.php');
+        $graph->setResult('feature', 'Tests\GoneTest::g', 0, '', 0.4, 1, 'tests/Feature/GoneTest.php');
+
+        $this->graph = $graph;
+    });
+
+    afterEach(function (): void {
+        @unlink($this->projectRoot.'/tests/Feature/FooTest.php');
+        @unlink($this->projectRoot.'/tests/Feature/BarTest.php');
+        @rmdir($this->projectRoot.'/tests/Feature');
+        @rmdir($this->projectRoot.'/tests');
+        @rmdir($this->projectRoot);
+    });
+
+    it('overlays a partial branch baseline on top of the fallback', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3)
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1)
+            ->and($this->graph->getTime('feature', 'Tests\BarTest::b'))->toBe(0.2)
+            ->and($this->graph->recordedAtSha('feature'))->toBe('main-sha')
+            ->and($this->graph->lastRunTree('feature'))->toBe(['app/A.php' => 'a1']);
+    });
+
+    it('lets a complete branch baseline shadow fallback results from the files it covers', function (): void {
+        $this->graph->markBaselineComplete('feature');
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3)
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBeNull()
+            ->and($this->graph->getTime('feature', 'Tests\BarTest::b'))->toBe(0.2);
+    });
+
+    it('memoizes the resolved baseline until the graph changes', function (): void {
+        expect(Reflection::getPropertyValue($this->graph, 'resolvedBaselines'))->toBe([]);
+
+        $this->graph->getTime('feature', 'Tests\FooTest::a');
+
+        expect(Reflection::getPropertyValue($this->graph, 'resolvedBaselines'))->toHaveKey('feature');
+
+        $this->graph->setResult('feature', 'Tests\FooTest::a', 0, '', 0.5, 1, 'tests/Feature/FooTest.php');
+
+        expect(Reflection::getPropertyValue($this->graph, 'resolvedBaselines'))->toBe([]);
+    });
+
+    it('resolves each requested fallback separately', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1)
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a', 'develop'))->toBe(0.9)
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+    });
+
+    it('keeps the resolved baseline out of the encoded graph', function (): void {
+        $before = $this->graph->encode();
+
+        $this->graph->getTime('feature', 'Tests\FooTest::a');
+
+        $after = $this->graph->encode();
+
+        expect($after)->toBe($before)
+            ->and(Graph::decode((string) $after, $this->projectRoot)?->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+    });
+
+    it('reflects setResult() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+
+        $this->graph->setResult('feature', 'Tests\FooTest::a', 0, '', 0.5, 1, 'tests/Feature/FooTest.php');
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.5);
+    });
+
+    it('reflects a fallback branch mutation after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\BarTest::b'))->toBe(0.2);
+
+        $this->graph->setResult('main', 'Tests\BarTest::b', 0, '', 0.6, 1, 'tests/Feature/BarTest.php');
+
+        expect($this->graph->getTime('feature', 'Tests\BarTest::b'))->toBe(0.6);
+    });
+
+    it('reflects setRecordedAtSha() after a lookup', function (): void {
+        expect($this->graph->recordedAtSha('feature'))->toBe('main-sha');
+
+        $this->graph->setRecordedAtSha('feature', 'feature-sha');
+
+        expect($this->graph->recordedAtSha('feature'))->toBe('feature-sha');
+    });
+
+    it('reflects setLastRunTree() after a lookup', function (): void {
+        expect($this->graph->lastRunTree('feature'))->toBe(['app/A.php' => 'a1']);
+
+        $this->graph->setLastRunTree('feature', ['app/A.php' => 'a2']);
+
+        expect($this->graph->lastRunTree('feature'))->toBe(['app/A.php' => 'a2']);
+    });
+
+    it('reflects clearResults() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3);
+
+        $this->graph->clearResults('feature');
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBeNull()
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+    });
+
+    it('reflects markBaselineComplete() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+
+        $this->graph->markBaselineComplete('feature');
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBeNull();
+    });
+
+    it('reflects pruneResultsForMissingFiles() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\GoneTest::g'))->toBe(0.4);
+
+        $this->graph->pruneResultsForMissingFiles('feature');
+
+        expect($this->graph->getTime('feature', 'Tests\GoneTest::g'))->toBeNull()
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3);
+    });
+
+    it('reflects pruneMissingBranches() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3);
+
+        $this->graph->pruneMissingBranches(['main']);
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBeNull()
+            ->and($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+    });
+
+    it('reflects pruneStaleResults() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBe(0.3);
+
+        $this->graph->pruneStaleResults('feature', ['tests/Feature/FooTest.php'], []);
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::f'))->toBeNull();
+    });
+
+    it('reflects setFallbackBranch() after a lookup', function (): void {
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.1);
+
+        $this->graph->setFallbackBranch('develop');
+
+        expect($this->graph->getTime('feature', 'Tests\FooTest::a'))->toBe(0.9);
     });
 });

--- a/tests/Visual/Parallel.php
+++ b/tests/Visual/Parallel.php
@@ -20,7 +20,7 @@ test('parallel', function () use ($run): void {
     $output = $run('--exclude-group=integration');
     $output = implode("\n", array_slice(explode("\n", (string) $output), -10));
 
-    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1581 passed (3431 assertions)';
+    $expected = '2 deprecated, 4 warnings, 5 incomplete, 3 notices, 40 todos, 27 skipped, 1596 passed (3470 assertions)';
 
     expect($output)
         ->toContain("Tests:    {$expected}")


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`Graph::baselineFor()` merges a branch's baseline over its fallback baseline on every call. When a branch baseline is marked complete, that means filtering the fallback's results by file authority (`withoutFilesCoveredBy()`) and then `array_replace()`-ing the two result sets, so each call walks both collections in full.

`Tia::getStatus()` calls three of the getters that go through `baselineFor()` (`getResult()`, `getAssertions()`, `getTime()`) for every replayed test. Once a graph holds a complete baseline for the current branch *and* a fallback baseline (which an ordinary successful run creates via `snapshotTestResults()` + `markBaselineComplete()`), a replay of N tests rebuilds the N-entry merged collection 3·N times, so replay cost grows quadratically with suite size.

On a ~26k-test suite this showed up as a "0 affected, everything replayed" run taking ~186 s instead of ~33 s, with all workers at ~85 % CPU inside Pest. The same run against a graph that only has a `main` baseline is fast, because `baselineFor()` takes the direct-fallback path.

This PR memoizes the resolved baseline per `(branch, fallbackBranch)` pair on the `Graph` instance:

- The resolution logic itself moves unchanged into `resolveBaseline()`; `baselineFor()` now just reads through the memo.
- The memo is a private, process-local array. It is not part of `encode()`, and `decode()` builds a fresh instance, so the on-disk graph and its schema are untouched.
- Every method that mutates `$baselines` or `$fallbackBranch` clears the memo first (`setFallbackBranch`, `setRecordedAtSha`, `setResult`, `setLastRunTree`, `clearResults`, `markBaselineComplete`, `pruneResultsForMissingFiles`, `pruneMissingBranches`, `pruneStaleResults`), so lookups after a mutation always resolve against the current state.

No selection, replay, shadowing, or persistence behaviour changes. The added unit tests cover the partial and complete merge rules, an explicit fallback argument, encoded-output stability, and a post-lookup invalidation case for each mutator, including a mutation of the fallback branch itself.

Micro-benchmark (three lookups per test, the same three `Tia::getStatus()` performs, against a decoded graph with complete `feature` and `main` baselines; PHP 8.5, macOS):

| Tests replayed | Lookups | `5.x` | This PR |
| ---: | ---: | ---: | ---: |
| 10,000 | 30,000 | 20.87 s | 0.004 s |
| 26,000 | 78,000 | 178.80 s | 0.010 s |

`composer test` passes locally (`test:lint`, `test:type:check`, `test:type:coverage`, `test:unit`, `test:parallel`, `test:integration`). The `success.txt` snapshot and the `Parallel` visual expectation are updated for the new tests only.

### Related:

- Possibly contributes to #1880 (replay overhead when 100 % of tests are replayed), although that report also describes time spent outside Pest's own duration, which this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ba59fczGLUTFBEMSHKWcS
